### PR TITLE
Hotfixes for bugs in the Reparameterization Proposal view

### DIFF
--- a/packages/dapp/src/components/parameterizer/Proposal.tsx
+++ b/packages/dapp/src/components/parameterizer/Proposal.tsx
@@ -27,7 +27,6 @@ export interface ProposalReduxProps {
 
 class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   public render(): JSX.Element {
-    console.log(this.props.proposal);
     return (
       <PageView>
         <ViewModule>

--- a/packages/dapp/src/components/parameterizer/Proposal.tsx
+++ b/packages/dapp/src/components/parameterizer/Proposal.tsx
@@ -27,6 +27,7 @@ export interface ProposalReduxProps {
 
 class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   public render(): JSX.Element {
+    console.log(this.props.proposal);
     return (
       <PageView>
         <ViewModule>
@@ -75,7 +76,7 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   private renderCanBeChallenged = (): JSX.Element => {
     return (
       <StyledFormContainer>
-        Proposal Application Phase ends in <CountdownTimer endTime={this.props.proposal.applicationExpiry.toNumber()} />
+        Proposal Application Phase ends in <CountdownTimer endTime={this.props.proposal.applicationExpiry.valueOf() / 1000} />
         <FormGroup>
           <TransactionButton
             transactions={[{ transaction: approveForProposalChallenge }, { transaction: this.challengeProposal }]}
@@ -90,7 +91,7 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   private renderUpdateParam = (): JSX.Element => {
     return (
       <StyledFormContainer>
-        Parameter Update Phase ends in <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.toNumber()} />
+        Parameter Update Phase ends in <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf / 1000} />
         <FormGroup>
           <TransactionButton transactions={[{ transaction: this.updateProposal }]}>Update Parameter</TransactionButton>
         </FormGroup>
@@ -101,7 +102,7 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   private renderResolveChallenge = (): JSX.Element => {
     return (
       <StyledFormContainer>
-        Resolve Challenge Phase ends in <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.toNumber()} />
+        Resolve Challenge Phase ends in <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf() / 1000} />
         <FormGroup>
           <TransactionButton transactions={[{ transaction: this.resolveChallenge }]}>
             Resolve Challenge
@@ -115,7 +116,7 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
     return (
       <>
         Commit Vote Phase ends in{" "}
-        <CountdownTimer endTime={this.props.proposal.challenge.challengeCommitExpiry.toNumber()} />
+        <CountdownTimer endTime={this.props.proposal.challenge.challengeCommitExpiry.valueOf() / 1000} />
         <CommitVoteDetail challengeID={this.props.proposal.challenge.id} />
       </>
     );
@@ -125,7 +126,7 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
     return (
       <>
         Reveal Vote Phase ends in{" "}
-        <CountdownTimer endTime={this.props.proposal.challenge.challengeRevealExpiry.toNumber()} />
+        <CountdownTimer endTime={this.props.proposal.challenge.challengeRevealExpiry.valueOf() / 1000} />
         <RevealVoteDetail challengeID={this.props.proposal.challenge.id} />
       </>
     );

--- a/packages/dapp/src/components/parameterizer/Proposal.tsx
+++ b/packages/dapp/src/components/parameterizer/Proposal.tsx
@@ -76,7 +76,8 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   private renderCanBeChallenged = (): JSX.Element => {
     return (
       <StyledFormContainer>
-        Proposal Application Phase ends in <CountdownTimer endTime={this.props.proposal.applicationExpiry.valueOf() / 1000} />
+        Proposal Application Phase ends in{" "}
+        <CountdownTimer endTime={this.props.proposal.applicationExpiry.valueOf() / 1000} />
         <FormGroup>
           <TransactionButton
             transactions={[{ transaction: approveForProposalChallenge }, { transaction: this.challengeProposal }]}
@@ -91,7 +92,8 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   private renderUpdateParam = (): JSX.Element => {
     return (
       <StyledFormContainer>
-        Parameter Update Phase ends in <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf / 1000} />
+        Parameter Update Phase ends in{" "}
+        <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf / 1000} />
         <FormGroup>
           <TransactionButton transactions={[{ transaction: this.updateProposal }]}>Update Parameter</TransactionButton>
         </FormGroup>
@@ -102,7 +104,8 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
   private renderResolveChallenge = (): JSX.Element => {
     return (
       <StyledFormContainer>
-        Resolve Challenge Phase ends in <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf() / 1000} />
+        Resolve Challenge Phase ends in{" "}
+        <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf() / 1000} />
         <FormGroup>
           <TransactionButton transactions={[{ transaction: this.resolveChallenge }]}>
             Resolve Challenge

--- a/packages/dapp/src/components/parameterizer/Proposal.tsx
+++ b/packages/dapp/src/components/parameterizer/Proposal.tsx
@@ -92,7 +92,7 @@ class Proposal extends React.Component<ProposalPageProps & ProposalReduxProps> {
     return (
       <StyledFormContainer>
         Parameter Update Phase ends in{" "}
-        <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf / 1000} />
+        <CountdownTimer endTime={this.props.proposal.propProcessByExpiry.valueOf() / 1000} />
         <FormGroup>
           <TransactionButton transactions={[{ transaction: this.updateProposal }]}>Update Parameter</TransactionButton>
         </FormGroup>

--- a/packages/dapp/src/helpers/parameterizer.ts
+++ b/packages/dapp/src/helpers/parameterizer.ts
@@ -50,10 +50,10 @@ export async function initializeProposalsSubscriptions(dispatch: Dispatch<any>):
     const applicationExpiry = await parameterizer.getPropApplicationExpiry(propID);
     const challengeCommitExpiry = !challengeID.isZero()
       ? await parameterizer.getPropChallengeCommitExpiry(propID)
-      : null;
+      : undefined;
     const challengeRevealExpiry = !challengeID.isZero()
       ? await parameterizer.getPropChallengeRevealExpiry(propID)
-      : null;
+      : undefined;
     const propProcessByExpiry = await parameterizer.getPropProcessBy(propID);
     dispatch(
       addOrUpdateProposal({

--- a/packages/dapp/src/helpers/parameterizer.ts
+++ b/packages/dapp/src/helpers/parameterizer.ts
@@ -48,8 +48,12 @@ export async function initializeProposalsSubscriptions(dispatch: Dispatch<any>):
     const propState = await parameterizer.getPropState(propID);
     const challengeID = await parameterizer.getChallengeID(propID);
     const applicationExpiry = await parameterizer.getPropApplicationExpiry(propID);
-    const challengeCommitExpiry = !challengeID.isZero() ? await parameterizer.getPropChallengeCommitExpiry(propID) : null;
-    const challengeRevealExpiry = !challengeID.isZero() ? await parameterizer.getPropChallengeRevealExpiry(propID) : null;
+    const challengeCommitExpiry = !challengeID.isZero()
+      ? await parameterizer.getPropChallengeCommitExpiry(propID)
+      : null;
+    const challengeRevealExpiry = !challengeID.isZero()
+      ? await parameterizer.getPropChallengeRevealExpiry(propID)
+      : null;
     const propProcessByExpiry = await parameterizer.getPropProcessBy(propID);
     dispatch(
       addOrUpdateProposal({

--- a/packages/dapp/src/helpers/parameterizer.ts
+++ b/packages/dapp/src/helpers/parameterizer.ts
@@ -48,8 +48,8 @@ export async function initializeProposalsSubscriptions(dispatch: Dispatch<any>):
     const propState = await parameterizer.getPropState(propID);
     const challengeID = await parameterizer.getChallengeID(propID);
     const applicationExpiry = await parameterizer.getPropApplicationExpiry(propID);
-    const challengeCommitExpiry = await parameterizer.getPropChallengeCommitExpiry(propID);
-    const challengeRevealExpiry = await parameterizer.getPropChallengeRevealExpiry(propID);
+    const challengeCommitExpiry = !challengeID.isZero() ? await parameterizer.getPropChallengeCommitExpiry(propID) : null;
+    const challengeRevealExpiry = !challengeID.isZero() ? await parameterizer.getPropChallengeRevealExpiry(propID) : null;
     const propProcessByExpiry = await parameterizer.getPropProcessBy(propID);
     dispatch(
       addOrUpdateProposal({


### PR DESCRIPTION
This updates fixes a couple of bugs that were preventing the Reparameterization Proposal view from rendering, which in turn would prevent users acting on proposals.