### PR TITLE
Transaction Button Fix

### DIFF
--- a/packages/components/src/TransactionButton.tsx
+++ b/packages/components/src/TransactionButton.tsx
@@ -129,6 +129,7 @@ export class TransactionButtonNoModal extends React.Component<TransactionButtonP
         return this.executeTransactions(transactions);
       } catch (err) {
         if (currTransaction.handleTransactionError) {
+          this.setState({ step: 0, disableButton: false });
           setImmediate(() => currTransaction.handleTransactionError!(err));
         }
       }

--- a/packages/components/src/TransactionButton.tsx
+++ b/packages/components/src/TransactionButton.tsx
@@ -128,8 +128,8 @@ export class TransactionButtonNoModal extends React.Component<TransactionButtonP
         }
         return this.executeTransactions(transactions);
       } catch (err) {
+        this.setState({ step: 0, disableButton: false });
         if (currTransaction.handleTransactionError) {
-          this.setState({ step: 0, disableButton: false });
           setImmediate(() => currTransaction.handleTransactionError!(err));
         }
       }


### PR DESCRIPTION
- reset state of transaction button if transaction has error of some kind
- https://app.clubhouse.io/civil/story/1298/dapp-transaction-button-gets-into-bad-state-when-transaction-fails-or-is-canceled
- https://app.clubhouse.io/civil/story/1299/transaction-button-releases-when-you-reject