### PR TITLE
Provide default (empty) theme for newsroom manager [ch2211]

### DIFF
--- a/packages/newsroom-manager/src/Newsroom.tsx
+++ b/packages/newsroom-manager/src/Newsroom.tsx
@@ -61,6 +61,10 @@ const Heading = ManagerHeading.extend`
 `;
 
 class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any>, NewsroomComponentState> {
+  public static defaultProps = {
+    theme: {},
+  };
+
   constructor(props: NewsroomProps) {
     super(props);
     this.state = {


### PR DESCRIPTION
Otherwise it breaks if you don't supply a theme.