### PR TITLE
using deployed token for rinkeby migrations

### DIFF
--- a/packages/contracts/conf/config.json
+++ b/packages/contracts/conf/config.json
@@ -20,7 +20,7 @@
     "appealChallengeCommitStageLength": 160,
     "appealChallengeRevealStageLength": 160
   },
-  "TokenAddress": "0x337cDDa6D41A327c5ad456166CCB781a9722AFf9",
+  "rinkebyTokenAddress": "0x617e6d6db50b2697b1fa37f43ec2834648c39020",
   "testnets": {
     "rinkeby": {
       "tokenHolders": [

--- a/packages/contracts/migrations/2_optional_for_test.ts
+++ b/packages/contracts/migrations/2_optional_for_test.ts
@@ -3,7 +3,7 @@
 import BN from "bignumber.js";
 
 import { config } from "./utils";
-import { MAIN_NETWORK } from "./utils/consts";
+import { MAIN_NETWORK, RINKEBY } from "./utils/consts";
 
 const Token = artifacts.require("EIP20");
 
@@ -26,7 +26,7 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
     return giveTokensTo(addresses.slice(1), originalCount);
   }
   deployer.then(async () => {
-    if (network !== MAIN_NETWORK) {
+    if (network !== MAIN_NETWORK && network !== RINKEBY) {
       await deployer.deploy(Token, totalSupply, "TestCvl", decimals, "TESTCVL");
       if (network in config.testnets) {
         const updatedAccounts = [...accounts, ...config.testnets[network].tokenHolders];

--- a/packages/contracts/migrations/4_deploy_plcr.ts
+++ b/packages/contracts/migrations/4_deploy_plcr.ts
@@ -1,7 +1,7 @@
 /* global artifacts */
 
 import { approveEverything, config, inTesting } from "./utils";
-import { MAIN_NETWORK } from "./utils/consts";
+import { RINKEBY } from "./utils/consts";
 
 const Token = artifacts.require("EIP20");
 const DLL = artifacts.require("DLL");
@@ -14,10 +14,10 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
     await deployer.link(DLL, PLCRVoting);
     await deployer.link(AttributeStore, PLCRVoting);
 
-    let tokenAddress = config.TokenAddress;
+    let tokenAddress = Token.address;
 
-    if (network !== MAIN_NETWORK) {
-      tokenAddress = Token.address;
+    if (network === RINKEBY) {
+      tokenAddress = config.rinkebyTokenAddress;
     }
 
     await deployer.deploy(PLCRVoting, tokenAddress);

--- a/packages/contracts/migrations/5_deploy_parameterizer.ts
+++ b/packages/contracts/migrations/5_deploy_parameterizer.ts
@@ -1,7 +1,7 @@
 /* global artifacts */
 
 import { approveEverything, config, inTesting } from "./utils";
-import { MAIN_NETWORK } from "./utils/consts";
+import { RINKEBY } from "./utils/consts";
 
 const Token = artifacts.require("EIP20");
 const DLL = artifacts.require("DLL");
@@ -16,10 +16,10 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
     await deployer.link(AttributeStore, Parameterizer);
 
     const parameterizerConfig = config.paramDefaults;
-    let tokenAddress = config.TokenAddress;
+    let tokenAddress = Token.address;
 
-    if (network !== MAIN_NETWORK) {
-      tokenAddress = Token.address;
+    if (network === RINKEBY) {
+      tokenAddress = config.rinkebyTokenAddress;
     }
 
     await deployer.deploy(Parameterizer, tokenAddress, PLCRVoting.address, [

--- a/packages/contracts/migrations/6_registry.ts
+++ b/packages/contracts/migrations/6_registry.ts
@@ -1,7 +1,7 @@
 /* global artifacts */
 
 import { approveEverything, config, inTesting } from "./utils";
-import { MAIN_NETWORK } from "./utils/consts";
+import { RINKEBY } from "./utils/consts";
 
 const Token = artifacts.require("EIP20");
 const DLL = artifacts.require("DLL");
@@ -17,10 +17,10 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
     await deployer.link(AttributeStore, CivilTCR);
 
     const parameterizerConfig = config.paramDefaults;
-    let tokenAddress = config.TokenAddress;
+    let tokenAddress = Token.address;
 
-    if (network !== MAIN_NETWORK) {
-      tokenAddress = Token.address;
+    if (network === RINKEBY) {
+      tokenAddress = config.rinkebyTokenAddress;
     }
     await deployer.deploy(
       CivilTCR,

--- a/packages/contracts/migrations/utils/consts.ts
+++ b/packages/contracts/migrations/utils/consts.ts
@@ -1,1 +1,2 @@
 export const MAIN_NETWORK = "mainnet";
+export const RINKEBY = "rinkeby";


### PR DESCRIPTION
 instead of deploying a new one every time