### PR TITLE
Respond to Extended Audit Issue 71 and 72

### DIFF
--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -377,6 +377,27 @@ contract CivilTCR is RestrictedAddressRegistry {
   }
 
   /**
+  @dev Determines the number of tokens awarded to the winning party in a challenge.
+  @param challengeID The challengeID to determine a reward for
+  */
+  function determineReward(uint challengeID) public view returns (uint) {
+    require(!challenges[challengeID].resolved && voting.pollEnded(challengeID));
+    bool overturned = appeals[challengeID].appealGranted && !appeals[challengeID].overturned;
+    // Edge case, nobody voted, give all tokens to the challenger.
+    if (overturned) {
+      if (civilVoting.getTotalNumberOfTokensForLosingOption(challengeID) == 0) {
+          return 2 * challenges[challengeID].stake;
+      }
+    } else {
+      if (voting.getTotalNumberOfTokensForWinningOption(challengeID) == 0) {
+          return 2 * challenges[challengeID].stake;
+      }
+    }
+
+    return (2 * challenges[challengeID].stake) - challenges[challengeID].rewardPool;
+  }
+
+  /**
   @notice Calculates the provided voter's token reward for the given poll.
   @dev differs from implementation in `AddressRegistry` in that it takes into consideration whether an
   appeal was granted and possible overturned via appeal challenge.

--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -334,8 +334,8 @@ contract CivilTCR is RestrictedAddressRegistry {
   }
 
   /**
-  @dev                Called by a voter to claim their reward for each completed vote. Someone
-                      must call updateStatus() before this can be called.
+  @dev Called by a voter to claim their reward for each completed vote. Someone must call 
+  updateStatus() before this can be called.
   @param _challengeID The PLCR pollID of the challenge a reward is being claimed for
   @param _salt        The salt of a voter's commit hash in the given poll
   */

--- a/packages/contracts/contracts/tcr/CivilTCR.sol
+++ b/packages/contracts/contracts/tcr/CivilTCR.sol
@@ -386,11 +386,11 @@ contract CivilTCR is RestrictedAddressRegistry {
     // Edge case, nobody voted, give all tokens to the challenger.
     if (overturned) {
       if (civilVoting.getTotalNumberOfTokensForLosingOption(challengeID) == 0) {
-          return 2 * challenges[challengeID].stake;
+        return 2 * challenges[challengeID].stake;
       }
     } else {
       if (voting.getTotalNumberOfTokensForWinningOption(challengeID) == 0) {
-          return 2 * challenges[challengeID].stake;
+        return 2 * challenges[challengeID].stake;
       }
     }
 


### PR DESCRIPTION
- overriding determineReward in CivilTCR.sol to get different token amounts when challenge was overridden