### PR TITLE
Rejected Listings via GraphQL & other fixes

### DIFF
--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -233,6 +233,25 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   }
 
   /**
+   * An unending stream of all events that change the state of a listing
+   * @param fromBlock Starting block in history for events concerning whitelisted addresses.
+   *                  Set to "latest" for only new events
+   * @returns currently listings as new events get triggered
+   */
+  public allEventsFromBlock(
+    fromBlock: number | "latest" = getDefaultFromBlock(),
+    toBlock?: number,
+  ): Observable<ListingWrapper> {
+    return Observable.merge(
+      this.allEventsExceptWhitelistFromBlock(fromBlock, toBlock),
+      this.instance
+        ._ApplicationWhitelistedStream({}, { fromBlock, toBlock })
+        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+        .concatMap(async l => l.getListingWrapper()),
+    );
+  }
+
+  /**
    * An unending stream of all addresses that have been whitelisted
    * @param fromBlock Starting block in history for events concerning whitelisted addresses.
    *                  Set to "latest" for only new events

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { connect } from "react-redux";
-import { Set } from "immutable";
 import {
   Hero,
   HomepageHero,
@@ -16,11 +15,10 @@ import { getFormattedTokenBalance } from "@joincivil/utils";
 import { getCivil } from "../../helpers/civilInstance";
 import * as heroImgUrl from "../images/img-hero-listings.png";
 import WhitelistedListingListContainer from "./WhitelistedListingListContainer";
-import ListingList from "./ListingList";
+import RejectedListingListContainer from "./RejectedListingListContainer";
 import { State } from "../../redux/reducers";
 import ListingsInProgress from "./ListingsInProgress";
 import { StyledPageContent, StyledListingCopy } from "../utility/styledComponents";
-import { EmptyRegistryTabContentComponent, REGISTRY_PHASE_TAB_TYPES } from "./EmptyRegistryTabContent";
 
 const TABS: string[] = ["whitelisted", "in-progress", "rejected"];
 
@@ -30,7 +28,6 @@ export interface ListingProps {
 }
 
 export interface ListingReduxProps {
-  rejectedListings: Set<string>;
   parameters: any;
   error: undefined | string;
   loadingFinished: boolean;
@@ -89,7 +86,7 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
                   Rejected Newsrooms have been removed from the Civil Registry due to a breach of the Civil
                   Constitution. Rejected Newsrooms can reapply to the Registry at any time. Learn how to reapply.
                 </StyledListingCopy>
-                {this.renderRejectedListings()}
+                <RejectedListingListContainer />
               </StyledPageContent>
             </Tab>
           </Tabs>
@@ -98,14 +95,6 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
     );
   }
 
-  private renderRejectedListings = (): JSX.Element => {
-    if (this.props.rejectedListings.count()) {
-      return <ListingList listings={this.props.rejectedListings} />;
-    }
-
-    return <EmptyRegistryTabContentComponent phaseTabType={REGISTRY_PHASE_TAB_TYPES.REJECTED} />;
-  };
-
   private onTabChange = (activeIndex: number = 0): void => {
     const tabName = TABS[activeIndex];
     this.props.history.push(`/registry/${tabName}`);
@@ -113,11 +102,10 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
 }
 
 const mapStateToProps = (state: State, ownProps: ListingProps): ListingProps & ListingReduxProps => {
-  const { rejectedListings, parameters } = state.networkDependent;
+  const { parameters } = state.networkDependent;
   const useGraphQL = state.useGraphQL;
   return {
     ...ownProps,
-    rejectedListings,
     parameters,
     error: undefined,
     loadingFinished: true,

--- a/packages/dapp/src/components/listinglist/RejectedListingListContainer.tsx
+++ b/packages/dapp/src/components/listinglist/RejectedListingListContainer.tsx
@@ -4,26 +4,26 @@ import { Set } from "immutable";
 import { ListingSummaryApprovedComponent } from "@joincivil/components";
 import ListingList from "./ListingList";
 import { State } from "../../redux/reducers";
-import WhitelistedListingListRedux from "./WhitelistedListingListRedux";
+import RejectedListingListRedux from "./RejectedListingListRedux";
 import { EmptyRegistryTabContentComponent, REGISTRY_PHASE_TAB_TYPES } from "./EmptyRegistryTabContent";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
 
-export interface WhitelistedListingsListContainerReduxProps {
+export interface RejectedListingsListContainerReduxProps {
   useGraphQL: boolean;
 }
 const LISTINGS_QUERY = gql`
-  query($whitelistedOnly: Boolean!) {
-    listings(whitelistedOnly: $whitelistedOnly) {
+  query($rejectedOnly: Boolean!) {
+    listings(rejectedOnly: $rejectedOnly) {
       contractAddress
     }
   }
 `;
-class WhitelistedListingListContainer extends React.Component<WhitelistedListingsListContainerReduxProps> {
+class RejectedListingListContainer extends React.Component<RejectedListingsListContainerReduxProps> {
   public render(): JSX.Element {
     if (this.props.useGraphQL) {
       return (
-        <Query query={LISTINGS_QUERY} variables={{ whitelistedOnly: true }} pollInterval={1000}>
+        <Query query={LISTINGS_QUERY} variables={{ rejectedOnly: true }} pollInterval={1000}>
           {({ loading, error, data }: any): JSX.Element => {
             if (loading) {
               return <></>;
@@ -50,12 +50,12 @@ class WhitelistedListingListContainer extends React.Component<WhitelistedListing
         </Query>
       );
     } else {
-      return <WhitelistedListingListRedux />;
+      return <RejectedListingListRedux />;
     }
   }
 }
 
-const mapStateToProps = (state: State): WhitelistedListingsListContainerReduxProps => {
+const mapStateToProps = (state: State): RejectedListingsListContainerReduxProps => {
   const useGraphQL = state.useGraphQL;
 
   return {
@@ -63,4 +63,4 @@ const mapStateToProps = (state: State): WhitelistedListingsListContainerReduxPro
   };
 };
 
-export default connect(mapStateToProps)(WhitelistedListingListContainer);
+export default connect(mapStateToProps)(RejectedListingListContainer);

--- a/packages/dapp/src/components/listinglist/RejectedListingListRedux.tsx
+++ b/packages/dapp/src/components/listinglist/RejectedListingListRedux.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { connect } from "react-redux";
+import { Set } from "immutable";
+
+import { ListingSummaryApprovedComponent } from "@joincivil/components";
+
+import ListingList from "./ListingList";
+import { EmptyRegistryTabContentComponent, REGISTRY_PHASE_TAB_TYPES } from "./EmptyRegistryTabContent";
+import { State } from "../../redux/reducers";
+
+export interface RejectedListingsListReduxReduxProps {
+  rejectedListings: Set<string>;
+}
+
+class RejectedListingListRedux extends React.Component<RejectedListingsListReduxReduxProps> {
+  public render(): JSX.Element {
+    if (this.props.rejectedListings.count()) {
+      return (
+        <ListingList ListingItemComponent={ListingSummaryApprovedComponent} listings={this.props.rejectedListings} />
+      );
+    }
+
+    return <EmptyRegistryTabContentComponent phaseTabType={REGISTRY_PHASE_TAB_TYPES.REJECTED} />;
+  }
+}
+
+const mapStateToProps = (state: State): RejectedListingsListReduxReduxProps => {
+  const { rejectedListings } = state.networkDependent;
+
+  return {
+    rejectedListings,
+  };
+};
+
+export default connect(mapStateToProps)(RejectedListingListRedux);

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -40,13 +40,11 @@ export async function initializeSubscriptions(dispatch: Dispatch<any>): Promise<
     },
     () => {
       dispatch(setLoadingFinished());
-      currentListingSubscriptions = tcr
-        .allEventsExceptWhitelistFromBlock(current)
-        .subscribe(async (listing: ListingWrapper) => {
-          await getNewsroom(dispatch, listing.address);
-          setupListingCallback(listing, dispatch);
-          dispatch(addListing(listing));
-        });
+      currentListingSubscriptions = tcr.allEventsFromBlock(current).subscribe(async (listing: ListingWrapper) => {
+        await getNewsroom(dispatch, listing.address);
+        setupListingCallback(listing, dispatch);
+        dispatch(addListing(listing));
+      });
     },
   );
 }


### PR DESCRIPTION
adding rejected listings components with graphql query option (basically identical to the way whitelisted listings work). little fixes elsewhere