### PR TITLE
move newsroom manager reducers to top level

### DIFF
--- a/packages/dapp/src/components/listing/Listing.tsx
+++ b/packages/dapp/src/components/listing/Listing.tsx
@@ -80,7 +80,8 @@ class ListingPage extends React.Component<ListingReduxProps & DispatchProp<any> 
 }
 
 const mapToStateToProps = (state: State, ownProps: ListingPageProps): ListingReduxProps => {
-  const { newsrooms, listings, listingsFetching, user, parameters, govtParameters } = state.networkDependent;
+  const { newsrooms } = state;
+  const { listings, listingsFetching, user, parameters, govtParameters } = state.networkDependent;
   const listingAddress = ownProps.match.params.listing;
 
   let listingDataRequestStatus;

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -79,7 +79,8 @@ const mapStateToProps = (
   state: State,
   ownProps: ListingListItemOwnProps,
 ): ListingListItemReduxProps & ListingListItemOwnProps => {
-  const { newsrooms, listings, challenges, challengeUserData, appealChallengeUserData, user } = state.networkDependent;
+  const { newsrooms } = state;
+  const { listings, challenges, challengeUserData, appealChallengeUserData, user } = state.networkDependent;
 
   let listingAddress = ownProps.listingAddress;
   let challenge;

--- a/packages/dapp/src/reducers/index.ts
+++ b/packages/dapp/src/reducers/index.ts
@@ -48,12 +48,12 @@ export interface State {
   networkDependent: NetworkDependentState;
   network: string;
   ui: Map<string, any>;
-}
-
-export interface NetworkDependentState {
   newsrooms: Map<string, NewsroomState>;
   newsroomUi: Map<string, any>;
   newsroomUsers: Map<EthAddress, string>;
+}
+
+export interface NetworkDependentState {
   currentUserNewsrooms: Set<string>;
   listings: Map<string, ListingWrapperWithExpiry>;
   listingsFetching: Map<string, any>;
@@ -89,9 +89,6 @@ export interface NetworkDependentState {
 }
 
 const networkDependentReducers = combineReducers({
-  newsrooms,
-  newsroomUi,
-  newsroomUsers,
   currentUserNewsrooms,
   listings,
   listingsFetching,
@@ -134,6 +131,9 @@ const networkDependent = (state: any, action: AnyAction) => {
 };
 
 export default combineReducers({
+  newsrooms, // have to be top level because come from a package
+  newsroomUi,
+  newsroomUsers,
   networkDependent,
   network,
   ui,


### PR DESCRIPTION
fixing it by adding a namespace to newsroom manager was getting to complicated