### PR TITLE
Refactor Progress modal to live in Transaction button by default

### DIFF
--- a/packages/components/src/DetailTransactionButton.stories.tsx
+++ b/packages/components/src/DetailTransactionButton.stories.tsx
@@ -2,8 +2,6 @@ import { storiesOf } from "@storybook/react";
 import * as React from "react";
 import styled from "styled-components";
 import { DetailTransactionButton } from "./DetailTransactionButton";
-import { Modal } from "./Modal";
-import { ModalContent, ModalHeading } from "./ModalContent";
 import { LoadingIndicator } from "./LoadingIndicator";
 import { Civil, TwoStepEthTransaction } from "@joincivil/core";
 
@@ -19,11 +17,6 @@ const createNewsroom = async (): Promise<TwoStepEthTransaction<any>> => {
   return civil!.newsroomDeployNonMultisigTrusted("hello");
 };
 
-let isTransactionProgressModalVisible = false;
-function toggleProgressModal(): void {
-  isTransactionProgressModalVisible = !isTransactionProgressModalVisible;
-}
-
 const Wrapper = styled.div`
   margin: 50px;
   max-width: 500px;
@@ -35,9 +28,7 @@ storiesOf("DetailTransactionButton", module)
       <Wrapper>
         <DetailTransactionButton
           civil={civil}
-          transactions={[
-            { transaction: createNewsroom, preTransaction: toggleProgressModal, postTransaction: toggleProgressModal },
-          ]}
+          transactions={[{ transaction: createNewsroom }]}
           estimateFunctions={[civil!.estimateNewsroomDeployTrusted.bind(civil, "some name")]}
           requiredNetwork="rinkeby"
         >
@@ -47,25 +38,13 @@ storiesOf("DetailTransactionButton", module)
     );
   })
   .add("detail transaction button with visible progress modal", () => {
-    const progressModal = (
-      <Modal textAlign="center">
-        <LoadingIndicator height={100} />
-        <ModalHeading>Your transaction is in progress.</ModalHeading>
-        <ModalContent>This can take 1-3 minutes. Please don't close the tab.</ModalContent>
-        <ModalContent>How about taking a little breather and standing for a bit? Maybe even stretching?</ModalContent>
-      </Modal>
-    );
-
     return (
       <Wrapper>
         <DetailTransactionButton
           civil={civil}
-          transactions={[
-            { transaction: createNewsroom, preTransaction: toggleProgressModal, postTransaction: toggleProgressModal },
-          ]}
+          transactions={[{ transaction: createNewsroom }]}
           estimateFunctions={[civil!.estimateNewsroomDeployTrusted.bind(civil, "some name")]}
           requiredNetwork="rinkeby"
-          progressModal={progressModal}
         >
           Create Newsroom
         </DetailTransactionButton>

--- a/packages/components/src/DetailTransactionButton.tsx
+++ b/packages/components/src/DetailTransactionButton.tsx
@@ -99,20 +99,12 @@ export class DetailTransactionButton extends React.Component<
 
   public render(): JSX.Element {
     const details = this.renderDetails();
-    const progressModal = this.getProgressModalEl();
     return (
       <Wrapper>
         {this.renderDetails()}
-        <TransactionButton
-          size={buttonSizes.SMALL}
-          disabled={this.isDisabled()}
-          transactions={this.props.transactions}
-          preExecuteTransactions={this.showProgressModal}
-          postExecuteTransactions={this.hideProgressModal}
-        >
+        <TransactionButton size={buttonSizes.SMALL} disabled={this.isDisabled()} transactions={this.props.transactions}>
           {this.props.children}
         </TransactionButton>
-        {progressModal}
       </Wrapper>
     );
   }
@@ -186,20 +178,4 @@ export class DetailTransactionButton extends React.Component<
       return this.renderTransactionDetails();
     }
   }
-
-  private getProgressModalEl = (): JSX.Element | undefined => {
-    if (this.props.progressModal) {
-      return React.cloneElement(this.props.progressModal as React.ReactElement<any>, {
-        visible: this.state.isProgressModalVisible,
-      });
-    }
-  };
-
-  private hideProgressModal = (): void => {
-    this.setState({ isProgressModalVisible: false });
-  };
-
-  private showProgressModal = (): void => {
-    this.setState({ isProgressModalVisible: true });
-  };
 }

--- a/packages/components/src/ProgressModalContent.tsx
+++ b/packages/components/src/ProgressModalContent.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { LoadingIndicator } from "./LoadingIndicator";
+import { ModalHeading, ModalContent } from "./ModalContent";
+import { Button } from "./Button";
+
+export interface ProgressModalContentProps {
+  hideModal?(): () => void;
+}
+
+export class ProgressModalContentInProgress extends React.Component<ProgressModalContentProps> {
+  public render(): JSX.Element {
+    return (
+      <>
+        <LoadingIndicator height={100} />
+        <ModalHeading>Your transaction is in progress.</ModalHeading>
+        <ModalContent>This can take 1-3 minutes. Please don't close the tab.</ModalContent>
+        <ModalContent>How about taking a little breather and standing for a bit? Maybe even stretching?</ModalContent>
+      </>
+    );
+  }
+}
+
+export class ProgressModalContentSuccess extends React.Component<ProgressModalContentProps> {
+  public render(): JSX.Element {
+    return (
+      <>
+        <ModalHeading>Success!</ModalHeading>
+        <ModalContent>Transaction processed.</ModalContent>
+        <Button onClick={this.handleOnClick}>Ok!</Button>
+      </>
+    );
+  }
+
+  private handleOnClick = (event: any): void => {
+    if (this.props.hideModal) {
+      this.props.hideModal();
+    }
+  };
+}
+
+export class ProgressModalContentError extends React.Component<ProgressModalContentProps> {
+  public render(): JSX.Element {
+    return (
+      <>
+        <ModalHeading>Uh oh!</ModalHeading>
+        <ModalContent>Your transaction failed. Please try again.</ModalContent>
+        <Button onClick={this.handleOnClick}>Dismiss</Button>
+      </>
+    );
+  }
+
+  private handleOnClick = (event: any): void => {
+    if (this.props.hideModal) {
+      this.props.hideModal();
+    }
+  };
+}

--- a/packages/dapp/src/components/newsroom/Newsroom.tsx
+++ b/packages/dapp/src/components/newsroom/Newsroom.tsx
@@ -2,24 +2,16 @@ import * as React from "react";
 import { FormHeading, StepProcess, Modal, ModalContent, Button, buttonSizes } from "@joincivil/components";
 import { NameAndAddress } from "./NameAndAddress";
 import { CompleteYourProfile } from "./CompleteYourProfile";
-<<<<<<< HEAD
-=======
-import { SignConstitution } from "./SignConstitution";
->>>>>>> Updates to Signing the Constitution
 import { connect, DispatchProp } from "react-redux";
 import { State } from "../../reducers";
 import { addNewsroom, getNewsroom, getEditors } from "../../actionCreators/newsrooms";
 import { EthAddress } from "@joincivil/core";
-import SignConstitution from "./SignConstitution";
+import { SignConstitution } from "./SignConstitution";
 
 export interface NewsroomState {
   modalOpen: boolean;
-<<<<<<< HEAD
   currentStep: number;
 };
-=======
-}
->>>>>>> Updates to Signing the Constitution
 
 export interface NewsroomProps {
   address?: string;


### PR DESCRIPTION
This update also includes default Success, Error, In Progress modal content, as well as hooks for implementing custom modal content for Transactions that are initiated via the `TransactionButton`.

It also adds a `try/catch` to the `executeTransactions()` method as a hook to trigger display of error modals.