### PR TITLE
DApp UI updates: Whitelisted / Rejected timestamps + Newsroom charter

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/ListingDetailsPhaseCard.stories.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ListingDetailsPhaseCard.stories.tsx
@@ -288,13 +288,18 @@ storiesOf("Listing Details Phase Card", module)
     );
   })
   .add("Whitelisted", () => {
-    return <Container>{process.env.NODE_ENV !== "test" && <WhitelistedCard transactions={[]} />}</Container>;
+    return (
+      <Container>
+        {process.env.NODE_ENV !== "test" && <WhitelistedCard whitelistedTimestamp={now} transactions={[]} />}
+      </Container>
+    );
   })
   .add("Rejected", () => {
     return (
       <Container>
         {process.env.NODE_ENV !== "test" && (
           <RejectedCard
+            listingRemovedTimestamp={now}
             totalVotes={totalVotes}
             votesFor={votesFor}
             votesAgainst={votesAgainst}

--- a/packages/components/src/ListingDetailPhaseCard/RejectedCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/RejectedCard.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { getLocalDateTimeStrings } from "@joincivil/utils";
 import { ListingDetailPhaseCardComponentProps } from "./types";
 import {
   StyledListingDetailPhaseCardContainer,
@@ -9,25 +10,36 @@ import {
 } from "./styledComponents";
 import { ChallengeResults, ChallengeResultsProps } from "../ChallengeResultsChart";
 
-export class RejectedCard extends React.Component<ListingDetailPhaseCardComponentProps & ChallengeResultsProps> {
-  public render(): JSX.Element {
-    return (
-      <StyledListingDetailPhaseCardContainer>
-        <StyledListingDetailPhaseCardSection>
-          <StyledPhaseDisplayName>Rejected Newsroom</StyledPhaseDisplayName>
-          <MetaItemValue>May 5, 2018, 8:30 GMT-0400</MetaItemValue>
-          <MetaItemLabel>Rejected date</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
-          <ChallengeResults
-            totalVotes={this.props.totalVotes}
-            votesFor={this.props.votesFor}
-            votesAgainst={this.props.votesAgainst}
-            percentFor={this.props.percentFor}
-            percentAgainst={this.props.percentAgainst}
-          />
-        </StyledListingDetailPhaseCardSection>
-      </StyledListingDetailPhaseCardContainer>
-    );
-  }
+export interface RejectedCardProps {
+  listingRemovedTimestamp?: number;
 }
+
+export const RejectedCard: React.StatelessComponent<
+  ListingDetailPhaseCardComponentProps & ChallengeResultsProps & RejectedCardProps
+> = props => {
+  let displayDateTime;
+
+  if (props.listingRemovedTimestamp) {
+    const listingRemovedDateTime = getLocalDateTimeStrings(props.listingRemovedTimestamp);
+    displayDateTime = `${listingRemovedDateTime[0]} ${listingRemovedDateTime[1]}`;
+  }
+
+  return (
+    <StyledListingDetailPhaseCardContainer>
+      <StyledListingDetailPhaseCardSection>
+        <StyledPhaseDisplayName>Rejected Newsroom</StyledPhaseDisplayName>
+        <MetaItemValue>{displayDateTime}</MetaItemValue>
+        <MetaItemLabel>Rejected date</MetaItemLabel>
+      </StyledListingDetailPhaseCardSection>
+      <StyledListingDetailPhaseCardSection>
+        <ChallengeResults
+          totalVotes={props.totalVotes}
+          votesFor={props.votesFor}
+          votesAgainst={props.votesAgainst}
+          percentFor={props.percentFor}
+          percentAgainst={props.percentAgainst}
+        />
+      </StyledListingDetailPhaseCardSection>
+    </StyledListingDetailPhaseCardContainer>
+  );
+};

--- a/packages/components/src/ListingDetailPhaseCard/WhitelistedCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/WhitelistedCard.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { getLocalDateTimeStrings } from "@joincivil/utils";
 import { ListingDetailPhaseCardComponentProps, SubmitChallengeProps } from "./types";
 import {
   StyledListingDetailPhaseCardContainer,
@@ -11,37 +12,48 @@ import {
 import { buttonSizes, InvertedButton } from "../Button";
 import { TransactionInvertedButton } from "../TransactionButton";
 
-export class WhitelistedCard extends React.Component<ListingDetailPhaseCardComponentProps & SubmitChallengeProps> {
-  public render(): JSX.Element {
+export interface WhitelistedCardProps {
+  whitelistedTimestamp?: number;
+}
+
+export const WhitelistedCard: React.StatelessComponent<
+  ListingDetailPhaseCardComponentProps & SubmitChallengeProps & WhitelistedCardProps
+> = props => {
+  let displayDateTime;
+
+  if (props.whitelistedTimestamp) {
+    const listingRemovedDateTime = getLocalDateTimeStrings(props.whitelistedTimestamp);
+    displayDateTime = `${listingRemovedDateTime[0]} ${listingRemovedDateTime[1]}`;
+  }
+
+  return (
+    <StyledListingDetailPhaseCardContainer>
+      <StyledListingDetailPhaseCardSection>
+        <StyledPhaseDisplayName>Approved Newsroom</StyledPhaseDisplayName>
+        <MetaItemValue>{displayDateTime}</MetaItemValue>
+        <MetaItemLabel>Approved date</MetaItemLabel>
+      </StyledListingDetailPhaseCardSection>
+      <StyledListingDetailPhaseCardSection>
+        <CTACopy>
+          If you believe this newsroom does not align with the <a href="#">Civil Constitution</a>, you may{" "}
+          <a href="#">submit a challenge</a>.
+        </CTACopy>
+        {renderSubmitChallengeButton(props)}
+      </StyledListingDetailPhaseCardSection>
+    </StyledListingDetailPhaseCardContainer>
+  );
+};
+
+const renderSubmitChallengeButton: React.StatelessComponent<
+  ListingDetailPhaseCardComponentProps & SubmitChallengeProps & WhitelistedCardProps
+> = props => {
+  if (props.handleSubmitChallenge) {
     return (
-      <StyledListingDetailPhaseCardContainer>
-        <StyledListingDetailPhaseCardSection>
-          <StyledPhaseDisplayName>Approved Newsroom</StyledPhaseDisplayName>
-          <MetaItemValue>May 5, 2018, 8:30 GMT-0400</MetaItemValue>
-          <MetaItemLabel>Approved date</MetaItemLabel>
-        </StyledListingDetailPhaseCardSection>
-        <StyledListingDetailPhaseCardSection>
-          <CTACopy>
-            If you believe this newsroom does not align with the <a href="#">Civil Constitution</a>, you may{" "}
-            <a href="#">submit a challenge</a>.
-          </CTACopy>
-          {this.renderSubmitChallengeButton()}
-        </StyledListingDetailPhaseCardSection>
-      </StyledListingDetailPhaseCardContainer>
+      <InvertedButton size={buttonSizes.MEDIUM} onClick={props.handleSubmitChallenge}>
+        Submit a Challenge
+      </InvertedButton>
     );
   }
 
-  private renderSubmitChallengeButton = (): JSX.Element => {
-    if (this.props.handleSubmitChallenge) {
-      return (
-        <InvertedButton size={buttonSizes.MEDIUM} onClick={this.props.handleSubmitChallenge}>
-          Submit a Challenge
-        </InvertedButton>
-      );
-    }
-
-    return (
-      <TransactionInvertedButton transactions={this.props.transactions!}>Submit a Challenge</TransactionInvertedButton>
-    );
-  };
-}
+  return <TransactionInvertedButton transactions={props.transactions!}>Submit a Challenge</TransactionInvertedButton>;
+};

--- a/packages/core/src/contracts/tcr/listing.ts
+++ b/packages/core/src/contracts/tcr/listing.ts
@@ -146,5 +146,23 @@ export class Listing {
     return subject;
   }
 
+  public latestWhitelisted(): BehaviorSubject<
+    TimestampedEvent<CivilTCR.LogEvents._ApplicationWhitelisted> | undefined
+  > {
+    const subject = new BehaviorSubject<TimestampedEvent<CivilTCR.LogEvents._ApplicationWhitelisted> | undefined>(
+      undefined,
+    );
+    this.whitelisteds().subscribe(subject);
+    return subject;
+  }
+
+  public latestListingRemoved(): BehaviorSubject<TimestampedEvent<CivilTCR.LogEvents._ListingRemoved> | undefined> {
+    const subject = new BehaviorSubject<TimestampedEvent<CivilTCR.LogEvents._ApplicationRemoved> | undefined>(
+      undefined,
+    );
+    this.listingRemoveds().subscribe(subject);
+    return subject;
+  }
+
   //#endregion
 }

--- a/packages/dapp/src/components/listing/Listing.tsx
+++ b/packages/dapp/src/components/listing/Listing.tsx
@@ -7,6 +7,7 @@ import ListingOwnerActions from "./ListingOwnerActions";
 import ListingDiscourse from "./ListingDiscourse";
 import ListingHistory from "./ListingHistory";
 import ListingHeader from "./ListingHeader";
+import ListingCharter from "./ListingCharter";
 import ListingPhaseActions from "./ListingPhaseActions";
 import ListingChallengeStatement from "./ListingChallengeStatement";
 import { State } from "../../reducers";
@@ -74,6 +75,14 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
             {!listingExistsAsNewsroom && this.renderListingNotFound()}
 
             <Tabs TabComponent={StyledTab}>
+              {(listingExistsAsNewsroom && (
+                <Tab title="About">
+                  <ListingTabContent>
+                    <ListingCharter listing={this.props.listing!} newsroom={this.props.newsroom!.wrapper} />
+                  </ListingTabContent>
+                </Tab>
+              )) || <></>}
+
               <Tab title="Discussions">
                 <ListingTabContent>
                   <ListingChallengeStatement listing={this.props.listingAddress} />
@@ -85,6 +94,7 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
                   <ListingDiscourse />
                 </ListingTabContent>
               </Tab>
+
               <Tab title="History">
                 <ListingTabContent>
                   <ListingHistory listingAddress={this.props.listingAddress} />

--- a/packages/dapp/src/components/listing/ListingCharter.tsx
+++ b/packages/dapp/src/components/listing/ListingCharter.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as sanitizeHtml from "sanitize-html";
+import { ListingWrapper, NewsroomWrapper } from "@joincivil/core";
+
+export interface ListingCharterProps {
+  newsroom?: NewsroomWrapper;
+  listing?: ListingWrapper;
+}
+
+class ListingCharter extends React.Component<ListingCharterProps> {
+  public render(): JSX.Element {
+    let cleanNewsroomCharter = "";
+    if (this.props.newsroom && this.props.newsroom.data.charter) {
+      const newsroomCharter = JSON.parse(this.props.newsroom.data.charter.content.toString()).charter;
+      cleanNewsroomCharter = sanitizeHtml(newsroomCharter, {
+        allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(["bzz"]),
+      });
+    }
+
+    return (
+      (this.props.listing &&
+        this.props.listing.data && <div dangerouslySetInnerHTML={{ __html: cleanNewsroomCharter }} />) || <></>
+    );
+  }
+}
+
+export default ListingCharter;

--- a/packages/dapp/src/components/listing/ListingPhaseActions.tsx
+++ b/packages/dapp/src/components/listing/ListingPhaseActions.tsx
@@ -7,7 +7,6 @@ import { ChallengeResolve } from "./ChallengeResolve";
 import {
   InApplicationCard,
   InApplicationResolveCard,
-  WhitelistedCard,
   RejectedCard as RejectedCardComponent,
   LoadingIndicator,
   ModalHeading,
@@ -21,6 +20,7 @@ import {
 import { getFormattedTokenBalance } from "@joincivil/utils";
 import { getCivil } from "../../helpers/civilInstance";
 import { ListingContainerProps, connectLatestChallengeSucceededResults } from "../utility/HigherOrderComponents";
+import WhitelistedDetail from "./WhitelistedDetail";
 
 export interface ListingPhaseActionsProps {
   listing: ListingWrapper;
@@ -105,11 +105,12 @@ class ListingPhaseActions extends React.Component<ListingPhaseActionsProps, List
   }
 
   private renderApplicationWhitelisted(): JSX.Element {
-    // @TODO(jon): Get the Whitelisted event for this listing and display that event's date
-    // in the card
     return (
       <>
-        <WhitelistedCard handleSubmitChallenge={this.handleSubmitChallenge} />
+        <WhitelistedDetail
+          listingAddress={this.props.listing.address}
+          handleSubmitChallenge={this.handleSubmitChallenge}
+        />
         {this.renderSubmitChallengeModal()}
       </>
     );

--- a/packages/dapp/src/components/listing/WhitelistedDetail.tsx
+++ b/packages/dapp/src/components/listing/WhitelistedDetail.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { connect, DispatchProp } from "react-redux";
+import { EthAddress } from "@joincivil/core";
+import { ListingDetailPhaseCardComponentProps, WhitelistedCard, WhitelistedCardProps } from "@joincivil/components";
+import { State } from "../../reducers";
+import { setupListingWhitelistedSubscription } from "../../actionCreators/listings";
+import { makeGetLatestWhitelistedTimestamp } from "../../selectors";
+import { ListingContainerProps } from "../utility/HigherOrderComponents";
+
+export interface WhitelistedCardSubmitChallengeProps {
+  listingAddress: EthAddress;
+  handleSubmitChallenge?(): void;
+}
+
+class WhitelistedDetail extends React.Component<
+  ListingDetailPhaseCardComponentProps & WhitelistedCardProps & WhitelistedCardSubmitChallengeProps & DispatchProp<any>
+> {
+  public async componentDidMount(): Promise<void> {
+    this.props.dispatch!(await setupListingWhitelistedSubscription(this.props.listingAddress));
+  }
+
+  public render(): JSX.Element {
+    return (
+      <>
+        <WhitelistedCard
+          whitelistedTimestamp={this.props.whitelistedTimestamp}
+          handleSubmitChallenge={this.props.handleSubmitChallenge}
+        />
+      </>
+    );
+  }
+}
+
+const makeMapStateToProps = () => {
+  const getLatestWhitelistedTimestamp = makeGetLatestWhitelistedTimestamp();
+
+  const mapStateToProps = (
+    state: State,
+    ownProps: WhitelistedCardSubmitChallengeProps & ListingContainerProps,
+  ): WhitelistedCardSubmitChallengeProps & WhitelistedCardProps => {
+    const whitelistedTimestamp = getLatestWhitelistedTimestamp(state, ownProps);
+    return { ...ownProps, whitelistedTimestamp };
+  };
+
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps)(WhitelistedDetail);

--- a/packages/dapp/src/reducers/index.ts
+++ b/packages/dapp/src/reducers/index.ts
@@ -21,6 +21,8 @@ import {
   ListingExtendedMetadata,
   listingHistorySubscriptions,
   rejectedListingLatestChallengeSubscriptions,
+  whitelistedSubscriptions,
+  rejectedListingRemovedSubscriptions,
 } from "./listings";
 import {
   parameters,
@@ -100,7 +102,9 @@ export interface NetworkDependentState {
   controller: string;
   appellateMembers: string[];
   listingHistorySubscriptions: Map<string, Subscription>;
+  rejectedListingRemovedSubscriptions: Map<string, Subscription>;
   rejectedListingLatestChallengeSubscriptions: Map<string, Subscription>;
+  whitelistedSubscriptions: Map<string, Subscription>;
 }
 
 const networkDependentReducers = combineReducers({
@@ -143,7 +147,9 @@ const networkDependentReducers = combineReducers({
   controller,
   appellateMembers,
   listingHistorySubscriptions,
+  rejectedListingRemovedSubscriptions,
   rejectedListingLatestChallengeSubscriptions,
+  whitelistedSubscriptions,
 });
 
 const networkDependent = (state: any, action: AnyAction) => {

--- a/packages/dapp/src/reducers/listings.ts
+++ b/packages/dapp/src/reducers/listings.ts
@@ -28,6 +28,8 @@ export interface ListingWrapperWithExpiry {
 
 export interface ListingExtendedMetadata {
   latestChallengeID?: BigNumber;
+  listingRemovedTimestamp?: number;
+  whitelistedTimestamp?: number;
 }
 
 export function listings(
@@ -104,6 +106,30 @@ export function rejectedListingLatestChallengeSubscriptions(
 ): Map<string, Subscription> {
   switch (action.type) {
     case listingActions.ADD_REJECTED_LISTING_LATEST_CHALLENGE_SUBSCRIPTION:
+      return state.set(action.data.address, action.data.subscription);
+    default:
+      return state;
+  }
+}
+
+export function rejectedListingRemovedSubscriptions(
+  state: Map<string, Subscription> = Map<string, Subscription>(),
+  action: AnyAction,
+): Map<string, Subscription> {
+  switch (action.type) {
+    case listingActions.ADD_REJECTED_LISTING_LISTING_REMOVED_SUBSCRIPTION:
+      return state.set(action.data.address, action.data.subscription);
+    default:
+      return state;
+  }
+}
+
+export function whitelistedSubscriptions(
+  state: Map<string, Subscription> = Map<string, Subscription>(),
+  action: AnyAction,
+): Map<string, Subscription> {
+  switch (action.type) {
+    case listingActions.ADD_LISTING_WHITELISTED_SUBSCRIPTION:
       return state.set(action.data.address, action.data.subscription);
     default:
       return state;

--- a/packages/dapp/src/selectors/index.ts
+++ b/packages/dapp/src/selectors/index.ts
@@ -226,3 +226,23 @@ export const makeGetLatestChallengeSucceededChallengeID = () => {
     return;
   });
 };
+
+export const makeGetLatestListingRemovedTimestamp = () => {
+  return createSelector([getListingExtendedMetadata], listingExtendedMetadata => {
+    if (listingExtendedMetadata && listingExtendedMetadata.listingRemovedTimestamp) {
+      const { listingRemovedTimestamp } = listingExtendedMetadata;
+      return listingRemovedTimestamp;
+    }
+    return;
+  });
+};
+
+export const makeGetLatestWhitelistedTimestamp = () => {
+  return createSelector([getListingExtendedMetadata], listingExtendedMetadata => {
+    if (listingExtendedMetadata && listingExtendedMetadata.whitelistedTimestamp) {
+      const { whitelistedTimestamp } = listingExtendedMetadata;
+      return whitelistedTimestamp;
+    }
+    return;
+  });
+};


### PR DESCRIPTION
- Display the listing whitelisted / rejected timestamps where appropriate
- Render the newsroom charter in the 'About' tab on the listing detail page