### PR TITLE
 Pre-populate logo and newsroom URL from props if available

### DIFF
--- a/packages/newsroom-manager/src/CreateCharterPartOne.tsx
+++ b/packages/newsroom-manager/src/CreateCharterPartOne.tsx
@@ -8,7 +8,6 @@ import {
   StepProps,
   StepDescription,
   QuestionToolTip,
-  buttonSizes,
   TextInput,
   TextareaInput,
 } from "@joincivil/components";
@@ -59,6 +58,16 @@ const LogoURLInput = styled(TextInput)`
     margin-bottom: 0;
   }
 `;
+const LogoImgWrap = styled.div`
+  position: relative;
+  width: 100px;
+`;
+const LogoImg = styled.img`
+  position: absolute;
+  width: 100px;
+  height: auto;
+  top: -50%;
+`;
 
 const NewsroomURLInput = styled(TextInput)`
   max-width: 400px;
@@ -108,21 +117,23 @@ class CreateCharterPartOneComponent extends React.Component<CreateCharterPartOne
               Logo
               <QuestionToolTip
                 explainerText={
-                  "You need to add a URL to a logo or image. You can add a logo to your WordPress media library and copy the URL here. We recommend the image dimensions to be at minimum  300 x 300 pixels."
+                  /*"You need to add a URL to a logo or image. You can add a logo to your WordPress media library and copy the URL here. We recommend the image be square and at minimum 300 x 300 pixels."*/
+                  "You need to add a URL to a logo or image. If you set a Site Icon in your WordPress dashboard under Appearance > Customize > Site Identity it will be used here. We recommend the image be square and at minimum 300 x 300 pixels."
                 }
               />
             </FormSubhead>
             <LogoFormWrap>
               <LogoURLWrap>
                 <LogoURLInput
-                  placeholder="Enter URL or Open Media Library"
+                  /*placeholder="Enter URL or Open Media Library"*/
                   noLabel
                   name="logoUrl"
                   value={this.props.charter.logoUrl || ""}
                   onChange={this.charterInputChange}
                 />
               </LogoURLWrap>
-              <TertiaryButton size={buttonSizes.SMALL}>Open Media Library</TertiaryButton>
+              <LogoImgWrap>{this.props.charter.logoUrl && <LogoImg src={this.props.charter.logoUrl} />}</LogoImgWrap>
+              {/*<TertiaryButton size={buttonSizes.SMALL}>Open Media Library</TertiaryButton>*/}
             </LogoFormWrap>
             <HelperText style={{ marginTop: 4 }}>Must be image URL</HelperText>
           </div>

--- a/packages/newsroom-manager/src/CreateCharterPartOne.tsx
+++ b/packages/newsroom-manager/src/CreateCharterPartOne.tsx
@@ -128,10 +128,7 @@ class CreateCharterPartOneComponent extends React.Component<CreateCharterPartOne
           </div>
 
           <div>
-            <FormSubhead>
-              Newsroom URL
-              {/*TODO: pre-fill with value from CMS*/}
-            </FormSubhead>
+            <FormSubhead>Newsroom URL</FormSubhead>
             <NewsroomURLInput
               name="newsroomUrl"
               value={this.props.charter.newsroomUrl || ""}

--- a/packages/newsroom-manager/src/Newsroom.tsx
+++ b/packages/newsroom-manager/src/Newsroom.tsx
@@ -69,6 +69,8 @@ export interface NewsroomProps {
   profileAddressSaving?: boolean;
   owners?: string[];
   editors?: string[];
+  newsroomUrl?: string;
+  logoUrl?: string;
   getPersistedCharter?(): Promise<Partial<CharterData> | void>;
   persistCharter?(charter: Partial<CharterData>): Promise<void>;
   saveAddressToProfile?(): Promise<void>;
@@ -117,7 +119,7 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
     }
 
     this.state = {
-      charter: this.getCharterFromLocalStorage() || {},
+      charter: this.defaultCharterValues(this.getCharterFromLocalStorage() || {}),
       currentStep,
     };
     this.checkCharterCompletion();
@@ -127,7 +129,12 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
         .getPersistedCharter()
         .then(charter => {
           if (charter) {
-            this.setState({ charter }, this.checkCharterCompletion);
+            this.setState(
+              {
+                charter: this.defaultCharterValues(charter),
+              },
+              this.checkCharterCompletion,
+            );
           }
         })
         .catch();
@@ -422,6 +429,16 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
       charterPartOneComplete,
       charterPartTwoComplete,
     });
+  };
+
+  /** Replace even empty string values for newsroom/logo URLs in case user has partially filled charter and later goes in to CMS and sets these values. */
+  private defaultCharterValues = (charter: Partial<CharterData>): Partial<CharterData> => {
+    const { newsroomUrl, logoUrl } = this.props;
+    return {
+      ...charter,
+      newsroomUrl: charter.newsroomUrl || newsroomUrl,
+      logoUrl: charter.logoUrl || logoUrl,
+    };
   };
 }
 


### PR DESCRIPTION
Also replace un-implemented CMS media library for logo with just an img tag