### PR TITLE
Fix React typing dependency issues

### DIFF
--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -33,9 +33,7 @@
     "styled-components": "^3.2.5"
   },
   "resolutions": {
-    "styled-components": "3.2.5",
-    "@types/react": "16.0.40",
-    "@types/react-dom": "16.0.4"
+    "styled-components": "3.2.5"
   },
   "scripts": {
     "start": "react-scripts-ts start",


### PR DESCRIPTION
Remove `@types/react` and `@types/react-dom` resolutions in the Dapp's package.json