### PR TITLE
DApp: Render legacy charter format

### DIFF
--- a/packages/dapp/src/components/listing/ListingCharter.tsx
+++ b/packages/dapp/src/components/listing/ListingCharter.tsx
@@ -13,7 +13,8 @@ class ListingCharter extends React.Component<ListingCharterProps> {
     if (this.props.newsroom && this.props.newsroom.data.charter) {
       let newsroomCharter;
       try {
-        newsroomCharter = JSON.parse(this.props.newsroom.data.charter.content.toString()).charter;
+        // TODO(jon): This is a temporary patch to handle the older charter format. It's needed while we're in transition to the newer schema and should be updated once the dapp is updated to properly handle the new charter
+        newsroomCharter = (this.props.newsroom.data.charter.content as any).charter;
       } catch (ex) {
         console.error("charter not formatted correctly");
       }

--- a/packages/dapp/src/components/listing/ListingHeader.tsx
+++ b/packages/dapp/src/components/listing/ListingHeader.tsx
@@ -19,7 +19,8 @@ class ListingHeader extends React.Component<ListingHeaderProps> {
     let newsroomDescription = "";
     if (this.props.newsroom.data.charter) {
       try {
-        newsroomDescription = JSON.parse(this.props.newsroom.data.charter.content.toString()).desc;
+        // TODO(jon): This is a temporary patch to handle the older charter format. It's needed while we're in transition to the newer schema and should be updated once the dapp is updated to properly handle the new charter
+        newsroomDescription = (this.props.newsroom.data.charter.content as any).desc;
       } catch (ex) {
         console.error("charter not formatted correctly");
       }

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -45,7 +45,8 @@ class ListingListItemComponent extends React.Component<
     let description = "";
     if (newsroom!.wrapper.data.charter) {
       try {
-        description = JSON.parse(newsroom!.wrapper.data.charter!.content.toString()).desc;
+        // TODO(jon): This is a temporary patch to handle the older charter format. It's needed while we're in transition to the newer schema and should be updated once the dapp is updated to properly handle the new charter
+        description = (newsroom!.wrapper.data.charter!.content as any).desc;
       } catch (ex) {
         console.error("charter not formatted correctly");
       }


### PR DESCRIPTION
Add temporary fix to properly render the older charter format after the update to parse the charter into a JS object in `core`