### PR TITLE
Import just debounce from lodash (smaller build)

### DIFF
--- a/packages/components/src/DetailTransactionButton.tsx
+++ b/packages/components/src/DetailTransactionButton.tsx
@@ -1,5 +1,5 @@
 import { Civil, EthAddress } from "@joincivil/core";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import * as React from "react";
 import { Subscription } from "rxjs/Subscription";
 import styled from "styled-components";

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "declarationDir": "build/",
     "jsx": "react",
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": true,
     "lib": ["dom", "es2017"]
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]

--- a/packages/newsroom-manager/src/CreateCharterPartOne.tsx
+++ b/packages/newsroom-manager/src/CreateCharterPartOne.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import styled from "styled-components";
 import {
   colors,

--- a/packages/newsroom-manager/src/CreateCharterPartTwo.tsx
+++ b/packages/newsroom-manager/src/CreateCharterPartTwo.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import styled from "styled-components";
 import { StepHeader, StepProps, StepDescription, TextareaInput } from "@joincivil/components";
 import { EthAddress, CharterData } from "@joincivil/core";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "pretty": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true, // https://github.com/ReactiveX/rxjs/issues/3031
+    "esModuleInterop": true,
     "typeRoots": ["packages/typescript-typings/types", "node_modules/@types"]
   }
 }


### PR DESCRIPTION
@dankins tagging you cause your commit 3039b8206a25dc95cab5b6cc7588d81ea455dc89 set `"allowSyntheticDefaultImports": false` in  components tsconfig. It was wasn't working with type checking for `import debounce from "lodash/debounce"` and making it true didn't break anything else, reading the docs seems like it should be ok.