### PR TITLE
switching voting result logic around

### DIFF
--- a/packages/contracts/test/tcr/registryWithAppeals/apply.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/apply.ts
@@ -10,19 +10,23 @@ const expect = chai.expect;
 const Newsroom = artifacts.require("Newsroom");
 const AddressRegistry = artifacts.require("AddressRegistry");
 const ContractAddressRegistry = artifacts.require("ContractAddressRegistry");
+const PLCRVoting = artifacts.require("PLCRVoting");
 
 const NEWSROOM_NAME = "unused newsroom name;";
 
 contract("Registry With Appeals", accounts => {
   describe("Function: apply", () => {
-    const [JAB, applicant, troll, challenger] = accounts;
+    const [JAB, applicant, troll, challenger, voter] = accounts;
     const unapproved = accounts[9];
     const listing1 = "0x0000000000000000000000000000000000000001";
     const minDeposit = utils.paramConfig.minDeposit;
     let registry: any;
+    let voting: any;
 
     beforeEach(async () => {
       registry = await utils.createAllCivilTCRInstance(accounts, JAB);
+      const votingAddress = await registry.voting();
+      voting = PLCRVoting.at(votingAddress);
     });
 
     describe("with real newsroom", () => {
@@ -87,7 +91,7 @@ contract("Registry With Appeals", accounts => {
           await registry.challenge(newsroomAddress, "", { from: challenger });
           await utils.advanceEvmTime(utils.paramConfig.commitStageLength + utils.paramConfig.revealStageLength + 1);
           await registry.requestAppeal(newsroomAddress, { from: applicant });
-          await utils.advanceEvmTime(1209620); // hack. should be getting value from registry contract
+          await utils.advanceEvmTime(utils.paramConfig.judgeAppealPhaseLength + 1);
 
           const applyTx = registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
           await expect(applyTx).to.eventually.be.rejectedWith(
@@ -97,22 +101,21 @@ contract("Registry With Appeals", accounts => {
         },
       );
 
-      it(
-        "should allow a listing to re-apply after losing challenge, " + "not being granted appeal, updating status",
-        async () => {
-          await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
-          await registry.challenge(newsroomAddress, "", { from: challenger });
-          await utils.advanceEvmTime(utils.paramConfig.commitStageLength);
-          await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
-          await registry.requestAppeal(newsroomAddress, { from: applicant });
-          await utils.advanceEvmTime(1209620); // hack. should be getting value from registry contract
-          await registry.updateStatus(newsroomAddress);
+      it("should allow a listing to re-apply after losing challenge (challenge vote successful), not being granted appeal, updating status", async () => {
+        await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
+        const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
+        await utils.commitVote(voting, pollID, "1", "100", "1234", voter);
+        await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
+        await voting.revealVote(pollID, "1", "1234", { from: voter });
+        await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
+        await registry.requestAppeal(newsroomAddress, { from: applicant });
+        await utils.advanceEvmTime(utils.paramConfig.judgeAppealPhaseLength + 1);
+        await registry.updateStatus(newsroomAddress);
 
-          await expect(registry.apply(newsroomAddress, minDeposit, "", { from: applicant })).to.eventually.be.fulfilled(
-            "should have allowed new application after being denied appeal",
-          );
-        },
-      );
+        await expect(registry.apply(newsroomAddress, minDeposit, "", { from: applicant })).to.eventually.be.fulfilled(
+          "should have allowed new application after being denied appeal",
+        );
+      });
     });
 
     describe("with troll newsroom", () => {

--- a/packages/contracts/test/tcr/registryWithAppeals/claimAppealChallengeReward.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/claimAppealChallengeReward.ts
@@ -43,20 +43,20 @@ contract("Registry", accounts => {
       const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
 
       // Alice is so committed
-      await utils.commitVote(voting, pollID, "0", "500", "420", voterAlice);
+      await utils.commitVote(voting, pollID, "1", "500", "420", voterAlice);
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
 
       // Alice is so revealing
-      await voting.revealVote(pollID, "0", "420", { from: voterAlice });
+      await voting.revealVote(pollID, "1", "420", { from: voterAlice });
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
 
       await registry.requestAppeal(newsroomAddress, { from: voterBob });
       await registry.grantAppeal(newsroomAddress, { from: JAB });
       const appealChallengePollID = await utils.challengeAppealAndGetPollID(newsroomAddress, challenger, registry);
 
-      await utils.commitVote(voting, appealChallengePollID, "0", "500", "1337", voterBob);
+      await utils.commitVote(voting, appealChallengePollID, "1", "500", "1337", voterBob);
       await utils.advanceEvmTime(utils.paramConfig.appealChallengeCommitStageLength + 1);
-      await voting.revealVote(appealChallengePollID, "0", "1337", { from: voterBob });
+      await voting.revealVote(appealChallengePollID, "1", "1337", { from: voterBob });
       await utils.advanceEvmTime(utils.paramConfig.appealChallengeRevealStageLength + 1);
 
       await registry.updateStatus(newsroomAddress);

--- a/packages/contracts/test/tcr/registryWithAppeals/requestAppeal.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/requestAppeal.ts
@@ -126,16 +126,18 @@ contract("Registry With Appeals", accounts => {
     it("should allow a listing to request appeal after going through process before and being denied", async () => {
       // 1st time
       await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
-      await registry.challenge(newsroomAddress, "", { from: challenger });
-      await utils.advanceEvmTime(utils.paramConfig.commitStageLength);
+      const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
+      await utils.commitVote(voting, pollID, "1", "500", "420", voter);
+      await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
+      await voting.revealVote(pollID, "1", "420", { from: voter });
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await registry.requestAppeal(newsroomAddress, { from: applicant });
-      await utils.advanceEvmTime(1209620); // hack. should be getting value from registry contract
+      await utils.advanceEvmTime(utils.paramConfig.judgeAppealPhaseLength + 1); // hack. should be getting value from registry contract
       await registry.updateStatus(newsroomAddress);
 
       // 2nd time around
       await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
-      await registry.challenge(newsroomAddress, "", { from: challenger });
+      await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength);
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await expect(registry.requestAppeal(newsroomAddress, { from: applicant })).to.eventually.be.fulfilled(
@@ -146,15 +148,17 @@ contract("Registry With Appeals", accounts => {
     it("should allow a listing to request appeal the 2nd time around but not requesting one the 1st time", async () => {
       // 1st time
       await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
-      await registry.challenge(newsroomAddress, "", { from: challenger });
-      await utils.advanceEvmTime(utils.paramConfig.commitStageLength);
+      const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
+      await utils.commitVote(voting, pollID, "1", "500", "420", voter);
+      await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
+      await voting.revealVote(pollID, "1", "420", { from: voter });
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await utils.advanceEvmTime(utils.paramConfig.requestAppealPhaseLength + 1); // hack. should be getting value from registry contract
       await registry.updateStatus(newsroomAddress);
 
       // 2nd time around
       await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
-      await registry.challenge(newsroomAddress, "", { from: challenger });
+      await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength);
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await expect(registry.requestAppeal(newsroomAddress, { from: applicant })).to.eventually.be.fulfilled(

--- a/packages/contracts/test/utils/contractutils.ts
+++ b/packages/contracts/test/utils/contractutils.ts
@@ -84,6 +84,66 @@ export async function challengeReparamAndGetPollID(
   return receipt.logs[0].args.pollID;
 }
 
+export async function simpleSuccessfulChallenge(
+  registry: any,
+  listing: string,
+  challenger: string,
+  voter: string,
+): Promise<void> {
+  const votingAddress = await registry.voting();
+  const voting = PLCRVoting.at(votingAddress);
+  const pollID = await challengeAndGetPollID(listing, challenger, registry);
+  await commitVote(voting, pollID, "1", "100", "123", voter);
+  await advanceEvmTime(paramConfig.commitStageLength + 1);
+  await voting.revealVote(pollID, "1", "123", { from: voter });
+  await advanceEvmTime(paramConfig.revealStageLength + 1);
+}
+
+export async function simpleUnsuccessfulChallenge(
+  registry: any,
+  listing: string,
+  challenger: string,
+  voter: string,
+): Promise<void> {
+  const votingAddress = await registry.voting();
+  const voting = PLCRVoting.at(votingAddress);
+  const pollID = await challengeAndGetPollID(listing, challenger, registry);
+  await commitVote(voting, pollID, "0", "100", "420", voter);
+  await advanceEvmTime(paramConfig.commitStageLength + 1);
+  await voting.revealVote(pollID, "0", "420", { from: voter });
+  await advanceEvmTime(paramConfig.revealStageLength + 1);
+}
+
+export async function simpleSuccessfulAppealChallenge(
+  registry: any,
+  listing: string,
+  challenger: string,
+  voter: string,
+): Promise<void> {
+  const votingAddress = await registry.voting();
+  const voting = PLCRVoting.at(votingAddress);
+  const pollID = await challengeAppealAndGetPollID(listing, challenger, registry);
+  await commitVote(voting, pollID, "1", "100", "123", voter);
+  await advanceEvmTime(paramConfig.appealChallengeCommitStageLength + 1);
+  await voting.revealVote(pollID, "1", "123", { from: voter });
+  await advanceEvmTime(paramConfig.appealChallengeRevealStageLength + 1);
+}
+
+export async function simpleUnsuccessfulAppealChallenge(
+  registry: any,
+  listing: string,
+  challenger: string,
+  voter: string,
+): Promise<void> {
+  const votingAddress = await registry.voting();
+  const voting = PLCRVoting.at(votingAddress);
+  const pollID = await challengeAppealAndGetPollID(listing, challenger, registry);
+  await commitVote(voting, pollID, "0", "100", "420", voter);
+  await advanceEvmTime(paramConfig.appealChallengeCommitStageLength + 1);
+  await voting.revealVote(pollID, "0", "420", { from: voter });
+  await advanceEvmTime(paramConfig.appealChallengeRevealStageLength + 1);
+}
+
 export async function addToWhitelist(
   listingAddress: string,
   deposit: BigNumber,


### PR DESCRIPTION
- voting.isPassed is now associated with a successful challenge (listing/application to be removed) or a successful appeal challenge (granted appeal to be overturned) to reduce confusion
- fixing unit tests