### PR TITLE
Fix `isOwner` check in Sign Consitution view

### DIFF
--- a/packages/dapp/src/components/newsroom/SignConstitution.tsx
+++ b/packages/dapp/src/components/newsroom/SignConstitution.tsx
@@ -117,7 +117,7 @@ class SignConstitutionComponent extends React.Component<
       return false;
     }
     const newsroom = await getNewsroom(this.props.address!);
-    const isOwner = await newsroom.isOwner(userAccount);
+    const isOwner = await newsroom.isOwner(userAccount.account);
     return isOwner;
   };
 }


### PR DESCRIPTION
Grab the user's eth address from the (new) correct spot in the redux store when checking if the user is an owener