### PR TITLE
Add and implement getDefaultFromBlock()

### DIFF
--- a/packages/core/src/content/eventstorageprovider.ts
+++ b/packages/core/src/content/eventstorageprovider.ts
@@ -1,5 +1,5 @@
 import { EthApi } from "@joincivil/ethapi";
-import { CivilErrors } from "@joincivil/utils";
+import { CivilErrors, getDefaultFromBlock } from "@joincivil/utils";
 import { EventStorage, EventStorageContract } from "../contracts/generated/wrappers/event_storage";
 import { findEventOrThrow } from "../contracts/utils/contracts";
 import { ContentData, StorageHeader } from "../types";
@@ -21,7 +21,7 @@ export class EventStorageProvider implements ContentProvider {
     // TODO(ritave): If the hash doesn't exist, this will never finish
     //               Add web3.filter.get to abi-gen, not only watch
     return (await this.eventStorage())
-      .StringStoredStream({ dataHash: what.contentHash }, { fromBlock: 0 })
+      .StringStoredStream({ dataHash: what.contentHash }, { fromBlock: getDefaultFromBlock() })
       .first() // Closes the stream on first event
       .map(event => event.args.data)
       .toPromise();

--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -10,6 +10,7 @@ import {
   recoverSigner,
   promisify,
   estimateRawHex,
+  getDefaultFromBlock,
 } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
 import * as Debug from "debug";
@@ -182,7 +183,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
   //#region streams
   public editors(): Observable<EthAddress> {
     return this.instance
-      .RoleAddedStream({ role: NewsroomRoles.Editor }, { fromBlock: 0 })
+      .RoleAddedStream({ role: NewsroomRoles.Editor }, { fromBlock: getDefaultFromBlock() })
       .map(e => e.args.grantee)
       .concatFilter(async e => this.isEditor(e));
   }
@@ -193,7 +194,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
    *                  Set to "latest" for only new events
    * @returns Metadata about the content from Ethereum. Use [[resolveContent]] to get actual contents
    */
-  public content(fromBlock: number | "latest" = 0): Observable<EthContentHeader> {
+  public content(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<EthContentHeader> {
     return this.instance
       .ContentPublishedStream({}, { fromBlock })
       .map(e => e.args.contentId)
@@ -209,7 +210,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
    */
   public revisions(
     contentId?: number | BigNumber | undefined,
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
   ): Observable<EthContentHeader> {
     const myContentId = contentId ? this.ethApi.toBigNumber(contentId) : undefined;
     return this.instance.RevisionUpdatedStream({ contentId: myContentId }, { fromBlock }).concatMap(async e => {
@@ -228,7 +229,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
    *                  Set to "latest" to only listen for new events
    * @returns Name history of this Newsroom
    */
-  public nameChanges(fromBlock: number | "latest" = 0): Observable<string> {
+  public nameChanges(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<string> {
     return this.instance.NameChangedStream({}, { fromBlock }).map(e => e.args.newName);
   }
   //#endregion
@@ -508,7 +509,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
     const myContentId = this.ethApi.toBigNumber(contentId);
     const myRevisionId = this.ethApi.toBigNumber(revisionId);
     return this.instance
-      .RevisionUpdatedStream({ contentId: myContentId, revisionId: myRevisionId }, { fromBlock: 0 })
+      .RevisionUpdatedStream({ contentId: myContentId, revisionId: myRevisionId }, { fromBlock: getDefaultFromBlock() })
       .concatMap(async item => {
         const transaction = await this.ethApi.getTransaction(item.transactionHash);
         return this.recoverArchiveTx(transaction);

--- a/packages/core/src/contracts/tcr/challenge.ts
+++ b/packages/core/src/contracts/tcr/challenge.ts
@@ -1,5 +1,5 @@
 import { EthApi } from "@joincivil/ethapi";
-import "@joincivil/utils";
+import { getDefaultFromBlock } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
 import * as Debug from "debug";
 import { ContentProvider } from "../../content/contentprovider";
@@ -53,7 +53,7 @@ export class Challenge {
 
   public async getListingIdForChallenge(): Promise<EthAddress> {
     const challengeEvent = await this.tcrInstance
-      ._ChallengeStream({ challengeID: this.challengeId }, { fromBlock: 0 })
+      ._ChallengeStream({ challengeID: this.challengeId }, { fromBlock: getDefaultFromBlock() })
       .first()
       .toPromise();
     return challengeEvent.args.listingAddress;
@@ -61,7 +61,7 @@ export class Challenge {
 
   private async getChallengeURI(): Promise<EthAddress> {
     const challengeEvent = await this.tcrInstance
-      ._ChallengeStream({ challengeID: this.challengeId }, { fromBlock: 0 })
+      ._ChallengeStream({ challengeID: this.challengeId }, { fromBlock: getDefaultFromBlock() })
       .first()
       .toPromise();
     return challengeEvent.args.data;

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -1,5 +1,5 @@
 import { EthApi, requireAccount } from "@joincivil/ethapi";
-import { CivilErrors } from "@joincivil/utils";
+import { CivilErrors, getDefaultFromBlock } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
 import * as Debug from "debug";
 import { Observable } from "rxjs/Observable";
@@ -159,7 +159,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently listings as new events get triggered
    */
   public allEventsExceptWhitelistFromBlock(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return Observable.merge(
@@ -235,7 +235,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently whitelisted addresses
    */
-  public whitelistedListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public whitelistedListings(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationWhitelistedStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -248,7 +251,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns listings currently in application stage
    */
-  public listingsInApplicationStage(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsInApplicationStage(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -261,7 +267,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns addresses ready to be whitelisted
    */
-  public readyToBeWhitelistedListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public readyToBeWhitelistedListings(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -276,7 +285,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently challenged addresses in commit vote phase
    */
   public currentChallengedCommitVotePhaseListings(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -293,7 +302,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently challenged addresses in reveal vote phase
    */
   public currentChallengedRevealVotePhaseListings(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -309,7 +318,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in request appeal phase
    */
-  public listingsAwaitingAppealRequest(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsAwaitingAppealRequest(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -318,7 +330,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   }
 
   public listingsWithChallengeToResolve(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -335,7 +347,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently challenged addresses in appeal phase
    */
   public listingsAwaitingAppealJudgment(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -352,7 +364,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently challenged addresses in appeal phase
    */
   public listingsAwaitingAppealChallenge(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -369,7 +381,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently challenged addresses in appeal phase
    */
   public listingsInAppealChallengeCommitPhase(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -386,7 +398,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @returns currently challenged addresses in appeal phase
    */
   public listingsInAppealChallengeRevealPhase(
-    fromBlock: number | "latest" = 0,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
     toBlock?: number,
   ): Observable<ListingWrapper> {
     return this.instance
@@ -402,7 +414,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public listingsWithAppealToResolve(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public listingsWithAppealToResolve(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -416,7 +431,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    *                  Set to "latest" for only new events
    * @returns currently challenged addresses in appeal phase
    */
-  public rejectedListings(fromBlock: number | "latest" = 0, toBlock?: number): Observable<ListingWrapper> {
+  public rejectedListings(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock, toBlock })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
@@ -426,13 +444,15 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
 
   public allApplicationsEver(): Observable<ListingWrapper> {
     return this.instance
-      ._ApplicationStream({}, { fromBlock: 0 })
+      ._ApplicationStream({}, { fromBlock: getDefaultFromBlock() })
       .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper());
   }
 
   public challengesStartedByUser(user: EthAddress): Observable<BigNumber> {
-    return this.instance._ChallengeStream({ challenger: user }, { fromBlock: 0 }).map(e => e.args.challengeID);
+    return this.instance
+      ._ChallengeStream({ challenger: user }, { fromBlock: getDefaultFromBlock() })
+      .map(e => e.args.challengeID);
   }
 
   //#endregion
@@ -452,10 +472,13 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
    * @return the challengeID associated with the pollID passed in
    */
   public async getChallengeIDForPollID(pollID: BigNumber): Promise<BigNumber> {
-    const challengeStream = this.instance._ChallengeStream({ challengeID: pollID }, { fromBlock: 0 });
+    const challengeStream = this.instance._ChallengeStream(
+      { challengeID: pollID },
+      { fromBlock: getDefaultFromBlock() },
+    );
     const appealChallengeStream = this.instance._GrantedAppealChallengedStream(
       { appealChallengeID: pollID },
-      { fromBlock: 0 },
+      { fromBlock: getDefaultFromBlock() },
     );
     const event = await challengeStream
       .merge(appealChallengeStream)
@@ -525,7 +548,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
 
   public async getRewardClaimed(challengeID: BigNumber, user: EthAddress): Promise<BigNumber> {
     const reward = await this.instance
-      ._RewardClaimedStream({ challengeID, voter: user }, { fromBlock: 0 })
+      ._RewardClaimedStream({ challengeID, voter: user }, { fromBlock: getDefaultFromBlock() })
       .first()
       .toPromise();
     return reward.args.reward;

--- a/packages/core/src/contracts/tcr/eip20.ts
+++ b/packages/core/src/contracts/tcr/eip20.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import "@joincivil/utils";
+import { getDefaultFromBlock } from "@joincivil/utils";
 import { Observable } from "rxjs";
 
 import { BaseWrapper } from "../basewrapper";
@@ -46,7 +46,7 @@ export class EIP20 extends BaseWrapper<EIP20Contract> {
     return this.multisigProxy.approve.sendTransactionAsync(spender, numTokens);
   }
 
-  public balanceUpdate(fromBlock: number | "latest" = 0, user: EthAddress): Observable<BigNumber> {
+  public balanceUpdate(fromBlock: number | "latest" = getDefaultFromBlock(), user: EthAddress): Observable<BigNumber> {
     return this.instance
       .TransferStream({ _from: user }, { fromBlock })
       .merge(this.instance.TransferStream({ _to: user }, { fromBlock }))

--- a/packages/core/src/contracts/tcr/government.ts
+++ b/packages/core/src/contracts/tcr/government.ts
@@ -1,5 +1,5 @@
 import { EthApi } from "@joincivil/ethapi";
-import { CivilErrors } from "@joincivil/utils";
+import { CivilErrors, getDefaultFromBlock } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
 import * as Debug from "debug";
 import { Observable } from "rxjs";
@@ -45,7 +45,7 @@ export class Government extends BaseWrapper<GovernmentContract> {
   /**
    * Gets an unending stream of parameters being set
    */
-  public getParameterSet(fromBlock: number | "latest" = 0): Observable<Param> {
+  public getParameterSet(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<Param> {
     return this.instance.ParameterSetStream({}, { fromBlock }).map(e => {
       return {
         paramName: e.args.name,

--- a/packages/core/src/contracts/tcr/listing.ts
+++ b/packages/core/src/contracts/tcr/listing.ts
@@ -1,5 +1,5 @@
 import { Observable, Subscription, BehaviorSubject } from "rxjs";
-import "@joincivil/utils";
+import { getDefaultFromBlock } from "@joincivil/utils";
 import { CivilTCRContract, CivilTCR } from "../generated/wrappers/civil_t_c_r";
 import { EthApi } from "@joincivil/ethapi";
 import { EthAddress, ListingWrapper, ListingData, TimestampedEvent } from "../../types";
@@ -49,31 +49,41 @@ export class Listing {
 
   //#region EventStreams
 
-  public applications(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._Application>> {
+  public applications(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._Application>> {
     return this.tcrInstance._ApplicationStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._Application>(this.ethApi, e);
     });
   }
 
-  public challenges(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._Challenge>> {
+  public challenges(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._Challenge>> {
     return this.tcrInstance._ChallengeStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._Challenge>(this.ethApi, e);
     });
   }
 
-  public deposits(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._Deposit>> {
+  public deposits(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._Deposit>> {
     return this.tcrInstance._DepositStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._Deposit>(this.ethApi, e);
     });
   }
 
-  public withdrawls(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._Withdrawal>> {
+  public withdrawls(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._Withdrawal>> {
     return this.tcrInstance._WithdrawalStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._Withdrawal>(this.ethApi, e);
     });
   }
 
-  public whitelisteds(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._ApplicationWhitelisted>> {
+  public whitelisteds(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._ApplicationWhitelisted>> {
     return this.tcrInstance
       ._ApplicationWhitelistedStream({ listingAddress: this.listingAddress }, { fromBlock })
       .map(e => {
@@ -82,27 +92,31 @@ export class Listing {
   }
 
   public applicationRemoveds(
-    fromBlock: number = 0,
+    fromBlock: number = getDefaultFromBlock(),
   ): Observable<TimestampedEvent<CivilTCR.LogEvents._ApplicationRemoved>> {
     return this.tcrInstance._ApplicationRemovedStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._ApplicationRemoved>(this.ethApi, e);
     });
   }
 
-  public listingRemoveds(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._ListingRemoved>> {
+  public listingRemoveds(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._ListingRemoved>> {
     return this.tcrInstance._ListingRemovedStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._ListingRemoved>(this.ethApi, e);
     });
   }
 
-  public failedChallenges(fromBlock: number = 0): Observable<TimestampedEvent<CivilTCR.LogEvents._ChallengeFailed>> {
+  public failedChallenges(
+    fromBlock: number = getDefaultFromBlock(),
+  ): Observable<TimestampedEvent<CivilTCR.LogEvents._ChallengeFailed>> {
     return this.tcrInstance._ChallengeFailedStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._ChallengeFailed>(this.ethApi, e);
     });
   }
 
   public successfulChallenges(
-    fromBlock: number = 0,
+    fromBlock: number = getDefaultFromBlock(),
   ): Observable<TimestampedEvent<CivilTCR.LogEvents._ChallengeSucceeded>> {
     return this.tcrInstance._ChallengeSucceededStream({ listingAddress: this.listingAddress }, { fromBlock }).map(e => {
       return createTimestampedEvent<CivilTCR.LogEvents._ChallengeSucceeded>(this.ethApi, e);

--- a/packages/core/src/contracts/tcr/parameterizer.ts
+++ b/packages/core/src/contracts/tcr/parameterizer.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { Observable } from "rxjs";
 import * as Debug from "debug";
-import { CivilErrors } from "@joincivil/utils";
+import { CivilErrors, getDefaultFromBlock } from "@joincivil/utils";
 
 import { Bytes32, EthAddress, TwoStepEthTransaction, ParamProposalState, ParamProp, PollID } from "../../types";
 import { EthApi, requireAccount } from "@joincivil/ethapi";
@@ -92,7 +92,7 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
    * @param fromBlock Starting block in history for events. Set to "latest" for only new events.
    * @returns currently active proposals propIDs
    */
-  public propIDsInApplicationPhase(fromBlock: number | "latest" = 0): Observable<string> {
+  public propIDsInApplicationPhase(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<string> {
     return this.instance
       ._ReparameterizationProposalStream({}, { fromBlock })
       .map(e => e.args.propID)
@@ -105,7 +105,7 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
    * @param fromBlock Starting block in history for events. Set to "latest" for only new events.
    * @returns currently active proposals in Challenge Commit Phase propIDs
    */
-  public propIDsInChallengeCommitPhase(fromBlock: number | "latest" = 0): Observable<string> {
+  public propIDsInChallengeCommitPhase(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<string> {
     return this.instance
       ._NewChallengeStream({}, { fromBlock })
       .map(e => e.args.propID)
@@ -118,7 +118,7 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
    * @param fromBlock Starting block in history for events. Set to "latest" for only new events
    * @returns currently active proposals in Challenge Reveal Phase propIDs
    */
-  public propIDsInChallengeRevealPhase(fromBlock: number | "latest" = 0): Observable<string> {
+  public propIDsInChallengeRevealPhase(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<string> {
     return this.instance
       ._NewChallengeStream({}, { fromBlock })
       .map(e => e.args.propID)
@@ -132,7 +132,7 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
    * @param fromBlock Starting block in history for events. Set to "latest" for only new events
    * @returns propIDs for proposals that can be updated
    */
-  public propIDsToProcess(fromBlock: number | "latest" = 0): Observable<string> {
+  public propIDsToProcess(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<string> {
     const applicationsToProcess = this.instance
       ._ReparameterizationProposalStream({}, { fromBlock })
       .map(e => e.args.propID)
@@ -152,7 +152,10 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
    * @param fromBlock Starting block in history for events. Set to "latest" for only new events
    * @returns pollIDs for proposals that have been challenged and resolved
    */
-  public pollIDsForResolvedChallenges(propID: string, fromBlock: number | "latest" = 0): Observable<PollID> {
+  public pollIDsForResolvedChallenges(
+    propID: string,
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+  ): Observable<PollID> {
     return this.instance
       ._NewChallengeStream({ propID }, { fromBlock })
       .concatFilter(async e => this.isChallengeResolved(e.args.challengeID))
@@ -165,7 +168,7 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
    * @param fromBlock Starting block in history for events. Set to "latest" for only new events
    * @returns propIDs for proposals that have been challenged and resolved
    */
-  public propIDsForResolvedChallenges(fromBlock: number | "latest" = 0): Observable<EthAddress> {
+  public propIDsForResolvedChallenges(fromBlock: number | "latest" = getDefaultFromBlock()): Observable<EthAddress> {
     return this.instance
       ._NewChallengeStream({}, { fromBlock })
       .concatFilter(async e => this.isChallengeResolved(e.args.challengeID))

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -1,5 +1,6 @@
 import { EthAddress, getNextTimerExpiry, ListingWrapper } from "@joincivil/core";
 import { addNewsroom } from "@joincivil/newsroom-manager";
+import { getDefaultFromBlock } from "@joincivil/utils";
 import { BigNumber } from "bignumber.js";
 import { Dispatch } from "react-redux";
 import { Observable, Subscription } from "rxjs";
@@ -15,6 +16,7 @@ import { getCivil, getTCR } from "./civilInstance";
 
 const listingTimeouts = new Map<string, number>();
 const setTimeoutTimeouts = new Map<string, number>();
+const civilGenesisBlock = getDefaultFromBlock();
 
 export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<void> {
   const tcr = await getTCR();
@@ -22,8 +24,8 @@ export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<
   const current = await civil.currentBlock();
 
   const initialLoadObservable = Observable.merge(
-    tcr.listingsInApplicationStage(0, current),
-    tcr.whitelistedListings(0, current),
+    tcr.listingsInApplicationStage(civilGenesisBlock, current),
+    tcr.whitelistedListings(civilGenesisBlock, current),
   );
   initialLoadObservable.subscribe(
     async (listing: ListingWrapper) => {
@@ -58,7 +60,7 @@ export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, 
   const tcr = await getTCR();
   challengeSubscription = tcr
     .getVoting()
-    .votesCommitted(0, user)
+    .votesCommitted(civilGenesisBlock, user)
     .subscribe(async (pollID: BigNumber) => {
       const challengeId = await tcr.getChallengeIDForPollID(pollID);
       const wrappedChallenge = await tcr.getChallengeData(challengeId);

--- a/packages/utils/src/civilHelpers.ts
+++ b/packages/utils/src/civilHelpers.ts
@@ -15,3 +15,8 @@ export function prepareNewsroomMessage(newsroomAddress: EthAddress, contentHash:
 export function prepareUserFriendlyNewsroomMessage(newsroomAddress: EthAddress, contentHash: Hex): string {
   return `I authorize this newsroom with address ${newsroomAddress} to publish this article whose content hashes to ${contentHash} using keccak256`;
 }
+
+export function getDefaultFromBlock(): number {
+  const civilGenesisBlock = 2848355;
+  return civilGenesisBlock;
+}

--- a/packages/utils/src/civilHelpers.ts
+++ b/packages/utils/src/civilHelpers.ts
@@ -16,7 +16,13 @@ export function prepareUserFriendlyNewsroomMessage(newsroomAddress: EthAddress, 
   return `I authorize this newsroom with address ${newsroomAddress} to publish this article whose content hashes to ${contentHash} using keccak256`;
 }
 
-export function getDefaultFromBlock(): number {
-  const civilGenesisBlock = 2848355;
-  return civilGenesisBlock;
+// TODO(jon): Update this to support the proper blocks by network
+export function getDefaultFromBlock(network: number = 4): number {
+  // A map of the network id to its corresponding default fromBlock, which
+  // could be the TCR genesis block or possibly the geneis block of the
+  // first Newsroom contract on that network
+  const defaultFromBlocks: { [index: string]: number } = {
+    4: 2848355,
+  };
+  return defaultFromBlocks[network.toString()];
 }


### PR DESCRIPTION
Add and implement `getDefaultFromBlock()` to `@joincivil/utils`, which returns the block number of the TCR genesis block

This is update is to play nicer with Infura's APIs by starting our sniffing of `getLogs` from the genesis of the TCR, and not the beginning of the log