### PR TITLE
Minor fixes and tweaks for Playtest

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/ChallengeAwaitingAppealDecisionCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ChallengeAwaitingAppealDecisionCard.tsx
@@ -4,8 +4,6 @@ import {
   StyledListingDetailPhaseCardContainer,
   StyledListingDetailPhaseCardSection,
   StyledPhaseDisplayName,
-  MetaItemValue,
-  MetaItemLabel,
   CTACopy,
 } from "./styledComponents";
 import { ProgressBarCountdownTimer } from "../PhaseCountdown/";

--- a/packages/components/src/ListingDetailPhaseCard/ChallengeAwaitingAppealDecisionCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ChallengeAwaitingAppealDecisionCard.tsx
@@ -27,10 +27,6 @@ export class AppealAwaitingDecisionCard extends React.Component<
           />
         </StyledListingDetailPhaseCardSection>
         <StyledListingDetailPhaseCardSection>
-          <MetaItemValue>1,000 CVL</MetaItemValue>
-          <MetaItemLabel>Amount of tokens deposited</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
           <CTACopy>
             Check back on August 24, 2018 for Civil Council’s decision to reject or grant the appeal. Read more for
             details of this appeal.

--- a/packages/components/src/ListingDetailPhaseCard/ChallengeRequestAppealCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ChallengeRequestAppealCard.tsx
@@ -29,10 +29,6 @@ export class ChallengeRequestAppealCard extends React.Component<
           />
         </StyledListingDetailPhaseCardSection>
         <StyledListingDetailPhaseCardSection>
-          <MetaItemValue>1,000 CVL</MetaItemValue>
-          <MetaItemLabel>Amount of tokens deposited</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
           <ChallengeResults
             totalVotes={this.props.totalVotes}
             votesFor={this.props.votesFor}

--- a/packages/components/src/ListingDetailPhaseCard/ChallengeRequestAppealCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ChallengeRequestAppealCard.tsx
@@ -4,8 +4,6 @@ import {
   StyledListingDetailPhaseCardContainer,
   StyledListingDetailPhaseCardSection,
   StyledPhaseDisplayName,
-  MetaItemValue,
-  MetaItemLabel,
   CTACopy,
 } from "./styledComponents";
 import { buttonSizes } from "../Button";

--- a/packages/components/src/ListingDetailPhaseCard/ChallengeResults.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ChallengeResults.tsx
@@ -86,7 +86,9 @@ export class ChallengeResults extends React.Component<ChallengeResultsProps> {
           </VotesPerTokenContainer>
 
           <BreakdownBarContainer>
-            <BreakdownBarPercentageLabel>{this.props.percentAgainst}%</BreakdownBarPercentageLabel>
+            <BreakdownBarPercentageLabel>
+              {this.props.percentAgainst.indexOf("NaN") < 0 ? this.props.percentAgainst : "0"}%
+            </BreakdownBarPercentageLabel>
             <BreakdownBarTotal>
               <BreakdownBarPercentage vote="remain" percentage={this.props.percentAgainst} />
             </BreakdownBarTotal>
@@ -102,7 +104,9 @@ export class ChallengeResults extends React.Component<ChallengeResultsProps> {
           </VotesPerTokenContainer>
 
           <BreakdownBarContainer>
-            <BreakdownBarPercentageLabel>{this.props.percentFor}%</BreakdownBarPercentageLabel>
+            <BreakdownBarPercentageLabel>
+              {this.props.percentFor.indexOf("NaN") < 0 ? this.props.percentFor : "0"}%
+            </BreakdownBarPercentageLabel>
             <BreakdownBarTotal>
               <BreakdownBarPercentage vote="remove" percentage={this.props.percentFor} />
             </BreakdownBarTotal>

--- a/packages/components/src/ListingDetailPhaseCard/CommitVote.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/CommitVote.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { buttonSizes } from "../Button";
+import { buttonSizes, DarkButton } from "../Button";
 import { InputGroup } from "../input/";
 import { CommitVoteProps } from "./types";
 import { TransactionDarkButton } from "../TransactionButton";
@@ -14,6 +14,7 @@ import {
 import { SaltField } from "./SaltField";
 
 export interface CommitVoteState {
+  voteOption?: number;
   numTokensError?: string;
   saltError?: string;
 }
@@ -22,13 +23,13 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
   constructor(props: CommitVoteProps) {
     super(props);
     this.state = {
+      voteOption: undefined,
       numTokensError: undefined,
       saltError: undefined,
     };
   }
 
   public render(): JSX.Element {
-    const disableButtons = !!this.state.numTokensError || !!this.state.saltError;
     return (
       <>
         {this.renderFormHeader()}
@@ -42,31 +43,37 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
         {this.renderSaltInput()}
 
         <VoteOptionsContainer>
-          <div onMouseEnter={this.setVoteToRemain}>
-            <TransactionDarkButton
-              size={buttonSizes.MEDIUM}
-              transactions={this.props.transactions}
-              modalContentComponents={this.props.modalContentComponents}
-              disabled={disableButtons}
-            >
-              ✔ Remain
-            </TransactionDarkButton>
-          </div>
+          <div onMouseEnter={this.setVoteToRemain}>{this.renderVoteButton({ voteOption: 0 })}</div>
           <StyledOrText>or</StyledOrText>
-          <div onMouseEnter={this.setVoteToRemove}>
-            <TransactionDarkButton
-              size={buttonSizes.MEDIUM}
-              transactions={this.props.transactions}
-              modalContentComponents={this.props.modalContentComponents}
-              disabled={disableButtons}
-            >
-              ✖ Remove
-            </TransactionDarkButton>
-          </div>
+          <div onMouseEnter={this.setVoteToRemove}>{this.renderVoteButton({ voteOption: 1 })}</div>
         </VoteOptionsContainer>
       </>
     );
   }
+
+  private renderVoteButton = (options: any): JSX.Element => {
+    const disableButtons = !!this.state.numTokensError || !!this.state.saltError;
+    let buttonText;
+    if (options.voteOption === 0) {
+      buttonText = "✔ Remain";
+    } else if (options.voteOption === 1) {
+      buttonText = "✖ Remove";
+    }
+    if (this.state.voteOption === options.voteOption) {
+      return (
+        <TransactionDarkButton
+          size={buttonSizes.MEDIUM}
+          transactions={this.props.transactions}
+          modalContentComponents={this.props.modalContentComponents}
+          disabled={disableButtons}
+        >
+          {buttonText}
+        </TransactionDarkButton>
+      );
+    }
+
+    return <DarkButton size={buttonSizes.MEDIUM}>{buttonText}</DarkButton>;
+  };
 
   private renderFormHeader = (): JSX.Element => {
     if (this.props.userHasCommittedVote) {
@@ -122,12 +129,14 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
     // A "remain" vote is a vote that doesn't support the
     // challenge, so `voteOption === 0`
     this.props.onInputChange({ voteOption: "0" });
+    this.setState(() => ({ voteOption: 0 }));
   };
 
   private setVoteToRemove = (): void => {
     // A "remove" vote is a vote that supports the
     // challenge, so `voteOption === 1`
     this.props.onInputChange({ voteOption: "1" });
+    this.setState(() => ({ voteOption: 1 }));
   };
 
   private validateSalt = (): boolean => {

--- a/packages/components/src/ListingDetailPhaseCard/InApplicationCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/InApplicationCard.tsx
@@ -4,8 +4,6 @@ import {
   StyledListingDetailPhaseCardContainer,
   StyledListingDetailPhaseCardSection,
   StyledPhaseDisplayName,
-  MetaItemValue,
-  MetaItemLabel,
   CTACopy,
 } from "./styledComponents";
 import { buttonSizes, InvertedButton } from "../Button";

--- a/packages/components/src/ListingDetailPhaseCard/InApplicationCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/InApplicationCard.tsx
@@ -28,10 +28,6 @@ export class InApplicationCard extends React.Component<
           />
         </StyledListingDetailPhaseCardSection>
         <StyledListingDetailPhaseCardSection>
-          <MetaItemValue>1,000 CVL</MetaItemValue>
-          <MetaItemLabel>Amount of tokens deposited</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
           <CTACopy>
             If you believe this newsroom does not align with the <a href="#">Civil Constitution</a>, you may{" "}
             <a href="#">submit a challenge</a>.

--- a/packages/components/src/ListingDetailPhaseCard/InApplicationResolveCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/InApplicationResolveCard.tsx
@@ -19,10 +19,6 @@ export class InApplicationResolveCard extends React.Component<ListingDetailPhase
           <StyledPhaseDisplayName>New Application</StyledPhaseDisplayName>
         </StyledListingDetailPhaseCardSection>
         <StyledListingDetailPhaseCardSection>
-          <MetaItemValue>1,000 CVL</MetaItemValue>
-          <MetaItemLabel>Amount of tokens deposited</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
           <CTACopy>This listing has passed the application process</CTACopy>
           <TransactionInvertedButton
             size={buttonSizes.MEDIUM}

--- a/packages/components/src/ListingDetailPhaseCard/InApplicationResolveCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/InApplicationResolveCard.tsx
@@ -4,8 +4,6 @@ import {
   StyledListingDetailPhaseCardContainer,
   StyledListingDetailPhaseCardSection,
   StyledPhaseDisplayName,
-  MetaItemValue,
-  MetaItemLabel,
   CTACopy,
 } from "./styledComponents";
 import { buttonSizes } from "../Button";

--- a/packages/components/src/ListingDetailPhaseCard/RejectedCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/RejectedCard.tsx
@@ -19,10 +19,6 @@ export class RejectedCard extends React.Component<ListingDetailPhaseCardComponen
           <MetaItemLabel>Rejected date</MetaItemLabel>
         </StyledListingDetailPhaseCardSection>
         <StyledListingDetailPhaseCardSection>
-          <MetaItemValue>1,000 CVL</MetaItemValue>
-          <MetaItemLabel>Amount of tokens deposited</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
           <ChallengeResults
             totalVotes={this.props.totalVotes}
             votesFor={this.props.votesFor}

--- a/packages/components/src/ListingDetailPhaseCard/RevealVote.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/RevealVote.tsx
@@ -1,11 +1,16 @@
 import * as React from "react";
 import { RevealVoteProps } from "./types";
-import { buttonSizes } from "../Button";
+import { buttonSizes, DarkButton } from "../Button";
 import { TransactionDarkButton } from "../TransactionButton";
 import { SaltInput } from "../input/";
 import { VoteOptionsContainer, StyledOrText, FormHeader, FormCopy } from "./styledComponents";
 
-export class RevealVote extends React.Component<RevealVoteProps> {
+export interface RevealVoteState {
+  voteOption?: number;
+  saltError?: string;
+}
+
+export class RevealVote extends React.Component<RevealVoteProps, RevealVoteState> {
   public render(): JSX.Element {
     return (
       <>
@@ -19,40 +24,50 @@ export class RevealVote extends React.Component<RevealVoteProps> {
         <SaltInput label="Enter your salt" name="salt" onChange={this.onChange} />
 
         <VoteOptionsContainer>
-          <div onMouseEnter={this.setVoteToRemain}>
-            <TransactionDarkButton
-              size={buttonSizes.MEDIUM}
-              transactions={this.props.transactions}
-              modalContentComponents={this.props.modalContentComponents}
-            >
-              ✔ Remain
-            </TransactionDarkButton>
-          </div>
+          <div onMouseEnter={this.setVoteToRemain}>{this.renderVoteButton({ voteOption: 0 })}</div>
           <StyledOrText>or</StyledOrText>
-          <div onMouseEnter={this.setVoteToRemove}>
-            <TransactionDarkButton
-              size={buttonSizes.MEDIUM}
-              transactions={this.props.transactions}
-              modalContentComponents={this.props.modalContentComponents}
-            >
-              ✖ Remove
-            </TransactionDarkButton>
-          </div>
+          <div onMouseEnter={this.setVoteToRemove}>{this.renderVoteButton({ voteOption: 1 })}</div>
         </VoteOptionsContainer>
       </>
     );
   }
 
+  private renderVoteButton = (options: any): JSX.Element => {
+    const disableButtons = !!this.state.saltError;
+    let buttonText;
+    if (options.voteOption === 0) {
+      buttonText = "✔ Remain";
+    } else if (options.voteOption === 1) {
+      buttonText = "✖ Remove";
+    }
+    if (this.state.voteOption === options.voteOption) {
+      return (
+        <TransactionDarkButton
+          size={buttonSizes.MEDIUM}
+          transactions={this.props.transactions}
+          modalContentComponents={this.props.modalContentComponents}
+          disabled={disableButtons}
+        >
+          {buttonText}
+        </TransactionDarkButton>
+      );
+    }
+
+    return <DarkButton size={buttonSizes.MEDIUM}>{buttonText}</DarkButton>;
+  };
+
   private setVoteToRemain = (): void => {
     // A "remain" vote is a vote that doesn't support the
     // challenge, so `voteOption === 0`
     this.props.onInputChange({ voteOption: "0" });
+    this.setState(() => ({ voteOption: 0 }));
   };
 
   private setVoteToRemove = (): void => {
     // A "remove" vote is a vote that supports the
     // challenge, so `voteOption === 1`
     this.props.onInputChange({ voteOption: "1" });
+    this.setState(() => ({ voteOption: 1 }));
   };
 
   private validateSalt = (): boolean => {

--- a/packages/components/src/ListingDetailPhaseCard/WhitelistedCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/WhitelistedCard.tsx
@@ -21,10 +21,6 @@ export class WhitelistedCard extends React.Component<ListingDetailPhaseCardCompo
           <MetaItemLabel>Approved date</MetaItemLabel>
         </StyledListingDetailPhaseCardSection>
         <StyledListingDetailPhaseCardSection>
-          <MetaItemValue>1,000 CVL</MetaItemValue>
-          <MetaItemLabel>Amount of tokens deposited</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
           <CTACopy>
             If you believe this newsroom does not align with the <a href="#">Civil Constitution</a>, you may{" "}
             <a href="#">submit a challenge</a>.

--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -45,6 +45,9 @@ import {
   findEvents,
 } from "./utils/contracts";
 import { TransactionReceipt } from "web3";
+import * as Debug from "debug";
+
+const debug = Debug("civil:newsroom");
 
 /**
  * A Newsroom can be thought of an organizational unit with a sole goal of providing content
@@ -327,13 +330,18 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
    * text needed for display
    * @param header Metadata you get from Ethereum
    */
-  public async resolveContent(header: EthContentHeader): Promise<NewsroomContent> {
+  public async resolveContent(header: EthContentHeader): Promise<NewsroomContent | undefined> {
     // TODO(ritave): Choose ContentProvider based on schema
-    const content = await this.contentProvider.get(header);
-    return {
-      ...header,
-      content,
-    };
+    try {
+      const content = await this.contentProvider.get(header);
+      return {
+        ...header,
+        content,
+      };
+    } catch (e) {
+      debug(`Resolving Content failed for EthContentHeader: ${header}`, e);
+      return;
+    }
   }
 
   /**

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -2,18 +2,14 @@ import * as React from "react";
 import NavBar from "./components/navbar/NavBar";
 import Main from "./components/Main";
 import { BrowserRouter as Router } from "react-router-dom";
-import { dappTheme } from "./components/utility/ViewModules";
-import { ThemeProvider } from "styled-components";
 
 export const App = (): JSX.Element => {
   return (
     <Router>
-      <ThemeProvider theme={dappTheme}>
-        <>
-          <NavBar />
-          <Main />
-        </>
-      </ThemeProvider>
+      <>
+        <NavBar />
+        <Main />
+      </>
     </Router>
   );
 };

--- a/packages/dapp/src/components/listing/AppealDetail.tsx
+++ b/packages/dapp/src/components/listing/AppealDetail.tsx
@@ -56,7 +56,7 @@ class AppealDetail extends React.Component<AppealDetailProps> {
     const hasAppealChallenge = appeal.appealChallenge;
     return (
       <StyledDiv>
-        {!hasAppealChallenge && this.renderAwaitingAppealDecision()}
+        {!hasAppealChallenge && !canAppealBeResolved && this.renderAwaitingAppealDecision()}
         {isAwaitingAppealChallenge && this.renderChallengeAppealStage()}
         {appeal.appealChallenge && (
           <AppealChallengeDetail

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -319,7 +319,8 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps, ChallengeVot
         <LoadingIndicator height={100} />
         <ModalHeading>Transaction in progress</ModalHeading>
         <ModalOrderedList>
-          <ModalListItem type={ModalListItemTypes.STRONG}>Resolving Challenge</ModalListItem>
+          <ModalListItem type={ModalListItemTypes.STRONG}>Approving for Request Appeal</ModalListItem>
+          <ModalListItem type={ModalListItemTypes.FADED}>Requesting Appeal</ModalListItem>
         </ModalOrderedList>
         <ModalContent>This can take 1-3 minutes. Please don't close the tab.</ModalContent>
         <ModalContent>How about taking a little breather and standing for a bit? Maybe even stretching?</ModalContent>

--- a/packages/dapp/src/components/listing/Listing.tsx
+++ b/packages/dapp/src/components/listing/Listing.tsx
@@ -1,34 +1,19 @@
 import * as React from "react";
+import { connect, DispatchProp } from "react-redux";
+import { EthAddress, ListingWrapper } from "@joincivil/core";
+import { NewsroomState } from "@joincivil/newsroom-manager";
 
 import ListingDiscourse from "./ListingDiscourse";
 import ListingHistory from "./ListingHistory";
 import ListingDetail from "./ListingDetail";
 import ListingPhaseActions from "./ListingPhaseActions";
 import ListingChallengeStatement from "./ListingChallengeStatement";
-import { EthAddress, ListingWrapper } from "@joincivil/core";
 import { State } from "../../reducers";
-import { connect, DispatchProp } from "react-redux";
 import { fetchAndAddListingData } from "../../actionCreators/listings";
-import { NewsroomState } from "@joincivil/newsroom-manager";
 import { makeGetListingPhaseState, makeGetListing, makeGetListingExpiry } from "../../selectors";
 import { Tabs } from "../tabs/Tabs";
 import { Tab } from "../tabs/Tab";
-
-import styled from "styled-components";
-import { ViewModule } from "../utility/ViewModules";
-const GridRow = styled.div`
-  display: flex;
-  margin: 0 auto;
-  padding: 0 0 200px;
-  width: 1200px;
-`;
-const LeftShark = styled.div`
-  width: 695px;
-`;
-const RightShark = styled.div`
-  margin: -100px 0 0 15px;
-  width: 485px;
-`;
+import { GridRow, LeftShark, RightShark, ListingTabContent } from "./styledComponents";
 
 export interface ListingPageProps {
   match: any;
@@ -78,14 +63,21 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
 
             <Tabs>
               <Tab tabText="Discuss">
-                <ViewModule>
+                <ListingTabContent>
                   <ListingChallengeStatement listing={this.props.listingAddress} />
+
+                  <p>
+                    Use this space to discuss, ask questions, or cheer on the newsmakers. If you have questions, check
+                    out our help page.
+                  </p>
                   <ListingDiscourse />
-                </ViewModule>
+                </ListingTabContent>
               </Tab>
 
               <Tab tabText="History">
-                <ListingHistory listing={this.props.listingAddress} />
+                <ListingTabContent>
+                  <ListingHistory listing={this.props.listingAddress} />
+                </ListingTabContent>
               </Tab>
             </Tabs>
           </LeftShark>

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
-import { State } from "../../reducers";
 import { connect } from "react-redux";
 import * as sanitizeHtml from "sanitize-html";
+import styled from "styled-components";
+import { State } from "../../reducers";
+import { ListingTabHeading } from "./styledComponents";
+
+const StyledChallengeStatementComponent = styled.div`
+  margin: 0 0 56px;
+`;
 
 export interface ListingChallengeStatementProps {
   listing: string;
@@ -24,7 +30,17 @@ class ListingChallengeStatement extends React.Component<
       const cleanStatement = sanitizeHtml(parsed.statement, {
         allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(["bzz"]),
       });
-      return <div dangerouslySetInnerHTML={{ __html: cleanStatement }} />;
+      return (
+        <StyledChallengeStatementComponent>
+          <ListingTabHeading>Newsroom listing is under challenge</ListingTabHeading>
+          <p>
+            Should this newsroom stay on the Civil Registry? Read the challenger’s statement below and vote with your
+            CVL tokens.
+          </p>
+          <ListingTabHeading>Challenge Statement</ListingTabHeading>
+          <div dangerouslySetInnerHTML={{ __html: cleanStatement }} />
+        </StyledChallengeStatementComponent>
+      );
     } else {
       return <div />;
     }

--- a/packages/dapp/src/components/listing/ListingHistory.tsx
+++ b/packages/dapp/src/components/listing/ListingHistory.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
 import { List } from "immutable";
-import { Heading } from "@joincivil/components";
 import { State } from "../../reducers";
 import ListingEvent from "./ListingEvent";
 import { setupListingHistorySubscription } from "../../actionCreators/listings";
+import { ListingTabHeading } from "./styledComponents";
 
 export interface ListingHistoryProps {
   listing: string;
@@ -18,12 +18,6 @@ export interface ListingHistoryReduxProps {
 export interface ListingHistoryState {
   error: undefined | string;
 }
-
-const ListingHistoryHeading = Heading.withComponent("div").extend`
-  font-size: 32px;
-  line-height: 34px;
-  margin: 40px 0;
-`;
 
 class ListingHistory extends React.Component<DispatchProp<any> & ListingHistoryReduxProps, ListingHistoryState> {
   constructor(props: DispatchProp<any> & ListingHistoryReduxProps) {
@@ -40,7 +34,7 @@ class ListingHistory extends React.Component<DispatchProp<any> & ListingHistoryR
   public render(): JSX.Element {
     return (
       <>
-        <ListingHistoryHeading>Listing History</ListingHistoryHeading>
+        <ListingTabHeading>Listing History</ListingTabHeading>
         {this.props.listingHistory.map((e, i) => {
           return <ListingEvent key={i} event={e} listing={this.props.listing} />;
         })}

--- a/packages/dapp/src/components/listing/styledComponents.tsx
+++ b/packages/dapp/src/components/listing/styledComponents.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import styled, { StyledComponentClass } from "styled-components";
+import { Heading } from "@joincivil/components";
+
+export const GridRow = styled.div`
+  display: flex;
+  margin: 0 auto;
+  padding: 0 0 200px;
+  width: 1200px;
+`;
+export const LeftShark = styled.div`
+  width: 695px;
+`;
+export const RightShark = styled.div`
+  margin: -100px 0 0 15px;
+  width: 485px;
+`;
+
+export const ListingTabHeading = Heading.withComponent("h3").extend`
+  font-size: 32px;
+  line-height: 34px;
+  margin: 34px 0 10px;
+`;
+
+export const ListingTabContent = styled.div`
+  font-size: 18px;
+  line-height: 33px;
+  padding: 40px 0 0;
+  width: 635px;
+
+  & p {
+    font-size: inherit;
+    line-height: inherit;
+  }
+`;

--- a/packages/dapp/src/components/tabs/Tab.tsx
+++ b/packages/dapp/src/components/tabs/Tab.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import styled from "styled-components";
+import { colors } from "@joincivil/components";
 
 const StyledLI = styled.li`
   display: inline-block;
   border: 1px solid transparent;
   border-bottom: none;
-  bottom: -1px;
+  bottom: -6px;
   position: relative;
   list-style: none;
   padding: 6px 12px;
@@ -17,7 +18,14 @@ export interface StyledSpanProps {
 }
 
 const StyledSpan = styled<StyledSpanProps, "span">("span")`
-  ${(props: StyledSpanProps): string => (props.active ? "text-decoration: underline" : "")};
+  display: inline-block;
+  border-bottom: 2px solid;
+  border-bottom-color: ${(props: StyledSpanProps): string => (props.active ? colors.accent.CIVIL_BLUE : "transparent")}
+  color: ${(props: StyledSpanProps): string => (props.active ? colors.primary.BLACK : colors.primary.CIVIL_GRAY_2)}
+  font-size: 18px;
+  line-height: 21px;
+  padding: 11px 0;
+  margin-right: 32px;
 `;
 
 export interface TabProps {

--- a/packages/dapp/tslint.json
+++ b/packages/dapp/tslint.json
@@ -2,6 +2,7 @@
   "extends": ["@joincivil/tslint-rules"],
   "rules": {
     "variable-name": [true, "ban-keywords", "allow-leading-underscore"],
-    "no-var-requires": false
+    "no-var-requires": false,
+    "no-unused-variable": [true, { "ignore-pattern": "^React|styled|StyledComponentClass" }]
   }
 }


### PR DESCRIPTION
- Fix grey buttons in DApp
- Don't display 'NaN' in Challenge Results chart
- Fix success modal for Commit Vote (by only having one transaction button in the DOM)
- Fix progress modal messaging for Approve For Request Appeal
- Add try/catch to `contentProvider.get()` call in Newsroom contract, to catch `FallbackProvider` error that can kill the DApp
- Remove newsroom deposit text from Phase cards
- Add some basic tab content / challenge statement styles to Listing Detail page
- Fix bug where Awaiting Appeal Decision and Resolve Appeal would appear at the same time