### PR TITLE
Council UX Improvement

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/AppealAwaitingDecisionCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealAwaitingDecisionCard.tsx
@@ -23,6 +23,7 @@ import { NeedHelp } from "./NeedHelp";
 export interface AppealProps {
   requester: string;
   appealFeePaid: string;
+  txIdToConfirm?: number;
 }
 
 export type AppealAwaitingDecisionCardProps = ListingDetailPhaseCardComponentProps &
@@ -32,9 +33,13 @@ export type AppealAwaitingDecisionCardProps = ListingDetailPhaseCardComponentPro
   AppealProps;
 
 const GrantAppealButton: React.StatelessComponent<AppealAwaitingDecisionCardProps> = props => {
+  let text = "Grant Appeal";
+  if (props.txIdToConfirm) {
+    text = "Confirm Appeal";
+  }
   return (
     <TransactionInvertedButton transactions={props.transactions!} modalContentComponents={props.modalContentComponents}>
-      Grant Appeal
+      {text}
     </TransactionInvertedButton>
   );
 };

--- a/packages/core/src/contracts/multisig/multisig.ts
+++ b/packages/core/src/contracts/multisig/multisig.ts
@@ -196,15 +196,20 @@ export class Multisig extends BaseWrapper<MultiSigWalletContract> {
   public transactions(filters: TransactionFilters = { pending: true }): Observable<MultisigTransaction> {
     // Notice that we're using transactionCount smart-contract variable, not getTransactonCount func
     return Observable.fromPromise(this.instance.transactionCount.callAsync())
-      .concatMap(async noTransactions =>
-        this.instance.getTransactionIds.callAsync(
+      .concatMap(async numTransactions => {
+        const ids = await this.instance.getTransactionIds.callAsync(
           this.ethApi.toBigNumber(0),
-          noTransactions,
-          filters.pending || false,
-          filters.executed || false,
-        ),
-      )
-      .concatMap(ids => Observable.from(ids))
+          this.ethApi.toBigNumber(numTransactions),
+          true,
+          false,
+        );
+        console.log("first ids:  " + ids);
+        return ids;
+      })
+      .concatMap(ids => {
+        console.log("ids: ", ids);
+        return Observable.from(ids);
+      })
       .concatMap(async id => this.transaction(id.toNumber()));
   }
 

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -6,6 +6,7 @@ import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { ContentProvider } from "../../content/contentprovider";
 import { AppealData, ContentData, EthAddress } from "../../types";
 import { AppealChallenge } from "./appealChallenge";
+import { EthAddress } from "@joincivil/typescript-types";
 
 const debug = Debug("civil:appeal");
 
@@ -14,12 +15,20 @@ export class Appeal {
   private tcrInstance: CivilTCRContract;
   private contentProvider: ContentProvider;
   private challengeId: BigNumber;
+  private listingAddress: EthAddress;
 
-  constructor(ethApi: EthApi, instance: CivilTCRContract, challengeId: BigNumber, contentProvider: ContentProvider) {
+  constructor(
+    ethApi: EthApi,
+    instance: CivilTCRContract,
+    challengeId: BigNumber,
+    listingAddress: EthAddress,
+    contentProvider: ContentProvider,
+  ) {
     this.ethApi = ethApi;
     this.tcrInstance = instance;
     this.challengeId = challengeId;
     this.contentProvider = contentProvider;
+    this.listingAddress = listingAddress;
   }
 
   public async getAppealData(): Promise<AppealData> {
@@ -37,6 +46,7 @@ export class Appeal {
       appealChallenge = await appealChallengeInstance.getAppealChallengeData();
     }
     const statement = await this.getAppealStatement();
+    const appealTxData = await this.tcrInstance.grantAppeal.getRaw(this.listingAddress, "", { gas: 0 });
     return {
       requester,
       appealFeePaid,
@@ -44,6 +54,7 @@ export class Appeal {
       appealGranted,
       appealOpenToChallengeExpiry,
       appealChallengeID,
+      appealTxData,
       appealChallenge,
       statement,
     };

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -4,7 +4,7 @@ import { EthApi } from "@joincivil/ethapi";
 import { getDefaultFromBlock } from "@joincivil/utils";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { ContentProvider } from "../../content/contentprovider";
-import { AppealData, ContentData, EthAddress } from "../../types";
+import { AppealData, ContentData } from "../../types";
 import { AppealChallenge } from "./appealChallenge";
 import { EthAddress } from "@joincivil/typescript-types";
 

--- a/packages/core/src/contracts/tcr/council.ts
+++ b/packages/core/src/contracts/tcr/council.ts
@@ -4,7 +4,9 @@ import * as Debug from "debug";
 import { EthAddress, TwoStepEthTransaction } from "../../types";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { GovernmentContract } from "../generated/wrappers/government";
-import { Multisig } from "../multisig/multisig";
+import { Multisig, TransactionFilters } from "../multisig/multisig";
+import { MultisigTransaction } from "../multisig/multisigtransaction";
+import { Observable } from "rxjs";
 
 const debug = Debug("civil:tcr");
 
@@ -49,5 +51,9 @@ export class Council {
 
   public async getAppellateMembers(): Promise<string[]> {
     return this.multisig.owners();
+  }
+
+  public transactions(filters: TransactionFilters = { pending: true }): Observable<MultisigTransaction> {
+    return this.multisig.transactions(filters);
   }
 }

--- a/packages/core/src/contracts/tcr/council.ts
+++ b/packages/core/src/contracts/tcr/council.ts
@@ -7,6 +7,7 @@ import { GovernmentContract } from "../generated/wrappers/government";
 import { Multisig, TransactionFilters } from "../multisig/multisig";
 import { MultisigTransaction } from "../multisig/multisigtransaction";
 import { Observable } from "rxjs";
+import { TxDataAll } from "@joincivil/typescript-types";
 
 const debug = Debug("civil:tcr");
 
@@ -39,9 +40,17 @@ export class Council {
     this.ethApi = api;
   }
 
+  public async getRawGrantAppeal(listingAddress: EthAddress, data: string = ""): Promise<TxDataAll> {
+    return this.civilInstance.grantAppeal.getRaw(listingAddress, data, { gas: 0 });
+  }
+
   public async grantAppeal(listingAddress: EthAddress, data: string = ""): Promise<TwoStepEthTransaction<any>> {
     const txdata = await this.civilInstance.grantAppeal.getRaw(listingAddress, data, { gas: 0 });
     return this.multisig.submitTransaction(this.civilInstance.address, this.ethApi.toBigNumber(0), txdata.data!);
+  }
+
+  public async confirmAppeal(txId: number): Promise<TwoStepEthTransaction<any>> {
+    return this.multisig.confirmTransaction(txId);
   }
 
   public async transferAppellate(newAppellate: EthAddress): Promise<TwoStepEthTransaction<any>> {

--- a/packages/core/src/contracts/tcr/listing.ts
+++ b/packages/core/src/contracts/tcr/listing.ts
@@ -34,7 +34,7 @@ export class Listing {
     );
     let challenge;
     if (!challengeID.isZero()) {
-      const c = new Challenge(this.ethApi, this.tcrInstance, this.contentProvider, challengeID);
+      const c = new Challenge(this.ethApi, this.tcrInstance, this.contentProvider, challengeID, this.listingAddress);
       challenge = await c.getChallengeData();
     }
     return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export * from "./utils/listingDataHelpers/userChallengeDataHelper";
 export * from "./utils/listingDataHelpers/pollHelper";
 export * from "./contracts/generated/events";
 export * from "./content";
+export * from "./contracts/multisig/multisigtransaction";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,7 @@ import {
   EthAddress,
   Hex,
   TxHash,
+  TxDataAll,
 } from "@joincivil/typescript-types";
 import BigNumber from "bignumber.js";
 import { CivilLogs } from "./contracts/generated/events";
@@ -156,6 +157,7 @@ export interface AppealData {
   appealGranted: boolean;
   appealOpenToChallengeExpiry: BigNumber;
   appealChallengeID: BigNumber;
+  appealTxData: TxDataAll;
   appealChallenge?: AppealChallengeData;
   statement?: ContentData;
 }

--- a/packages/dapp/src/actionCreators/government.ts
+++ b/packages/dapp/src/actionCreators/government.ts
@@ -1,4 +1,5 @@
 import { AnyAction } from "redux";
+import { MultisigTransaction } from "@joincivil/core/build/src/contracts/multisig/multisigtransaction";
 
 export enum governmentActions {
   SET_GOVT_PARAMETER = "SET_GOVT_PARAMETER",
@@ -8,6 +9,7 @@ export enum governmentActions {
   SET_APPELLATE = "SET_APPELLATE",
   SET_CONTROLLER = "SET_CONTROLLER",
   SET_APPELLATE_MEMBERS = "SET_APPELLATE_MEMBERS",
+  ADD_COUNCIL_MULTISIG_TRANSACTION = "ADD_COUNCIL_MULTISIG_TRANSACTION",
 }
 
 export const setGovernmentParameter = (paramName: string, paramValue: any): AnyAction => {
@@ -62,5 +64,12 @@ export const setAppellateMembers = (members: string[]): AnyAction => {
   return {
     type: governmentActions.SET_APPELLATE_MEMBERS,
     data: members,
+  };
+};
+
+export const addCouncilMultisigTransaction = (transaction: MultisigTransaction): AnyAction => {
+  return {
+    type: governmentActions.ADD_COUNCIL_MULTISIG_TRANSACTION,
+    data: transaction,
   };
 };

--- a/packages/dapp/src/apis/civilTCR.ts
+++ b/packages/dapp/src/apis/civilTCR.ts
@@ -62,12 +62,14 @@ export async function approve(
 }
 
 export async function approveForProposeReparameterization(): Promise<TwoStepEthTransaction | void> {
+  console.log("approveForProposeReparameterization");
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();
   const parameterizer = await tcr.getParameterizer();
   const eip = await tcr.getToken();
   const deposit = await parameterizer.getParameterValue("pMinDeposit");
   const approvedTokensForSpender = await eip.getApprovedTokensForSpender(parameterizer.address);
+  console.log("approvedTokensForSpender: " + approvedTokensForSpender);
   if (approvedTokensForSpender.lessThan(deposit)) {
     return eip.approveSpender(parameterizer.address, deposit);
   }
@@ -185,11 +187,26 @@ export async function setAppellate(address: EthAddress): Promise<TwoStepEthTrans
   return council.transferAppellate(address);
 }
 
+export async function getRawGrantAppeal(address: EthAddress): Promise<string> {
+  const civil = getCivil();
+  const tcr = await civil.tcrSingletonTrusted();
+  const council = await tcr.getCouncil();
+  const tx = await council.getRawGrantAppeal(address);
+  return tx.data!;
+}
+
 export async function grantAppeal(address: EthAddress): Promise<TwoStepEthTransaction> {
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();
   const council = await tcr.getCouncil();
   return council.grantAppeal(address);
+}
+
+export async function confirmAppeal(id: number): Promise<TwoStepEthTransaction> {
+  const civil = getCivil();
+  const tcr = await civil.tcrSingletonTrusted();
+  const council = await tcr.getCouncil();
+  return council.confirmAppeal(id);
 }
 
 export async function approveVotingRights(numTokens: BigNumber): Promise<TwoStepEthTransaction | void> {
@@ -239,6 +256,7 @@ export async function proposeReparameterization(
   paramName: string,
   newValue: BigNumber,
 ): Promise<TwoStepEthTransaction | void> {
+  console.log("proposeReparameterization");
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();
   const parameterizer = await tcr.getParameterizer();

--- a/packages/dapp/src/apis/civilTCR.ts
+++ b/packages/dapp/src/apis/civilTCR.ts
@@ -62,14 +62,12 @@ export async function approve(
 }
 
 export async function approveForProposeReparameterization(): Promise<TwoStepEthTransaction | void> {
-  console.log("approveForProposeReparameterization");
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();
   const parameterizer = await tcr.getParameterizer();
   const eip = await tcr.getToken();
   const deposit = await parameterizer.getParameterValue("pMinDeposit");
   const approvedTokensForSpender = await eip.getApprovedTokensForSpender(parameterizer.address);
-  console.log("approvedTokensForSpender: " + approvedTokensForSpender);
   if (approvedTokensForSpender.lessThan(deposit)) {
     return eip.approveSpender(parameterizer.address, deposit);
   }
@@ -256,7 +254,6 @@ export async function proposeReparameterization(
   paramName: string,
   newValue: BigNumber,
 ): Promise<TwoStepEthTransaction | void> {
-  console.log("proposeReparameterization");
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();
   const parameterizer = await tcr.getParameterizer();

--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -26,7 +26,7 @@ import Listing from "./listing/Listing";
 import Listings from "./listinglist/Listings";
 import NewsroomManagementV1 from "./newsroom/NewsroomManagement";
 import NewsroomManagement from "./newsroom/NewsroomManagementV2";
-import Parameterizer from "./parameterizer";
+import Parameterizer from "./Parameterizer";
 import Government from "./council/Government";
 
 class Main extends React.Component<DispatchProp<any> & RouteComponentProps<any>> {

--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -26,7 +26,7 @@ import Listing from "./listing/Listing";
 import Listings from "./listinglist/Listings";
 import NewsroomManagementV1 from "./newsroom/NewsroomManagement";
 import NewsroomManagement from "./newsroom/NewsroomManagementV2";
-import Parameterizer from "./Parameterizer";
+import Parameterizer from "./parameterizer";
 import Government from "./council/Government";
 
 class Main extends React.Component<DispatchProp<any> & RouteComponentProps<any>> {

--- a/packages/dapp/src/components/listing/AppealDetail.tsx
+++ b/packages/dapp/src/components/listing/AppealDetail.tsx
@@ -125,7 +125,6 @@ class AppealDetail extends React.Component<AppealDetailProps> {
     let modalContentComponents;
     if (isAwaitingAppealJudgment && this.props.isMemberOfAppellate) {
       if (this.props.txIdToConfirm) {
-        console.log("yes good");
         const confirmAppealProgressModal = this.renderConfirmAppealProgressModal();
         modalContentComponents = {
           [ModalContentEventNames.CONFIRM_APPEAL]: confirmAppealProgressModal,
@@ -137,7 +136,6 @@ class AppealDetail extends React.Component<AppealDetailProps> {
           },
         ];
       } else {
-        console.log("no bad");
         const grantAppealProgressModal = this.renderGrantAppealProgressModal();
         modalContentComponents = {
           [ModalContentEventNames.GRANT_APPEAL]: grantAppealProgressModal,

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -112,6 +112,7 @@ export interface ChallengeContainerReduxProps {
   parameters: any;
   govtParameters: any;
   isMemberOfAppellate: boolean;
+  txIdToConfirm?: number;
 }
 
 export interface ChallengeDetailProps {
@@ -129,6 +130,7 @@ export interface ChallengeDetailProps {
   balance?: BigNumber;
   votingBalance?: BigNumber;
   isMemberOfAppellate: boolean;
+  txIdToConfirm?: number;
   newsroom: NewsroomWrapper;
 }
 
@@ -227,6 +229,7 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps, ChallengeVot
         tokenBalance={(this.props.balance && this.props.balance.toNumber()) || 0}
         user={this.props.user}
         isMemberOfAppellate={this.props.isMemberOfAppellate}
+        txIdToConfirm={this.props.txIdToConfirm}
       />
     );
   }
@@ -608,6 +611,7 @@ class ChallengeContainer extends React.Component<
         votingBalance={this.props.votingBalance}
         govtParameters={this.props.govtParameters}
         isMemberOfAppellate={this.props.isMemberOfAppellate}
+        txIdToConfirm={this.props.txIdToConfirm}
       />
     );
   }
@@ -629,8 +633,21 @@ const makeMapStateToProps = () => {
     state: State,
     ownProps: ChallengeDetailContainerProps,
   ): ChallengeContainerReduxProps & ChallengeDetailContainerProps => {
-    const { challengesFetching, user, parameters, govtParameters } = state.networkDependent;
+    const {
+      challengesFetching,
+      user,
+      parameters,
+      govtParameters,
+      councilMultisigTransactions,
+    } = state.networkDependent;
+    let txIdToConfirm;
     const challengeData = getChallenge(state, ownProps);
+    if (challengeData && challengeData.challenge && challengeData.challenge.appeal) {
+      const txData = challengeData.challenge.appeal.appealTxData.data!;
+      if (councilMultisigTransactions.has(txData)) {
+        txIdToConfirm = councilMultisigTransactions.get(txData).id;
+      }
+    }
     const newsroomState = getNewsroom(state, ownProps);
     const challengeID = ownProps.challengeID;
     let listingAddress: string | undefined = ownProps.listingAddress;
@@ -667,6 +684,7 @@ const makeMapStateToProps = () => {
       parameters,
       govtParameters,
       isMemberOfAppellate,
+      txIdToConfirm,
       ...ownProps,
     };
   };

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -644,8 +644,9 @@ const makeMapStateToProps = () => {
     const challengeData = getChallenge(state, ownProps);
     if (challengeData && challengeData.challenge && challengeData.challenge.appeal) {
       const txData = challengeData.challenge.appeal.appealTxData.data!;
-      if (councilMultisigTransactions.has(txData.substring(0, 74))) {
-        txIdToConfirm = councilMultisigTransactions.get(txData).id;
+      const key = txData.substring(0, 74);
+      if (councilMultisigTransactions.has(key)) {
+        txIdToConfirm = councilMultisigTransactions.get(key).id;
       }
     }
     const newsroomState = getNewsroom(state, ownProps);

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -644,7 +644,7 @@ const makeMapStateToProps = () => {
     const challengeData = getChallenge(state, ownProps);
     if (challengeData && challengeData.challenge && challengeData.challenge.appeal) {
       const txData = challengeData.challenge.appeal.appealTxData.data!;
-      if (councilMultisigTransactions.has(txData)) {
+      if (councilMultisigTransactions.has(txData.substring(0, 74))) {
         txIdToConfirm = councilMultisigTransactions.get(txData).id;
       }
     }

--- a/packages/dapp/src/helpers/government.ts
+++ b/packages/dapp/src/helpers/government.ts
@@ -8,9 +8,11 @@ import {
   setAppellate,
   setController,
   setAppellateMembers,
+  addCouncilMultisigTransaction,
 } from "../actionCreators/government";
 import { getGovernmentParameters } from "../apis/civilTCR";
 import { getCivil, getTCR } from "./civilInstance";
+import { MultisigTransaction } from "@joincivil/core/build/src/contracts/multisig/multisigtransaction";
 
 export async function initializeGovernment(dispatch: Dispatch<any>): Promise<void> {
   const paramKeys: string[] = Object.values(GovernmentParameters);
@@ -49,7 +51,7 @@ export async function initializeConstitution(dispatch: Dispatch<any>): Promise<v
   const appellateMembers = await council.getAppellateMembers();
   dispatch(setAppellateMembers(appellateMembers));
 
-  council.transactions().subscribe(async (t: any) => {
-    console.log("found a transaction. it's: ", t);
+  council.transactions().subscribe(async (transaction: MultisigTransaction) => {
+    dispatch(addCouncilMultisigTransaction(transaction));
   });
 }

--- a/packages/dapp/src/helpers/government.ts
+++ b/packages/dapp/src/helpers/government.ts
@@ -48,4 +48,8 @@ export async function initializeConstitution(dispatch: Dispatch<any>): Promise<v
   dispatch(setController(controller));
   const appellateMembers = await council.getAppellateMembers();
   dispatch(setAppellateMembers(appellateMembers));
+
+  council.transactions().subscribe(async (t: any) => {
+    console.log("found a transaction. it's: ", t);
+  });
 }

--- a/packages/dapp/src/reducers/government.ts
+++ b/packages/dapp/src/reducers/government.ts
@@ -68,7 +68,6 @@ export function councilMultisigTransactions(
 ): Map<string, MultisigTransaction> {
   switch (action.type) {
     case governmentActions.ADD_COUNCIL_MULTISIG_TRANSACTION:
-      console.log("action.data: ", action.data.information.data);
       return state.set(action.data.information.data, action.data);
     default:
       return state;

--- a/packages/dapp/src/reducers/government.ts
+++ b/packages/dapp/src/reducers/government.ts
@@ -68,7 +68,7 @@ export function councilMultisigTransactions(
 ): Map<string, MultisigTransaction> {
   switch (action.type) {
     case governmentActions.ADD_COUNCIL_MULTISIG_TRANSACTION:
-      return state.set(action.data.information.data, action.data);
+      return state.set(action.data.information.data.substring(0, 74), action.data);
     default:
       return state;
   }

--- a/packages/dapp/src/reducers/government.ts
+++ b/packages/dapp/src/reducers/government.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from "redux";
 import { governmentActions } from "../actionCreators/government";
 import { Map } from "immutable";
+import { MultisigTransaction } from "@joincivil/core/build/src/contracts/multisig/multisigtransaction";
 
 export function govtParameters(state: object = {}, action: AnyAction): object {
   switch (action.type) {
@@ -56,6 +57,19 @@ export function appellateMembers(state: string[] = [""], action: AnyAction): str
   switch (action.type) {
     case governmentActions.SET_APPELLATE_MEMBERS:
       return action.data;
+    default:
+      return state;
+  }
+}
+
+export function councilMultisigTransactions(
+  state: Map<string, MultisigTransaction> = Map<string, MultisigTransaction>(),
+  action: AnyAction,
+): Map<string, MultisigTransaction> {
+  switch (action.type) {
+    case governmentActions.ADD_COUNCIL_MULTISIG_TRANSACTION:
+      console.log("action.data: ", action.data.information.data);
+      return state.set(action.data.information.data, action.data);
     default:
       return state;
   }

--- a/packages/dapp/src/reducers/index.ts
+++ b/packages/dapp/src/reducers/index.ts
@@ -39,7 +39,15 @@ import {
   challengesStartedByUser,
   challengeUserData,
 } from "./challenges";
-import { government, govtParameters, constitution, appellate, controller, appellateMembers } from "./government";
+import {
+  government,
+  govtParameters,
+  constitution,
+  appellate,
+  controller,
+  appellateMembers,
+  councilMultisigTransactions,
+} from "./government";
 import { user } from "./userAccount";
 import { network, networkName } from "./network";
 import { ui } from "./ui";
@@ -55,6 +63,7 @@ import { currentUserNewsrooms } from "./newsrooms";
 import { newsrooms, NewsroomState, newsroomUi, newsroomUsers } from "@joincivil/newsroom-manager";
 import { networkActions } from "../actionCreators/network";
 import { Subscription } from "rxjs";
+import { MultisigTransaction } from "@joincivil/core/build/src/contracts/multisig/multisigtransaction";
 
 export interface State {
   networkDependent: NetworkDependentState;
@@ -107,6 +116,7 @@ export interface NetworkDependentState {
   rejectedListingRemovedSubscriptions: Map<string, Subscription>;
   rejectedListingLatestChallengeSubscriptions: Map<string, Subscription>;
   whitelistedSubscriptions: Map<string, Subscription>;
+  councilMultisigTransactions: Map<string, MultisigTransaction>;
 }
 
 const networkDependentReducers = combineReducers({
@@ -150,6 +160,7 @@ const networkDependentReducers = combineReducers({
   rejectedListingRemovedSubscriptions,
   rejectedListingLatestChallengeSubscriptions,
   whitelistedSubscriptions,
+  councilMultisigTransactions,
 });
 
 const networkDependent = (state: any, action: AnyAction) => {

--- a/packages/dapp/src/reducers/index.ts
+++ b/packages/dapp/src/reducers/index.ts
@@ -58,12 +58,12 @@ import {
   UserChallengeData,
   EthAddress,
   ParamPropChallengeData,
+  MultisigTransaction,
 } from "@joincivil/core";
 import { currentUserNewsrooms } from "./newsrooms";
 import { newsrooms, NewsroomState, newsroomUi, newsroomUsers } from "@joincivil/newsroom-manager";
 import { networkActions } from "../actionCreators/network";
 import { Subscription } from "rxjs";
-import { MultisigTransaction } from "@joincivil/core";
 
 export interface State {
   networkDependent: NetworkDependentState;

--- a/packages/dapp/src/reducers/index.ts
+++ b/packages/dapp/src/reducers/index.ts
@@ -63,7 +63,7 @@ import { currentUserNewsrooms } from "./newsrooms";
 import { newsrooms, NewsroomState, newsroomUi, newsroomUsers } from "@joincivil/newsroom-manager";
 import { networkActions } from "../actionCreators/network";
 import { Subscription } from "rxjs";
-import { MultisigTransaction } from "@joincivil/core/build/src/contracts/multisig/multisigtransaction";
+import { MultisigTransaction } from "@joincivil/core";
 
 export interface State {
   networkDependent: NetworkDependentState;


### PR DESCRIPTION
- rather than forcing council members to go to Gnosis, now we load up any pending council transactions into redux, as well as the raw tx data for any appeals
- when rendering the appeal data, if the raw tx data matches anything in the council multisig, go through confirm tx flow instead of submit tx to multisig