### PR TITLE
More Unit Tests for TCR contracts

### DIFF
--- a/packages/contracts/test/tcr/registry/exit.ts
+++ b/packages/contracts/test/tcr/registry/exit.ts
@@ -23,6 +23,14 @@ contract("Registry", accounts => {
       token = await Token.at(tokenAddress);
     });
 
+    it("should not allow a listing to exit if listing is not whitelisted", async () => {
+      await registry.apply(listing17, utils.paramConfig.minDeposit, "", { from: applicant });
+      await expect(registry.exitListing(listing17, { from: applicant })).to.eventually.be.rejectedWith(
+        REVERTED,
+        "should not have allowed listing in application stage to exit",
+      );
+    });
+
     it("should allow a listing to exit when no challenge exists", async () => {
       const initialApplicantTokenHoldings = await token.balanceOf(applicant);
 

--- a/packages/contracts/test/tcr/registryWithAppeals/apply.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/apply.ts
@@ -16,6 +16,7 @@ const NEWSROOM_NAME = "unused newsroom name;";
 contract("Registry With Appeals", accounts => {
   describe("Function: apply", () => {
     const [JAB, applicant, troll, challenger] = accounts;
+    const unapproved = accounts[9];
     const listing1 = "0x0000000000000000000000000000000000000001";
     const minDeposit = utils.paramConfig.minDeposit;
     let registry: any;
@@ -44,6 +45,15 @@ contract("Registry With Appeals", accounts => {
         expect(whitelisted).to.be.false("whitelisted != false");
         expect(owner).to.be.equal(applicant, "owner of application != address that applied");
         expect(unstakedDeposit).to.be.bignumber.equal(utils.paramConfig.minDeposit, "incorrect unstakedDeposit");
+      });
+
+      it("should fail if applicant has not approved registry as spender of token", async () => {
+        await expect(
+          registry.apply(newsroomAddress, utils.paramConfig.minDeposit, "", { from: unapproved }),
+        ).to.eventually.be.rejectedWith(
+          REVERTED,
+          "should not have allowed applicant to apply if they have not approved registry as spender",
+        );
       });
 
       it("should not allow a listing to apply which has a pending application", async () => {

--- a/packages/contracts/test/tcr/registryWithAppeals/requestAppeal.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/requestAppeal.ts
@@ -15,6 +15,7 @@ const NEWSROOM_NAME = "unused newsroom name";
 contract("Registry With Appeals", accounts => {
   describe("Function: requestAppeal", () => {
     const [JAB, applicant, challenger, voter] = accounts;
+    const unapproved = accounts[9];
     let registry: any;
     let voting: any;
     let testNewsroom: any;
@@ -85,6 +86,17 @@ contract("Registry With Appeals", accounts => {
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await expect(registry.requestAppeal(newsroomAddress, { from: applicant })).to.eventually.be.fulfilled(
         "Should have allowed appeal on application with failed challenge that has been processed",
+      );
+    });
+
+    it("should fail if requester has not approved registry as spender of token", async () => {
+      await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
+      await registry.challenge(newsroomAddress, "", { from: challenger });
+      await utils.advanceEvmTime(utils.paramConfig.commitStageLength);
+      await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
+      await expect(registry.requestAppeal(newsroomAddress, { from: unapproved })).to.eventually.be.rejectedWith(
+        REVERTED,
+        "Should not have allowed request to appeal if they did not approve registry as spender",
       );
     });
 

--- a/packages/contracts/test/utils/contractutils.ts
+++ b/packages/contracts/test/utils/contractutils.ts
@@ -169,7 +169,7 @@ async function createTestRegistryInstance(registryContract: any, parameterizer: 
 
   const registry = await registryContract.new(tokenAddress, plcrAddress, parameterizerAddress);
 
-  await approveRegistryFor(accounts);
+  await approveRegistryFor(accounts.slice(0, 8));
   return registry;
 }
 
@@ -203,7 +203,7 @@ async function createTestCivilTCRInstance(
 
   const registry = await CivilTCR.new(tokenAddress, plcrAddress, parameterizerAddress, government.address);
 
-  await approveRegistryFor(accounts);
+  await approveRegistryFor(accounts.slice(0, 8));
   return registry;
 }
 


### PR DESCRIPTION
- add unit tests that increase code coverage when user making transaction has not properly approved registry as a spender of token
- a few more random unit tests for more code coverage
