### PR TITLE
Fix Deploy Newsroom

### DIFF
--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -73,7 +73,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
         charterUri,
         charterHash,
         [ethApi.account!],
-        new BigNumber(1),
+        ethApi.toBigNumber(1),
         txData,
       ),
       async factoryReceipt => {


### PR DESCRIPTION
- even core can't make big numbers correctly, so use the helper function to make one when creating newsroom contract via factory