### PR TITLE
secondary audit feedback

### DIFF
--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -4,6 +4,7 @@ import "./RestrictedAddressRegistry.sol";
 import "../interfaces/IGovernment.sol";
 import "./CivilPLCRVoting.sol";
 import "../proof-of-use/telemetry/TokenTelemetryI.sol";
+import "./CivilParameterizer.sol";
 
 /**
 @title CivilTCR - Token Curated Registry with Appeallate Functionality and Restrictions on Application
@@ -62,23 +63,23 @@ contract CivilTCR is RestrictedAddressRegistry {
   /**
   @notice Init function calls AddressRegistry init then sets IGovernment
   @dev passes tokenAddr, plcrAddr, paramsAddr up to RestrictedAddressRegistry constructor
-  @param tokenAddr Address of the TCR's intrinsic ERC20 token
-  @param plcrAddr Address of a PLCR voting contract for the provided token
-  @param paramsAddr Address of a Parameterizer contract
+  @param token TCR's intrinsic ERC20 token
+  @param plcr CivilPLCR voting contract for the provided token
+  @param param CivilParameterizer contract
   @param govt IGovernment contract
   */
   constructor(
-    address tokenAddr,
-    address plcrAddr,
-    address paramsAddr,
+    EIP20Interface token,
+    CivilPLCRVoting plcr,
+    CivilParameterizer param,
     IGovernment govt,
     TokenTelemetryI tele
-  ) public RestrictedAddressRegistry(tokenAddr, plcrAddr, paramsAddr, "CivilTCR")
+  ) public RestrictedAddressRegistry(token, address(plcr), address(param), "CivilTCR")
   {
     require(address(govt) != 0);
     require(govt.getGovernmentController() != 0);
     require(address(tele) != 0);
-    civilVoting = CivilPLCRVoting(plcrAddr);
+    civilVoting = plcr;
     government = govt;
     telemetry = tele;
   }

--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -393,7 +393,6 @@ contract CivilTCR is RestrictedAddressRegistry {
   ) public view returns (uint)
   {
     Challenge challenge = challenges[challengeID];
-    Appeal appeal = appeals[challengeID];
     uint totalTokens = challenge.totalTokens;
     uint rewardPool = challenge.rewardPool;
     uint voterTokens = getNumChallengeTokens(voter, challengeID, salt);

--- a/packages/contracts/contracts/tcr/Government.sol
+++ b/packages/contracts/contracts/tcr/Government.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.24;
 import "../interfaces/IGovernment.sol";
 import "../installed_contracts/PLCRVoting.sol";
 import "../installed_contracts/EIP20Interface.sol";
@@ -58,7 +58,6 @@ contract Government is IGovernment {
   NewConstProposal activeConstProp;
 
   // Global Variables
-  EIP20Interface public token;
   PLCRVoting public voting;
   // solium-disable-next-line
   uint public PROCESSBY = 604800; // 7 days
@@ -70,7 +69,6 @@ contract Government is IGovernment {
   function Government(
     address appellateAddr,
     address governmentControllerAddr,
-    address tokenAddr,
     address plcrAddr,
     uint appealFeeAmount,
     uint requestAppealLength,
@@ -87,7 +85,6 @@ contract Government is IGovernment {
     require(governmentControllerAddr != 0);
     appellate = appellateAddr;
     governmentController = governmentControllerAddr;
-    token = EIP20Interface(tokenAddr);
     voting = PLCRVoting(plcrAddr);
     set("requestAppealLen", requestAppealLength);
     set("judgeAppealLen", judgeAppealLength);

--- a/packages/contracts/contracts/tcr/Government.sol
+++ b/packages/contracts/contracts/tcr/Government.sol
@@ -16,9 +16,11 @@ contract Government is IGovernment {
   event _ParameterSet(string name, uint value);
   event _GovtReparameterizationProposal(string name, uint value, bytes32 propID, uint pollID);
   event _ProposalPassed(bytes32 propId, uint pollID);
+  event _ProposalExpired(bytes32 propId, uint pollID);
   event _ProposalFailed(bytes32 propId, uint pollID);
   event _NewConstProposal(bytes32 proposedHash, string proposedURI, uint pollID);
   event _NewConstProposalPassed(bytes32 constHash, string constURI);
+  event _NewConstProposalExpired(bytes32 constHash, string constURI);
   event _NewConstProposalFailed(bytes32 constHash, string constURI);
 
   modifier onlyGovernmentController {
@@ -223,8 +225,10 @@ contract Government is IGovernment {
     if (voting.isPassed(prop.pollID)) { // The challenge failed
       if (prop.processBy > now) {
         set(prop.name, prop.value);
+        emit _ProposalPassed(_propID, prop.pollID);
+      } else {
+        emit _ProposalExpired(_propID, prop.pollID);
       }
-      emit _ProposalPassed(_propID, prop.pollID);
     } else { // The challenge succeeded or nobody voted
       emit _ProposalFailed(_propID, prop.pollID);
     }
@@ -240,8 +244,10 @@ contract Government is IGovernment {
       if (activeConstProp.processBy > now) {
         constitutionHash = activeConstProp.newConstHash;
         constitutionURI = activeConstProp.newConstURI;
+        emit _NewConstProposalPassed(activeConstProp.newConstHash, activeConstProp.newConstURI);
+      } else {
+        emit _NewConstProposalExpired(activeConstProp.newConstHash, activeConstProp.newConstURI);
       }
-      emit _NewConstProposalPassed(activeConstProp.newConstHash, activeConstProp.newConstURI);
     } else { // The challenge succeeded or nobody voted
       emit _NewConstProposalFailed(activeConstProp.newConstHash, activeConstProp.newConstURI);
     }

--- a/packages/contracts/migrations/7_government.ts
+++ b/packages/contracts/migrations/7_government.ts
@@ -1,6 +1,5 @@
 import { config } from "./utils";
 const Government = artifacts.require("Government");
-const Token = artifacts.require("EIP20");
 const PLCRVoting = artifacts.require("CivilPLCRVoting");
 
 module.exports = (deployer: any, network: string, accounts: string[]) => {
@@ -26,7 +25,6 @@ module.exports = (deployer: any, network: string, accounts: string[]) => {
       Government,
       appellate,
       govtController,
-      Token.address,
       PLCRVoting.address,
       parameterizerConfig.appealFeeAmount,
       parameterizerConfig.requestAppealPhaseLength,

--- a/packages/contracts/test/tcr/registryWithAppeals/claimAppealChallengeReward.ts
+++ b/packages/contracts/test/tcr/registryWithAppeals/claimAppealChallengeReward.ts
@@ -82,13 +82,13 @@ contract("Registry with Appeals", accounts => {
       const challenger2BalanceAfter = await token.balanceOf(challenger2);
       const appealerBalanceAfter = await token.balanceOf(voterBob);
 
-      expect(challenger2BalanceAfter).to.be.bignumber.equal(
-        challenger2BalanceBefore,
+      expect(appealerBalanceAfter).to.be.bignumber.equal(
+        appealerBalanceBefore,
         "appealer should not have gained money from losing",
       );
-      const expected = appealerBalanceBefore.add(utils.paramConfig.appealFeeAmount * 2);
+      const expected = challenger2BalanceBefore.add(utils.paramConfig.appealFeeAmount * 2);
 
-      expect(appealerBalanceAfter).to.be.bignumber.equal(
+      expect(challenger2BalanceAfter).to.be.bignumber.equal(
         expected,
         "appeal challenger should have received both deposits",
       );

--- a/packages/contracts/test/utils/contractutils.ts
+++ b/packages/contracts/test/utils/contractutils.ts
@@ -264,7 +264,6 @@ async function createTestCivilTCRInstance(
   const government = await Government.new(
     appellateEntity,
     appellateEntity,
-    tokenAddress,
     plcrAddress,
     parameterizerConfig.appealFeeAmount,
     parameterizerConfig.requestAppealPhaseLength,


### PR DESCRIPTION
- emit different event when government proposal passes but not updated before expiration
- removing deadcode 
- using contract typed parameters in CivilTCR constructor instead of just addresses