### PR TITLE
Respond to Audit Finding 3.35

### DIFF
--- a/packages/contracts/contracts/tcr/AddressRegistry.sol
+++ b/packages/contracts/contracts/tcr/AddressRegistry.sol
@@ -459,18 +459,18 @@ contract AddressRegistry {
     // Stores the total tokens used for voting by the winning side for reward purposes
     challenge.totalTokens = voting.getTotalNumberOfTokensForWinningOption(challengeID);
 
-    if (voting.isPassed(challengeID)) { // Case: challenge succeeded, listing to be removed
-      resetListing(listingAddress);
-      // Transfer the reward to the challenger
-      require(token.transfer(challenge.challenger, reward));
-      emit _ChallengeSucceeded(listingAddress, challengeID, challenge.rewardPool, challenge.totalTokens);
-    } else { // Case: challenge failed, listing to be whitelisted
+    if (voting.isPassed(challengeID)) { // Case: challenge failed, listing to be whitelisted
       whitelistApplication(listingAddress);
       // Unlock stake so that it can be retrieved by the applicant
       listing.unstakedDeposit += reward;
 
       listing.challengeID = 0;
       emit _ChallengeFailed(listingAddress, challengeID, challenge.rewardPool, challenge.totalTokens);
+     } else { // Case: challenge succeeded, listing to be removed
+      resetListing(listingAddress);
+      // Transfer the reward to the challenger
+      require(token.transfer(challenge.challenger, reward));
+      emit _ChallengeSucceeded(listingAddress, challengeID, challenge.rewardPool, challenge.totalTokens);
     }
   }
 

--- a/packages/contracts/test/tcr/registry/updateStatus.ts
+++ b/packages/contracts/test/tcr/registry/updateStatus.ts
@@ -57,9 +57,9 @@ contract("Registry", accounts => {
     it("should not whitelist a listing that failed a challenge", async () => {
       await registry.apply(listing24, minDeposit, "", { from: applicant });
       const pollID = await utils.challengeAndGetPollID(listing24, challenger, registry);
-      await utils.commitVote(voting, pollID, "1", "100", "123", voter);
+      await utils.commitVote(voting, pollID, "0", "100", "123", voter);
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
-      await voting.revealVote(pollID, "1", "123", { from: voter });
+      await voting.revealVote(pollID, "0", "123", { from: voter });
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await registry.updateStatus(listing24);
       const [, isWhitelisted] = await registry.listings(listing24);

--- a/packages/contracts/test/tcr/registry/userStories.ts
+++ b/packages/contracts/test/tcr/registry/userStories.ts
@@ -46,7 +46,7 @@ contract("Registry", accounts => {
       // Virgin commit
       const tokensArg = "10";
       const salt = "420";
-      const voteOption = "0";
+      const voteOption = "1";
       await utils.commitVote(voting, pollID, voteOption, tokensArg, salt, voter);
 
       const numTokens = await voting.getNumTokens(voter, pollID);
@@ -70,7 +70,7 @@ contract("Registry", accounts => {
 
       // updateStatus
       const pollResult = await voting.isPassed.call(pollID);
-      expect(pollResult).to.be.false("Poll should have failed");
+      expect(pollResult).to.be.true("Poll should have failed");
 
       // Add to whitelist
       await registry.updateStatus(listing28);
@@ -84,8 +84,8 @@ contract("Registry", accounts => {
       // Challenge and get back the pollID
       const pollID = await utils.challengeAndGetPollID(listing28, challenger, registry);
 
-      await utils.commitVote(voting, pollID, "1", "10", "420", voter);
-      await utils.commitVote(voting, pollID, "0", "15", "123", voter);
+      await utils.commitVote(voting, pollID, "0", "10", "420", voter);
+      await utils.commitVote(voting, pollID, "1", "15", "123", voter);
 
       const numTokens = await voting.getNumTokens(voter, pollID);
       expect(numTokens).to.be.bignumber.equal("15", "Should have committed the correct number of tokens");
@@ -99,7 +99,7 @@ contract("Registry", accounts => {
       let rpa = await voting.revealPeriodActive.call(pollID);
       expect(rpa).to.be.true("Reveal period should be active");
 
-      await voting.revealVote(pollID, "0", "123", { from: voter });
+      await voting.revealVote(pollID, "1", "123", { from: voter });
 
       // End reveal period
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
@@ -108,7 +108,7 @@ contract("Registry", accounts => {
 
       // updateStatus
       const pollResult = await voting.isPassed.call(pollID);
-      expect(pollResult).to.be.false("Poll should have failed");
+      expect(pollResult).to.be.true("Poll should have succeeded");
 
       // Add to whitelist
       await registry.updateStatus(listing28);

--- a/packages/contracts/test/tcr/registryWithAppeals/apply.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/apply.ts
@@ -100,9 +100,9 @@ contract("Registry With Appeals", accounts => {
       it("should allow a listing to re-apply after losing challenge (challenge vote successful), not being granted appeal, updating status", async () => {
         await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
         const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
-        await utils.commitVote(voting, pollID, "1", "100", "1234", voter);
+        await utils.commitVote(voting, pollID, "0", "100", "1234", voter);
         await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
-        await voting.revealVote(pollID, "1", "1234", { from: voter });
+        await voting.revealVote(pollID, "0", "1234", { from: voter });
         await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
         await registry.requestAppeal(newsroomAddress, { from: applicant });
         await utils.advanceEvmTime(utils.paramConfig.judgeAppealPhaseLength + 1);

--- a/packages/contracts/test/tcr/registryWithAppeals/requestAppeal.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/requestAppeal.ts
@@ -123,9 +123,9 @@ contract("Registry With Appeals", accounts => {
       // 1st time
       await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
       const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
-      await utils.commitVote(voting, pollID, "1", "500", "420", voter);
+      await utils.commitVote(voting, pollID, "0", "500", "420", voter);
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
-      await voting.revealVote(pollID, "1", "420", { from: voter });
+      await voting.revealVote(pollID, "0", "420", { from: voter });
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await registry.requestAppeal(newsroomAddress, { from: applicant });
       await utils.advanceEvmTime(utils.paramConfig.judgeAppealPhaseLength + 1); // hack. should be getting value from registry contract
@@ -145,9 +145,9 @@ contract("Registry With Appeals", accounts => {
       // 1st time
       await registry.apply(newsroomAddress, minDeposit, "", { from: applicant });
       const pollID = await utils.challengeAndGetPollID(newsroomAddress, challenger, registry);
-      await utils.commitVote(voting, pollID, "1", "500", "420", voter);
+      await utils.commitVote(voting, pollID, "0", "500", "420", voter);
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength + 1);
-      await voting.revealVote(pollID, "1", "420", { from: voter });
+      await voting.revealVote(pollID, "0", "420", { from: voter });
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await utils.advanceEvmTime(utils.paramConfig.requestAppealPhaseLength + 1); // hack. should be getting value from registry contract
       await registry.updateStatus(newsroomAddress);

--- a/packages/contracts/test/utils/contractutils.ts
+++ b/packages/contracts/test/utils/contractutils.ts
@@ -87,9 +87,9 @@ export async function simpleSuccessfulChallenge(
   const votingAddress = await registry.voting();
   const voting = PLCRVoting.at(votingAddress);
   const pollID = await challengeAndGetPollID(listing, challenger, registry);
-  await commitVote(voting, pollID, "1", "100", "123", voter);
+  await commitVote(voting, pollID, "0", "100", "123", voter);
   await advanceEvmTime(paramConfig.commitStageLength + 1);
-  await voting.revealVote(pollID, "1", "123", { from: voter });
+  await voting.revealVote(pollID, "0", "123", { from: voter });
   await advanceEvmTime(paramConfig.revealStageLength + 1);
 }
 
@@ -102,9 +102,9 @@ export async function simpleUnsuccessfulChallenge(
   const votingAddress = await registry.voting();
   const voting = PLCRVoting.at(votingAddress);
   const pollID = await challengeAndGetPollID(listing, challenger, registry);
-  await commitVote(voting, pollID, "0", "100", "420", voter);
+  await commitVote(voting, pollID, "1", "100", "420", voter);
   await advanceEvmTime(paramConfig.commitStageLength + 1);
-  await voting.revealVote(pollID, "0", "420", { from: voter });
+  await voting.revealVote(pollID, "1", "420", { from: voter });
   await advanceEvmTime(paramConfig.revealStageLength + 1);
 }
 
@@ -117,9 +117,9 @@ export async function simpleSuccessfulAppealChallenge(
   const votingAddress = await registry.voting();
   const voting = PLCRVoting.at(votingAddress);
   const pollID = await challengeAppealAndGetPollID(listing, challenger, registry);
-  await commitVote(voting, pollID, "1", "100", "123", voter);
+  await commitVote(voting, pollID, "0", "100", "123", voter);
   await advanceEvmTime(paramConfig.appealChallengeCommitStageLength + 1);
-  await voting.revealVote(pollID, "1", "123", { from: voter });
+  await voting.revealVote(pollID, "0", "123", { from: voter });
   await advanceEvmTime(paramConfig.appealChallengeRevealStageLength + 1);
 }
 
@@ -132,9 +132,9 @@ export async function simpleUnsuccessfulAppealChallenge(
   const votingAddress = await registry.voting();
   const voting = PLCRVoting.at(votingAddress);
   const pollID = await challengeAppealAndGetPollID(listing, challenger, registry);
-  await commitVote(voting, pollID, "0", "100", "420", voter);
+  await commitVote(voting, pollID, "1", "100", "420", voter);
   await advanceEvmTime(paramConfig.appealChallengeCommitStageLength + 1);
-  await voting.revealVote(pollID, "0", "420", { from: voter });
+  await voting.revealVote(pollID, "1", "420", { from: voter });
   await advanceEvmTime(paramConfig.appealChallengeRevealStageLength + 1);
 }
 


### PR DESCRIPTION
- switching meaning of 'voting.isPassed' in TCR contracts to match standard implementation
- fixing unit tests after changes to contracts 