### PR TITLE
Improved scripts in npm packages and their yarn support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,11 @@ jobs:
                 key: node-modules-{{ checksum "package.json" }}
             - run:
                 name: Install modules
-                command: yarn --frozen-lockfile
+                command: yarn --frozen-lockfile install
             - save_cache:
                 key: node-modules-{{ checksum "package.json" }}
                 paths:
                     - node_modules
-            - run:
-                name: Bootstrapping
-                command: yarn lerna bootstrap
             - run:
                 name: Building
                 command: yarn lerna:run build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   ],
   "scripts": {
     "lerna": "lerna",
-    "lerna:run": "lerna run"
+    "lerna:run": "lerna run",
+    "prepare": "lerna run prepare"
   },
   "devDependencies": {
     "lerna": "^2.9.0"

--- a/packages/civil.ts/package.json
+++ b/packages/civil.ts/package.json
@@ -5,14 +5,16 @@
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
-    "build": "npm run generate && tsc && copyfiles -u 2 './src/artifacts/**/*.json' ./build/src/artifacts",
+    "build": "run-s generate tsc build:copyArtifacts",
+    "build:copyArtifacts": "copyfiles -u 2 './src/artifacts/**/*.json' ./build/src/artifacts",
     "lint": "tslint --project ./",
-    "generate": "npm run generate:contracts && npm run generate:artifacts",
+    "generate": "run-p generate:*",
     "generate:contracts": "abi-gen --abis 'src/artifacts/**/*.json' --template 'src/templates/contract/contract.handlebars' --partials 'src/templates/contract/partials/**/*.handlebars' --output 'src/contracts/generated/'",
     "generate:artifacts": "civil-generate-from-files 'src/artifacts/**/*.json' 'src/templates/artifacts.handlebars' 'src/contracts/generated/artifacts.ts'",
     "test": "mocha build/test/ --reporter mocha-multi-reporters --reporter-options configFile=mocha.json",
     "tsc": "tsc",
-    "prepublishOnly": "npm run build && npm run lint && npm run test"
+    "prepublishOnly": "run-s build lint test",
+    "clean": "rimraf build/"
   },
   "repository": {
     "type": "git",
@@ -41,6 +43,8 @@
     "mocha": "^5.0.0",
     "mocha-junit-reporter": "^1.16.0",
     "mocha-multi-reporters": "^1.1.7",
+    "npm-run-all": "^4.1.2",
+    "rimraf": "^2.6.2",
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "web3-typescript-typings": "^0.9.11"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,16 +4,17 @@
   "version": "1.0.0",
   "description": "Smart Contracts needed to make the ecosystem work",
   "scripts": {
-    "build": "npm run compile && npm run strip-artifacts",
-    "compile": "npm run build:solidity && npm run build:typescript",
-    "build:typescript": "npm run lint:typescript; tsc",
-    "build:solidity": "npm run lint:solidity; truffle compile",
-    "lint": "npm run lint:typescript && npm run lint:solidity",
-    "test": "npm run compile && truffle test --network test",
+    "build": "run-s compile build:stripArtifacts",
+    "build:stripArtifacts": "node build/scripts/strip-artifacts.js \"build/contracts/**/*.json\" build/artifacts",
+    "compile": "run-p --aggregate-output compile:*",
+    "compile:typescript": "tsc",
+    "compile:solidity": "truffle compile",
+    "lint": "run-p --aggregate-output lint:*",
     "lint:typescript": "tslint --project ./",
     "lint:solidity": "solium --dir contracts/",
+    "test": "truffle test --network test",
+    "clean": "rimraf build/",
     "postinstall": "truffle install",
-    "strip-artifacts": "node build/scripts/strip-artifacts.js \"build/contracts/**/*.json\" build/artifacts",
     "truffle": "truffle",
     "tsc": "tsc",
     "tslint": "tslint",
@@ -29,7 +30,7 @@
     "url": "https://github.com/joincivil/contracts/issues"
   },
   "homepage": "https://github.com/joincivil/contracts#readme",
-  "dependencies": {
+  "devDependencies": {
     "@types/chai": "^4.0.10",
     "@types/chai-as-promised": "^7.1.0",
     "@types/glob": "^5.0.34",
@@ -48,12 +49,11 @@
     "mocha-multi-reporters": "^1.1.7",
     "rimraf": "^2.6.2",
     "truffle": "^4.0.3",
-    "zeppelin-solidity": "^1.4.0"
-  },
-  "devDependencies": {
+    "zeppelin-solidity": "^1.4.0",
     "@joincivil/tslint-rules": "^2.4.0",
     "solium": "^1.1.5",
     "solium-plugin-security": "^0.1.1",
+    "npm-run-all": "^4.1.2",
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "web3-typescript-typings": "^0.9.11"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,7 +14,7 @@
     "lint:solidity": "solium --dir contracts/",
     "test": "truffle test --network test",
     "clean": "rimraf build/",
-    "postinstall": "truffle install",
+    "prepare": "truffle install",
     "truffle": "truffle",
     "tsc": "tsc",
     "tslint": "tslint",

--- a/packages/debug-ui/gulpfile.js
+++ b/packages/debug-ui/gulpfile.js
@@ -122,7 +122,3 @@ gulp.task('server', ['build'], () => {
 })
 
 gulp.task('serve', ['watch', 'server'])
-
-gulp.task('clean', () => {
-    return del(config.deployDir)
-})

--- a/packages/debug-ui/package.json
+++ b/packages/debug-ui/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "npm run gulp build",
     "serve": "npm run gulp serve",
+    "clean": "rimraf build/",
     "gulp": "gulp",
     "tsc": "tsc"
   },
@@ -27,6 +28,7 @@
     "gulp-typescript": "^3.2.3",
     "gulp-webpack-typescript-pipeline": "^9.0.1",
     "pug": "^2.0.0-rc.4",
+    "rimraf": "^2.6.2",
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "web3-typescript-typings": "^0.9.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,10 @@ array-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
 
+array-filter@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -340,6 +344,14 @@ array-find-index@^1.0.1:
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
+
+array-map@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+
+array-reduce@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 array-slice@^0.2.3:
   version "0.2.3"
@@ -1455,6 +1467,13 @@ defaults@^1.0.0, defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -1679,6 +1698,24 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.4.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 es5-ext@^0.10.14, es5-ext@^0.10.30, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2:
   version "0.10.39"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.39.tgz#fca21b67559277ca4ac1a1ed7048b107b6f76d87"
@@ -1815,7 +1852,7 @@ event-emitter@^0.3.5, event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-event-stream@^3.3.2:
+event-stream@^3.3.2, event-stream@~3.3.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
@@ -2079,6 +2116,10 @@ for-own@^1.0.0:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -2163,7 +2204,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -2985,6 +3026,10 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
 is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
@@ -3002,6 +3047,10 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3172,7 +3221,7 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
 
-is-regex@^1.0.3:
+is-regex@^1.0.3, is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -3195,6 +3244,10 @@ is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
 is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-text-path@^1.0.0:
   version "1.0.1"
@@ -4209,6 +4262,20 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
+npm-run-all@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.2.tgz#90d62d078792d20669139e718621186656cea056"
+  dependencies:
+    ansi-styles "^3.2.0"
+    chalk "^2.1.0"
+    cross-spawn "^5.1.0"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    ps-tree "^1.1.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -4258,6 +4325,10 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4643,6 +4714,12 @@ promise@^7.0.1:
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
+ps-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -5325,6 +5402,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shell-quote@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
+  dependencies:
+    array-filter "~0.0.0"
+    array-map "~0.0.0"
+    array-reduce "~0.0.0"
+    jsonify "~0.0.0"
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -5619,6 +5705,14 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.padend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz#f3aaef7c1719f170c5eab1c32bf780d96e21f2f0"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.4.3"
+    function-bind "^1.0.2"
 
 string_decoder@^1.0.0, string_decoder@~1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,7 +1315,7 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:


### PR DESCRIPTION
The tests will fail until #12 is merged due to previous merge without CI tests run, making tests fail due to empty files (commented out) in test directories.