### PR TITLE
Loading Steps

### DIFF
--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -158,7 +158,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently listings as new events get triggered
    */
-  public allEventsExceptWhitelistFromBlock(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public allEventsExceptWhitelistFromBlock(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return Observable.merge(
       this.instance
         ._AppealRequestedStream({}, { fromBlock, toBlock })
@@ -272,7 +275,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in commit vote phase
    */
-  public currentChallengedCommitVotePhaseListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public currentChallengedCommitVotePhaseListings(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -286,7 +292,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in reveal vote phase
    */
-  public currentChallengedRevealVotePhaseListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public currentChallengedRevealVotePhaseListings(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -308,7 +317,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
       .concatFilter(l => isAwaitingAppealRequest(l.data));
   }
 
-  public listingsWithChallengeToResolve(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsWithChallengeToResolve(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -322,7 +334,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsAwaitingAppealJudgment(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsAwaitingAppealJudgment(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -336,7 +351,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsAwaitingAppealChallenge(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsAwaitingAppealChallenge(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -350,7 +368,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsInAppealChallengeCommitPhase(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsInAppealChallengeCommitPhase(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -364,7 +385,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsInAppealChallengeRevealPhase(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsInAppealChallengeRevealPhase(
+    fromBlock: number | "latest" = 0,
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -158,70 +158,70 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently listings as new events get triggered
    */
-  public allEventsExceptWhitelistFromBlock(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public allEventsExceptWhitelistFromBlock(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return Observable.merge(
       this.instance
-        ._AppealRequestedStream({}, { fromBlock })
+        ._AppealRequestedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._AppealGrantedStream({}, { fromBlock })
+        ._AppealGrantedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._FailedChallengeOverturnedStream({}, { fromBlock })
+        ._FailedChallengeOverturnedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._SuccessfulChallengeOverturnedStream({}, { fromBlock })
+        ._SuccessfulChallengeOverturnedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._GrantedAppealChallengedStream({}, { fromBlock })
+        ._GrantedAppealChallengedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._GrantedAppealOverturnedStream({}, { fromBlock })
+        ._GrantedAppealOverturnedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._GrantedAppealConfirmedStream({}, { fromBlock })
+        ._GrantedAppealConfirmedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._ChallengeStream({}, { fromBlock })
+        ._ChallengeStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._DepositStream({}, { fromBlock })
+        ._DepositStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._WithdrawalStream({}, { fromBlock })
+        ._WithdrawalStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._ApplicationRemovedStream({}, { fromBlock })
+        ._ApplicationRemovedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._ListingRemovedStream({}, { fromBlock })
+        ._ListingRemovedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._ListingWithdrawnStream({}, { fromBlock })
+        ._ListingWithdrawnStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._TouchAndRemovedStream({}, { fromBlock })
+        ._TouchAndRemovedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._ChallengeFailedStream({}, { fromBlock })
+        ._ChallengeFailedStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
 
       this.instance
-        ._ChallengeSucceededStream({}, { fromBlock })
+        ._ChallengeSucceededStream({}, { fromBlock, toBlock })
         .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
     ).concatMap(async l => l.getListingWrapper());
   }
@@ -245,9 +245,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns listings currently in application stage
    */
-  public listingsInApplicationStage(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsInApplicationStage(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ApplicationStream({}, { fromBlock })
+      ._ApplicationStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper());
   }
@@ -258,9 +258,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns addresses ready to be whitelisted
    */
-  public readyToBeWhitelistedListings(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public readyToBeWhitelistedListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ApplicationStream({}, { fromBlock })
+      ._ApplicationStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => canBeWhitelisted(l.data));
@@ -272,9 +272,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in commit vote phase
    */
-  public currentChallengedCommitVotePhaseListings(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public currentChallengedCommitVotePhaseListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInChallengedCommitVotePhase(l.data));
@@ -286,9 +286,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in reveal vote phase
    */
-  public currentChallengedRevealVotePhaseListings(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public currentChallengedRevealVotePhaseListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInChallengedRevealVotePhase(l.data));
@@ -300,17 +300,17 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in request appeal phase
    */
-  public listingsAwaitingAppealRequest(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsAwaitingAppealRequest(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isAwaitingAppealRequest(l.data));
   }
 
-  public listingsWithChallengeToResolve(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsWithChallengeToResolve(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => canChallengeBeResolved(l.data));
@@ -322,9 +322,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsAwaitingAppealJudgment(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsAwaitingAppealJudgment(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isListingAwaitingAppealJudgment(l.data));
@@ -336,9 +336,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsAwaitingAppealChallenge(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsAwaitingAppealChallenge(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isListingAwaitingAppealChallenge(l.data));
@@ -350,9 +350,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsInAppealChallengeCommitPhase(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsInAppealChallengeCommitPhase(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInAppealChallengeCommitPhase(l.data));
@@ -364,9 +364,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsInAppealChallengeRevealPhase(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsInAppealChallengeRevealPhase(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInAppealChallengeRevealPhase(l.data));
@@ -378,9 +378,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsWithAppealToResolve(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public listingsWithAppealToResolve(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ChallengeStream({}, { fromBlock })
+      ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => canListingAppealBeResolved(l.data));
@@ -392,9 +392,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public rejectedListings(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public rejectedListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ApplicationStream({}, { fromBlock })
+      ._ApplicationStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => l.data.appExpiry.isZero());

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -232,9 +232,9 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently whitelisted addresses
    */
-  public whitelistedListings(fromBlock: number | "latest" = 0): Observable<ListingWrapper> {
+  public whitelistedListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
     return this.instance
-      ._ApplicationWhitelistedStream({}, { fromBlock })
+      ._ApplicationWhitelistedStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper());
   }

--- a/packages/core/src/contracts/tcr/voting.ts
+++ b/packages/core/src/contracts/tcr/voting.ts
@@ -44,9 +44,9 @@ export class Voting extends BaseWrapper<CivilPLCRVotingContract> {
    *                  Set to "latest" for only new events
    * @returns currently active polls (by id)
    */
-  public activePolls(fromBlock: number | "latest" = 0): Observable<BigNumber> {
+  public activePolls(fromBlock: number | "latest" = 0, toBlock?: number): Observable<BigNumber> {
     return this.instance
-      ._PollCreatedStream({}, { fromBlock })
+      ._PollCreatedStream({}, { fromBlock, toBlock })
       .map(e => e.args.pollID)
       .concatFilter(async pollID => this.instance.pollExists.callAsync(pollID));
   }
@@ -57,8 +57,8 @@ export class Voting extends BaseWrapper<CivilPLCRVotingContract> {
    *                  Set to "latest" for only new events
    * @param user pollIDs of polls the user has committed votes for
    */
-  public votesCommitted(fromBlock: number | "latest" = 0, user?: EthAddress): Observable<BigNumber> {
-    return this.instance._VoteCommittedStream({ voter: user }, { fromBlock }).map(e => e.args.pollID);
+  public votesCommitted(fromBlock: number | "latest" = 0, user?: EthAddress, toBlock?: number): Observable<BigNumber> {
+    return this.instance._VoteCommittedStream({ voter: user }, { fromBlock, toBlock }).map(e => e.args.pollID);
   }
 
   public balanceUpdate(fromBlock: number | "latest" = 0, user: EthAddress): Observable<BigNumber> {
@@ -187,6 +187,7 @@ export class Voting extends BaseWrapper<CivilPLCRVotingContract> {
         ._VoteRevealedStream({ pollID }, { fromBlock: 0 })
         .first()
         .toPromise();
+
       return reveal;
     }
     return undefined;

--- a/packages/dapp/src/actionCreators/listings.ts
+++ b/packages/dapp/src/actionCreators/listings.ts
@@ -19,6 +19,7 @@ export enum listingActions {
   FETCH_LISTING_DATA = "FETCH_LISTING_DATA",
   FETCH_LISTING_DATA_COMPLETE = "FETCH_LISTING_DATA_COMPLETE",
   FETCH_LISTING_DATA_IN_PROGRESS = "FETCH_LISTING_DATA_IN_PROGRESS",
+  SET_LOADING_FINISHED = "SET_LOADING_FINISHED",
 }
 
 export const addListing = (listing: ListingWrapper): any => {
@@ -258,5 +259,11 @@ export const setupListingWhitelistedSubscription = async (listingID: string): Pr
         });
       dispatch(addWhitelistedSubscription(listingID, subscription));
     }
+  };
+};
+
+export const setLoadingFinished = (): AnyAction => {
+  return {
+    type: listingActions.SET_LOADING_FINISHED,
   };
 };

--- a/packages/dapp/src/actionCreators/ui.ts
+++ b/packages/dapp/src/actionCreators/ui.ts
@@ -2,6 +2,7 @@ import { AnyAction } from "redux";
 
 export enum uiActions {
   ADD_OR_UPDATE_UI_STATE = "ADD_OR_UPDATE_UI_STATE",
+  SET_LOADING_FINISHED = "SET_LOADING_FINISHED",
 }
 
 export const addOrUpdateUIState = (key: string, value: any): AnyAction => {

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -23,6 +23,7 @@ export interface ListingReduxProps {
   rejectedListings: Set<string>;
   parameters: any;
   error: undefined | string;
+  loadingFinished: boolean;
 }
 
 class Listings extends React.Component<ListingProps & ListingReduxProps> {
@@ -49,36 +50,39 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
     return (
       <>
         {hero}
-        <Tabs
-          activeIndex={activeIndex}
-          TabsNavComponent={StyledTabNav}
-          TabComponent={StyledTabLarge}
-          onActiveTabChange={this.onTabChange}
-        >
-          <Tab title={"Whitelisted Newsrooms"}>
-            <StyledPageContent>
-              <StyledListingCopy>
-                All approved Newsrooms should align with the Civil Constitution, and are subject to Civil community
-                review. By participating in our governance, you can help curate high-quality, trustworthy journalism.
-              </StyledListingCopy>
-              <ListingList listings={this.props.whitelistedListings} />
-            </StyledPageContent>
-          </Tab>
-          <Tab title={"Newsrooms Under Consideration"}>
-            <StyledPageContent>
-              <ListingsInProgress />
-            </StyledPageContent>
-          </Tab>
-          <Tab title={"Rejected Newsrooms"}>
-            <StyledPageContent>
-              <StyledListingCopy>
-                Rejected Newsrooms have been removed from the Civil Registry due to a breach of the Civil Constitution.
-                Rejected Newsrooms can reapply to the Registry at any time. Learn how to reapply.
-              </StyledListingCopy>
-              <ListingList listings={this.props.rejectedListings} />
-            </StyledPageContent>
-          </Tab>
-        </Tabs>
+        {!this.props.loadingFinished && "loading..."}
+        {this.props.loadingFinished && (
+          <Tabs
+            activeIndex={activeIndex}
+            TabsNavComponent={StyledTabNav}
+            TabComponent={StyledTabLarge}
+            onActiveTabChange={this.onTabChange}
+          >
+            <Tab title={"Whitelisted Newsrooms"}>
+              <StyledPageContent>
+                <StyledListingCopy>
+                  All approved Newsrooms should align with the Civil Constitution, and are subject to Civil community
+                  review. By participating in our governance, you can help curate high-quality, trustworthy journalism.
+                </StyledListingCopy>
+                <ListingList listings={this.props.whitelistedListings} />
+              </StyledPageContent>
+            </Tab>
+            <Tab title={"Newsrooms Under Consideration"}>
+              <StyledPageContent>
+                <ListingsInProgress />
+              </StyledPageContent>
+            </Tab>
+            <Tab title={"Rejected Newsrooms"}>
+              <StyledPageContent>
+                <StyledListingCopy>
+                  Rejected Newsrooms have been removed from the Civil Registry due to a breach of the Civil
+                  Constitution. Rejected Newsrooms can reapply to the Registry at any time. Learn how to reapply.
+                </StyledListingCopy>
+                <ListingList listings={this.props.rejectedListings} />
+              </StyledPageContent>
+            </Tab>
+          </Tabs>
+        )}
       </>
     );
   }
@@ -90,7 +94,7 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
 }
 
 const mapStateToProps = (state: State, ownProps: ListingProps): ListingProps & ListingReduxProps => {
-  const { whitelistedListings, rejectedListings, parameters } = state.networkDependent;
+  const { whitelistedListings, rejectedListings, parameters, loadingFinished } = state.networkDependent;
 
   return {
     ...ownProps,
@@ -98,6 +102,7 @@ const mapStateToProps = (state: State, ownProps: ListingProps): ListingProps & L
     rejectedListings,
     parameters,
     error: undefined,
+    loadingFinished,
   };
 };
 

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -21,7 +21,6 @@ export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<
   const civil = getCivil();
   const current = await civil.currentBlock();
 
-  console.log("START SUBSCRIPTION. current: " + current);
   const initialLoadObservable = Observable.merge(
     tcr.listingsInApplicationStage(0, current),
     tcr.whitelistedListings(0, current),
@@ -33,10 +32,9 @@ export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<
       dispatch(addListing(listing));
     },
     err => {
-      console.log("error");
+      console.log("error: ", err);
     },
     () => {
-      console.log("ON COMPLETE. start new subscription.");
       dispatch(setLoadingFinished());
       tcr.allEventsExceptWhitelistFromBlock(current).subscribe(async (listing: ListingWrapper) => {
         await getNewsroom(dispatch, listing.address);

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -9,7 +9,7 @@ import {
   addUserChallengeData,
   addUserChallengeStarted,
 } from "../actionCreators/challenges";
-import { addListing } from "../actionCreators/listings";
+import { addListing, setLoadingFinished } from "../actionCreators/listings";
 import { addUserNewsroom } from "../actionCreators/newsrooms";
 import { getCivil, getTCR } from "./civilInstance";
 
@@ -37,6 +37,7 @@ export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<
     },
     () => {
       console.log("ON COMPLETE. start new subscription.");
+      dispatch(setLoadingFinished());
       tcr.allEventsExceptWhitelistFromBlock(current).subscribe(async (listing: ListingWrapper) => {
         await getNewsroom(dispatch, listing.address);
         setupListingCallback(listing, dispatch);

--- a/packages/dapp/src/reducers/index.ts
+++ b/packages/dapp/src/reducers/index.ts
@@ -23,6 +23,7 @@ import {
   rejectedListingLatestChallengeSubscriptions,
   whitelistedSubscriptions,
   rejectedListingRemovedSubscriptions,
+  loadingFinished,
 } from "./listings";
 import {
   parameters,
@@ -81,6 +82,7 @@ export interface NetworkDependentState {
   resolveChallengeListings: Set<string>;
   resolveAppealListings: Set<string>;
   rejectedListings: Set<string>;
+  loadingFinished: boolean;
   user: { account: any };
   parameters: object;
   proposals: Map<string, object>;
@@ -126,6 +128,7 @@ const networkDependentReducers = combineReducers({
   resolveChallengeListings,
   resolveAppealListings,
   rejectedListings,
+  loadingFinished,
   user,
   parameters,
   proposals,

--- a/packages/dapp/src/reducers/listings.ts
+++ b/packages/dapp/src/reducers/listings.ts
@@ -304,3 +304,12 @@ export function rejectedListings(state: Set<string> = Set<string>(), action: Any
       return state;
   }
 }
+
+export function loadingFinished(state: boolean = false, action: AnyAction): boolean {
+  switch (action.type) {
+    case listingActions.SET_LOADING_FINISHED:
+      return true;
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
- load existing listings from past events separately from future events
- display "loading" while loading, so we don't get half-loaded newsrooms rendering