### PR TITLE
Responding to Audit Findings 3.30, 3.31, 3.32

### DIFF
--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -67,10 +67,12 @@ contract CivilTCR is RestrictedAddressRegistry {
     address tokenAddr,
     address plcrAddr,
     address paramsAddr,
-    address govtAddr
+    IGovernment govt
   ) public RestrictedAddressRegistry(tokenAddr, plcrAddr, paramsAddr)
   {
-    government = IGovernment(govtAddr);
+    require(govt != 0);
+    require(govt.getGovernmentController() != 0);
+    government = govt;
   }
 
   // --------------------
@@ -145,9 +147,10 @@ contract CivilTCR is RestrictedAddressRegistry {
   --------
   Emits `_GovernmentTransfered` if successful.
   */
-  function transferGovernment(address newAddress) external onlyGovernmentController {
-    government = IGovernment(newAddress);
-    emit _GovernmentTransfered(newAddress);
+  function transferGovernment(IGovernment newGovernment) external onlyGovernmentController {
+    require(newGovernment != 0);
+    government = newGovernment;
+    emit _GovernmentTransfered(newGovernment);
   }
 
   // --------

--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -61,7 +61,7 @@ contract CivilTCR is RestrictedAddressRegistry {
   @param tokenAddr Address of the TCR's intrinsic ERC20 token
   @param plcrAddr Address of a PLCR voting contract for the provided token
   @param paramsAddr Address of a Parameterizer contract
-  @param govtAddr Address of a IGovernment contract
+  @param govt IGovernment contract
   */
   function CivilTCR(
     address tokenAddr,
@@ -70,7 +70,7 @@ contract CivilTCR is RestrictedAddressRegistry {
     IGovernment govt
   ) public RestrictedAddressRegistry(tokenAddr, plcrAddr, paramsAddr)
   {
-    require(govt != 0);
+    require(address(govt) != 0);
     require(govt.getGovernmentController() != 0);
     government = govt;
   }
@@ -148,7 +148,7 @@ contract CivilTCR is RestrictedAddressRegistry {
   Emits `_GovernmentTransfered` if successful.
   */
   function transferGovernment(IGovernment newGovernment) external onlyGovernmentController {
-    require(newGovernment != 0);
+    require(address(newGovernment) != 0);
     government = newGovernment;
     emit _GovernmentTransfered(newGovernment);
   }

--- a/packages/contracts/contracts/tcr/Government.sol
+++ b/packages/contracts/contracts/tcr/Government.sol
@@ -43,6 +43,8 @@ contract Government is IGovernment {
     string constURI
   ) public
   {
+    require(appellateAddr != 0);
+    require(governmentControllerAddr != 0);
     appellate = appellateAddr;
     governmentController = governmentControllerAddr;
     internalSet("requestAppealLen", requestAppealLength);
@@ -104,6 +106,7 @@ contract Government is IGovernment {
   @param newAppellate address of entity that will be made the Appellate
   */
   function setAppellate(address newAppellate) external onlyGovernmentController {
+    require(newAppellate != 0);
     appellate = newAppellate;
     emit AppellateSet(newAppellate);
   }


### PR DESCRIPTION
- Adding safety checks for government parameters in constructor and transferGovernment function
- avoid bypassing static type system for government parameter