### PR TITLE
Fixes for some annoying bugs in the DApp

### DIFF
--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joincivil/dapp",
   "version": "0.1.3",
-  "homepage": "./",
+  "homepage": "/",
   "private": true,
   "dependencies": {
     "@joincivil/core": "^4.0.2",

--- a/packages/dapp/src/apis/civilTCR.ts
+++ b/packages/dapp/src/apis/civilTCR.ts
@@ -11,6 +11,14 @@ export async function approveForChallenge(): Promise<TwoStepEthTransaction | voi
   return approve(minDeposit);
 }
 
+export async function approveForApply(): Promise<TwoStepEthTransaction | void> {
+  const civil = getCivil();
+  const tcr = civil.tcrSingletonTrusted();
+  const parameterizer = await tcr.getParameterizer();
+  const minDeposit = await parameterizer.getParameterValue("minDeposit");
+  return approve(minDeposit);
+}
+
 export async function approveForAppeal(): Promise<TwoStepEthTransaction | void> {
   const civil = getCivil();
   const tcr = civil.tcrSingletonTrusted();
@@ -42,9 +50,11 @@ export async function approve(amount: BigNumber): Promise<TwoStepEthTransaction 
   }
 }
 
-export async function applyToTCR(address: EthAddress, deposit: BigNumber): Promise<TwoStepEthTransaction> {
+export async function applyToTCR(address: EthAddress): Promise<TwoStepEthTransaction> {
   const civil = getCivil();
   const tcr = civil.tcrSingletonTrusted();
+  const parameterizer = await tcr.getParameterizer();
+  const deposit = await parameterizer.getParameterValue("minDeposit");
   return tcr.apply(address, deposit, "");
 }
 

--- a/packages/dapp/src/components/newsroom/NewsroomManagement.tsx
+++ b/packages/dapp/src/components/newsroom/NewsroomManagement.tsx
@@ -4,9 +4,8 @@ import { List } from "immutable";
 import { NewsroomRoles, TwoStepEthTransaction } from "@joincivil/core";
 import { Subscription } from "rxjs";
 import TransactionButton from "../utility/TransactionButton";
-import { applyToTCR, approve, getNewsroom } from "../../apis/civilTCR";
+import { applyToTCR, approveForApply, getNewsroom } from "../../apis/civilTCR";
 import NewsroomDetail from "./NewsroomDetail";
-import BigNumber from "bignumber.js";
 import { PageView, ViewModule } from "../utility/ViewModules";
 
 export interface NewsroomManagementState {
@@ -89,11 +88,11 @@ class NewsroomManagement extends React.Component<NewsroomManagementProps, Newsro
   }
 
   private approve = async (): Promise<TwoStepEthTransaction | void> => {
-    return approve(new BigNumber(100));
+    return approveForApply();
   };
 
   private applyToTCR = async (): Promise<TwoStepEthTransaction> => {
-    return applyToTCR(this.props.match.params.newsroomAddress, new BigNumber(100));
+    return applyToTCR(this.props.match.params.newsroomAddress);
   };
 
   private postApply = (result: any) => {


### PR DESCRIPTION
- Change `homepage` to `/` so the dapp stops using relative paths for
generated assets files
- Grab deposit amounts from the Parameterizer when approve/applying to
TCR. Note: This is due to some unidentifed weirdness w/ `BigNumber`.
We'll fix this for real in a fturue update