### PR TITLE
updating .solcover.js 

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,16 @@
 module.exports = {
   dir: "./packages/contracts",
+  skipFiles: [
+    "tcr/installed_contracts/attrstore/contracts/AttributeStore.sol",
+    "tcr/installed_contracts/attrstore/contracts/Migrations.sol",
+    "tcr/installed_contracts/dll/contracts/DLL.sol",
+    "tcr/installed_contracts/dll/contracts/Migrations.sol",
+    "tcr/installed_contracts/tokens/contracts/Migrations.sol",
+    "tcr/installed_contracts/tokens/contracts/eip20/EIP20.sol",
+    "tcr/installed_contracts/tokens/contracts/eip20/EIP20Factory.sol",
+    "tcr/installed_contracts/tokens/contracts/eip20/EIP20Interface.sol",
+    "tcr/installed_contracts/tokens/contracts/Migrations.sol",
+    "zeppelin-solidity/ECRecovery.sol",
+    "zeppelin-solidity/Ownable.sol",
+  ],
 };


### PR DESCRIPTION
- updating .solcover.js to skip files that we had to copy into our repo from EPM & zeppelin due to doxity limitations