### PR TITLE
DApp: Look at all listing applications since the beginning

### DIFF
--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -3,17 +3,15 @@ import { getTCR, getCivil } from "./civilInstance";
 import { addListing } from "../actionCreators/listings";
 import { addNewsroom } from "../actionCreators/newsrooms";
 import { EthAddress, ListingWrapper } from "@joincivil/core";
-import { getApplicationMaximumLengthInBlocks } from "../apis/civilTCR";
 import { Observable } from "rxjs";
 
 export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<void> {
   const tcr = getTCR();
   const civil = getCivil();
   const current = await civil.currentBlock();
-  const applicationBlock = current - (await getApplicationMaximumLengthInBlocks()).toNumber();
   await Observable.merge(
     tcr.whitelistedListings(0),
-    tcr.listingsInApplicationStage(applicationBlock),
+    tcr.listingsInApplicationStage(),
     tcr.allEventsExceptWhitelistFromBlock(current),
   ).subscribe(async (listing: ListingWrapper) => {
     await getNewsroom(dispatch, listing.address);


### PR DESCRIPTION
Update so the `listingsInApplication` event stream loads from the beginning, and not from the `getApplicationMaximumLengthInBlocks` helper method.

This update addresses the issue where applications in various Appeal and Resolve Challenge phases weren't getting loaded into the DApp.