### PR TITLE
Statement Loading Refactors

### DIFF
--- a/packages/core/src/civil.ts
+++ b/packages/core/src/civil.ts
@@ -13,7 +13,7 @@ import { Newsroom } from "./contracts/newsroom";
 import { UserGroups } from "./contracts/proof-of-use/usergroups";
 import { CivilTCR } from "./contracts/tcr/civilTCR";
 import { Council } from "./contracts/tcr/council";
-import { ContentData, EthContentHeader, StorageHeader } from "./types";
+import { ContentData, StorageHeader } from "./types";
 
 // See debug in npm, you can use `localStorage.debug = "civil:*" to enable logging
 const debug = Debug("civil:main");

--- a/packages/core/src/civil.ts
+++ b/packages/core/src/civil.ts
@@ -13,7 +13,7 @@ import { Newsroom } from "./contracts/newsroom";
 import { UserGroups } from "./contracts/proof-of-use/usergroups";
 import { CivilTCR } from "./contracts/tcr/civilTCR";
 import { Council } from "./contracts/tcr/council";
-import { ContentData, EthContentHeader } from "./types";
+import { ContentData, EthContentHeader, StorageHeader } from "./types";
 
 // See debug in npm, you can use `localStorage.debug = "civil:*" to enable logging
 const debug = Debug("civil:main");
@@ -232,12 +232,25 @@ export class Civil {
     return uri;
   }
 
-  public async getContent(header: EthContentHeader): Promise<ContentData | undefined> {
+  public async getContent(header: StorageHeader): Promise<ContentData | undefined> {
     try {
       const content = await this.contentProvider.get(header);
       return content;
     } catch (e) {
       debug(`Resolving Content failed for EthContentHeader: ${header}`, e);
+      return;
+    }
+  }
+
+  public async getBareContent(uri: string): Promise<ContentData | undefined> {
+    try {
+      const content = await this.contentProvider.get({
+        uri,
+        contentHash: "",
+      });
+      return content;
+    } catch (e) {
+      debug(`Resolving Content failed for uri: ${uri}`, e);
       return;
     }
   }

--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -381,7 +381,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
    */
   public async loadArticle(articleId: number | BigNumber): Promise<NewsroomContent | undefined> {
     const header = await this.loadContentHeader(articleId);
-    if (!is0x0Hash(header.contentHash)) {
+    if (header.contentHash && !is0x0Hash(header.contentHash)) {
       return this.resolveContent(header);
     } else {
       return undefined;
@@ -768,7 +768,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
       return this.twoStepOrMulti(
         await this.multisigProxy.publishContent.sendTransactionAsync(
           storageHeader.uri,
-          storageHeader.contentHash,
+          storageHeader.contentHash!,
           author,
           signature,
         ),
@@ -781,7 +781,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
         this.ethApi,
         await this.instance.publishContent.sendTransactionAsync(
           storageHeader.uri,
-          storageHeader.contentHash,
+          storageHeader.contentHash!,
           author,
           signature,
         ),
@@ -816,7 +816,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
         await this.multisigProxy.updateRevision.sendTransactionAsync(
           this.ethApi.toBigNumber(contentId),
           storageHeader.uri,
-          storageHeader.contentHash,
+          storageHeader.contentHash!,
           signature,
         ),
         findRevisionId,
@@ -829,7 +829,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
         await this.instance.updateRevision.sendTransactionAsync(
           this.ethApi.toBigNumber(contentId),
           storageHeader.uri,
-          storageHeader.contentHash,
+          storageHeader.contentHash!,
           signature,
         ),
         findRevisionId,

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -77,23 +77,4 @@ export class Appeal {
       return;
     }
   }
-
-  private async getAppealStatementURI(): Promise<string | undefined> {
-    const uri = await this.getAppealURI();
-    return uri;
-  }
-
-  private async getAppealStatement(): Promise<ContentData | undefined> {
-    const uri = await this.getAppealURI();
-    if (!uri) {
-      return;
-    }
-    try {
-      const appealStatement = await this.contentProvider.get({ uri, contentHash: "" });
-      return appealStatement;
-    } catch (e) {
-      debug(`Getting Appeal Statement failed for ChallengeID: ${this.challengeId}`, e);
-      return;
-    }
-  }
 }

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -45,7 +45,7 @@ export class Appeal {
       const appealChallengeInstance = new AppealChallenge(this.ethApi, this.tcrInstance, appealChallengeID);
       appealChallenge = await appealChallengeInstance.getAppealChallengeData();
     }
-    const statement = await this.getAppealStatement();
+    const appealStatementURI = await this.getAppealURI();
     const appealTxData = await this.tcrInstance.grantAppeal.getRaw(this.listingAddress, "", { gas: 0 });
     return {
       requester,
@@ -56,11 +56,11 @@ export class Appeal {
       appealChallengeID,
       appealTxData,
       appealChallenge,
-      statement,
+      appealStatementURI,
     };
   }
 
-  private async getAppealURI(): Promise<EthAddress | undefined> {
+  private async getAppealURI(): Promise<string | undefined> {
     const currentBlock = await this.ethApi.getLatestBlockNumber();
 
     try {
@@ -76,6 +76,11 @@ export class Appeal {
       debug(`Getting AppealURI failed for ChallengeID: ${this.challengeId}`, e);
       return;
     }
+  }
+
+  private async getAppealStatementURI(): Promise<string | undefined> {
+    const uri = await this.getAppealURI();
+    return uri;
   }
 
   private async getAppealStatement(): Promise<ContentData | undefined> {

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -3,8 +3,7 @@ import * as Debug from "debug";
 import { EthApi } from "@joincivil/ethapi";
 import { getDefaultFromBlock } from "@joincivil/utils";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
-import { ContentProvider } from "../../content/contentprovider";
-import { AppealData, ContentData } from "../../types";
+import { AppealData } from "../../types";
 import { AppealChallenge } from "./appealChallenge";
 import { EthAddress } from "@joincivil/typescript-types";
 
@@ -13,21 +12,13 @@ const debug = Debug("civil:appeal");
 export class Appeal {
   private ethApi: EthApi;
   private tcrInstance: CivilTCRContract;
-  private contentProvider: ContentProvider;
   private challengeId: BigNumber;
   private listingAddress: EthAddress;
 
-  constructor(
-    ethApi: EthApi,
-    instance: CivilTCRContract,
-    challengeId: BigNumber,
-    listingAddress: EthAddress,
-    contentProvider: ContentProvider,
-  ) {
+  constructor(ethApi: EthApi, instance: CivilTCRContract, challengeId: BigNumber, listingAddress: EthAddress) {
     this.ethApi = ethApi;
     this.tcrInstance = instance;
     this.challengeId = challengeId;
-    this.contentProvider = contentProvider;
     this.listingAddress = listingAddress;
   }
 

--- a/packages/core/src/contracts/tcr/appealChallenge.ts
+++ b/packages/core/src/contracts/tcr/appealChallenge.ts
@@ -1,15 +1,21 @@
 import { EthApi } from "@joincivil/ethapi";
 import BigNumber from "bignumber.js";
+import * as Debug from "debug";
 import { AppealChallengeData } from "../../types";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { Voting } from "./voting";
+import { getDefaultFromBlock } from "@joincivil/utils";
+
+const debug = Debug("civil:appeal");
 
 export class AppealChallenge {
+  private ethApi: EthApi;
   private tcrInstance: CivilTCRContract;
   private challengeId: BigNumber;
   private voting: Promise<Voting>;
 
   constructor(ethApi: EthApi, instance: CivilTCRContract, challengeId: BigNumber) {
+    this.ethApi = ethApi;
     this.tcrInstance = instance;
     this.challengeId = challengeId;
     this.voting = Voting.singleton(ethApi);
@@ -21,6 +27,7 @@ export class AppealChallenge {
       this.challengeId,
     );
     const poll = await resolvedVoting.getPoll(this.challengeId);
+    const appealChallengeStatementURI = await this.getAppealChallengeURI();
 
     return {
       rewardPool,
@@ -29,6 +36,25 @@ export class AppealChallenge {
       stake,
       totalTokens,
       poll,
+      appealChallengeStatementURI,
     };
+  }
+
+  private async getAppealChallengeURI(): Promise<string | undefined> {
+    const currentBlock = await this.ethApi.getLatestBlockNumber();
+
+    try {
+      const appealChallengeMadeEvent = await this.tcrInstance
+        ._GrantedAppealChallengedStream(
+          { challengeID: this.challengeId },
+          { fromBlock: getDefaultFromBlock(), toBlock: currentBlock },
+        )
+        .first()
+        .toPromise();
+      return appealChallengeMadeEvent.args.data;
+    } catch (e) {
+      debug(`Getting ChallengeAppealURI failed for ChallengeID: ${this.challengeId}`, e);
+      return;
+    }
   }
 }

--- a/packages/core/src/contracts/tcr/challenge.ts
+++ b/packages/core/src/contracts/tcr/challenge.ts
@@ -3,7 +3,7 @@ import { getDefaultFromBlock } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
 import * as Debug from "debug";
 import { ContentProvider } from "../../content/contentprovider";
-import { ChallengeData, ContentData, EthAddress, EthContentHeader } from "../../types";
+import { ChallengeData, EthAddress } from "../../types";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { Appeal } from "./appeal";
 import { Voting } from "./voting";
@@ -38,7 +38,7 @@ export class Challenge {
     const [rewardPool, challenger, resolved, stake, totalTokens] = await this.tcrInstance.challenges.callAsync(
       this.challengeId,
     );
-    const challengeStatementURI = await this.getChallengeStatementURI();
+    const challengeStatementURI = await this.getChallengeURI();
 
     const poll = await resolvedVoting.getPoll(this.challengeId);
     const requestAppealExpiry = await this.tcrInstance.challengeRequestAppealExpiries.callAsync(this.challengeId);
@@ -83,23 +83,5 @@ export class Challenge {
       .first()
       .toPromise();
     return challengeEvent.args.data;
-  }
-
-  private async getChallengeStatementURI(): Promise<string | undefined> {
-    const uri = await this.getChallengeURI();
-    return uri;
-  }
-
-  private async getChallengeStatement(): Promise<ContentData | undefined> {
-    const uri = await this.getChallengeURI();
-    if (uri) {
-      try {
-        const challengeStatement = await this.contentProvider.get({ uri, contentHash: "" });
-        return challengeStatement;
-      } catch (e) {
-        debug(`Getting Challenge Statement failed for ChallengeID: ${this.challengeId}`, e);
-        return;
-      }
-    }
   }
 }

--- a/packages/core/src/contracts/tcr/challenge.ts
+++ b/packages/core/src/contracts/tcr/challenge.ts
@@ -3,7 +3,7 @@ import { getDefaultFromBlock } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
 import * as Debug from "debug";
 import { ContentProvider } from "../../content/contentprovider";
-import { ChallengeData, ContentData, EthAddress } from "../../types";
+import { ChallengeData, ContentData, EthAddress, EthContentHeader } from "../../types";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { Appeal } from "./appeal";
 import { Voting } from "./voting";
@@ -38,7 +38,7 @@ export class Challenge {
     const [rewardPool, challenger, resolved, stake, totalTokens] = await this.tcrInstance.challenges.callAsync(
       this.challengeId,
     );
-    const statement = await this.getChallengeStatement();
+    const challengeStatementURI = await this.getChallengeStatementURI();
 
     const poll = await resolvedVoting.getPoll(this.challengeId);
     const requestAppealExpiry = await this.tcrInstance.challengeRequestAppealExpiries.callAsync(this.challengeId);
@@ -57,7 +57,7 @@ export class Challenge {
     const appeal = await appealInstance.getAppealData();
 
     return {
-      statement,
+      challengeStatementURI,
       rewardPool,
       challenger,
       resolved,
@@ -83,6 +83,11 @@ export class Challenge {
       .first()
       .toPromise();
     return challengeEvent.args.data;
+  }
+
+  private async getChallengeStatementURI(): Promise<string | undefined> {
+    const uri = await this.getChallengeURI();
+    return uri;
   }
 
   private async getChallengeStatement(): Promise<ContentData | undefined> {

--- a/packages/core/src/contracts/tcr/challenge.ts
+++ b/packages/core/src/contracts/tcr/challenge.ts
@@ -1,33 +1,21 @@
 import { EthApi } from "@joincivil/ethapi";
 import { getDefaultFromBlock } from "@joincivil/utils";
 import BigNumber from "bignumber.js";
-import * as Debug from "debug";
-import { ContentProvider } from "../../content/contentprovider";
 import { ChallengeData, EthAddress } from "../../types";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { Appeal } from "./appeal";
 import { Voting } from "./voting";
 
-const debug = Debug("civil:challenge");
-
 export class Challenge {
   private ethApi: EthApi;
   private tcrInstance: CivilTCRContract;
-  private contentProvider: ContentProvider;
   private challengeId: BigNumber;
   private voting: Promise<Voting>;
   private listingAddress?: EthAddress;
 
-  constructor(
-    ethApi: EthApi,
-    instance: CivilTCRContract,
-    contentProvider: ContentProvider,
-    challengeId: BigNumber,
-    listingAddress?: EthAddress,
-  ) {
+  constructor(ethApi: EthApi, instance: CivilTCRContract, challengeId: BigNumber, listingAddress?: EthAddress) {
     this.ethApi = ethApi;
     this.tcrInstance = instance;
-    this.contentProvider = contentProvider;
     this.challengeId = challengeId;
     this.listingAddress = listingAddress;
     this.voting = Voting.singleton(ethApi);
@@ -47,13 +35,7 @@ export class Challenge {
     if (!listingAddress) {
       listingAddress = await this.getListingIdForChallenge();
     }
-    const appealInstance = new Appeal(
-      this.ethApi,
-      this.tcrInstance,
-      this.challengeId,
-      listingAddress,
-      this.contentProvider,
-    );
+    const appealInstance = new Appeal(this.ethApi, this.tcrInstance, this.challengeId, listingAddress);
     const appeal = await appealInstance.getAppealData();
 
     return {

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -165,70 +165,70 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
     return Observable.merge(
       this.instance
         ._ApplicationStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
       this.instance
         ._AppealRequestedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._AppealGrantedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._FailedChallengeOverturnedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._SuccessfulChallengeOverturnedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._GrantedAppealChallengedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._GrantedAppealOverturnedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._GrantedAppealConfirmedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._ChallengeStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._DepositStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._WithdrawalStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._ApplicationRemovedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._ListingRemovedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._ListingWithdrawnStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._TouchAndRemovedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._ChallengeFailedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
 
       this.instance
         ._ChallengeSucceededStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress)),
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress)),
     ).concatMap(async l => l.getListingWrapper());
   }
 
@@ -246,7 +246,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
       this.allEventsExceptWhitelistFromBlock(fromBlock, toBlock),
       this.instance
         ._ApplicationWhitelistedStream({}, { fromBlock, toBlock })
-        .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+        .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
         .concatMap(async l => l.getListingWrapper()),
     );
   }
@@ -263,7 +263,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationWhitelistedStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper());
   }
 
@@ -279,7 +279,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper());
   }
 
@@ -295,7 +295,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => canBeWhitelisted(l.data));
   }
@@ -312,7 +312,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInChallengedCommitVotePhase(l.data));
   }
@@ -329,7 +329,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInChallengedRevealVotePhase(l.data));
   }
@@ -346,7 +346,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isAwaitingAppealRequest(l.data));
   }
@@ -357,7 +357,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => canChallengeBeResolved(l.data));
   }
@@ -374,7 +374,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isListingAwaitingAppealJudgment(l.data));
   }
@@ -391,7 +391,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isListingAwaitingAppealChallenge(l.data));
   }
@@ -408,7 +408,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInAppealChallengeCommitPhase(l.data));
   }
@@ -425,7 +425,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => isInAppealChallengeRevealPhase(l.data));
   }
@@ -442,7 +442,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ChallengeStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => canListingAppealBeResolved(l.data));
   }
@@ -459,7 +459,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   ): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock, toBlock })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper())
       .concatFilter(l => l.data.appExpiry.isZero());
   }
@@ -467,7 +467,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   public allApplicationsEver(): Observable<ListingWrapper> {
     return this.instance
       ._ApplicationStream({}, { fromBlock: getDefaultFromBlock() })
-      .map(e => new Listing(this.ethApi, this.instance, this.contentProvider, e.args.listingAddress))
+      .map(e => new Listing(this.ethApi, this.instance, e.args.listingAddress))
       .concatMap(async l => l.getListingWrapper());
   }
 
@@ -480,7 +480,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   //#endregion
 
   public getListing(listingAddress: EthAddress): Listing {
-    return new Listing(this.ethApi, this.instance, this.contentProvider, listingAddress);
+    return new Listing(this.ethApi, this.instance, listingAddress);
   }
 
   /*
@@ -511,7 +511,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
   }
 
   public async getChallengeData(challengeID: BigNumber): Promise<WrappedChallengeData> {
-    const challenge = new Challenge(this.ethApi, this.instance, this.contentProvider, challengeID);
+    const challenge = new Challenge(this.ethApi, this.instance, challengeID);
     const listingAddress = await challenge.getListingIdForChallenge();
     const challengeData = await challenge.getChallengeData();
     return {

--- a/packages/core/src/contracts/tcr/listing.ts
+++ b/packages/core/src/contracts/tcr/listing.ts
@@ -5,18 +5,15 @@ import { EthApi } from "@joincivil/ethapi";
 import { EthAddress, ListingWrapper, ListingData, TimestampedEvent } from "../../types";
 import { createTimestampedEvent } from "../../utils/events";
 import { Challenge } from "./challenge";
-import { ContentProvider } from "../../content/contentprovider";
 
 export class Listing {
   private ethApi: EthApi;
   private tcrInstance: CivilTCRContract;
-  private contentProvider: ContentProvider;
   private listingAddress: EthAddress;
 
-  constructor(ethApi: EthApi, instance: CivilTCRContract, contentProvider: ContentProvider, address: EthAddress) {
+  constructor(ethApi: EthApi, instance: CivilTCRContract, address: EthAddress) {
     this.ethApi = ethApi;
     this.tcrInstance = instance;
-    this.contentProvider = contentProvider;
     this.listingAddress = address;
   }
 
@@ -34,7 +31,7 @@ export class Listing {
     );
     let challenge;
     if (!challengeID.isZero()) {
-      const c = new Challenge(this.ethApi, this.tcrInstance, this.contentProvider, challengeID, this.listingAddress);
+      const c = new Challenge(this.ethApi, this.tcrInstance, challengeID, this.listingAddress);
       challenge = await c.getChallengeData();
     }
     return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -201,7 +201,7 @@ export interface AppealData {
   appealChallengeID: BigNumber;
   appealTxData?: TxDataAll;
   appealChallenge?: AppealChallengeData;
-  statement?: ContentData;
+  appealStatementURI?: string;
 }
 
 /**
@@ -214,6 +214,7 @@ export interface AppealChallengeData {
   stake: BigNumber;
   totalTokens: BigNumber;
   poll: PollData;
+  appealChallengeStatementURI?: string;
 }
 
 export type PollID = BigNumber;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,7 +34,7 @@ export interface StorageHeader {
   /**
    * Normalized content schema hashed using keccak256 algorithm
    */
-  contentHash: Hex;
+  contentHash?: Hex;
 }
 
 export interface SignedContentHeader {
@@ -44,9 +44,9 @@ export interface SignedContentHeader {
 }
 
 export interface BaseContentHeader extends StorageHeader {
-  contentId: ContentId;
+  contentId?: ContentId;
   revisionId?: RevisionId;
-  timestamp: Date;
+  timestamp?: Date;
 }
 
 export interface EthContentHeader extends BaseContentHeader, SignedContentHeader {
@@ -166,7 +166,7 @@ export interface WrappedChallengeData {
  * The data associated with a Challenge
  */
 export interface ChallengeData {
-  statement?: ContentData;
+  challengeStatementURI?: string;
   rewardPool: BigNumber;
   challenger: EthAddress;
   resolved: boolean;

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -150,7 +150,7 @@ const mapToStateToProps = (
   if (challenge) {
     challengeStatement = content.get(challenge.challenge.challengeStatementURI!);
 
-    if (challenge.challenge.appeal && challenge.challenge.appeal) {
+    if (challenge.challenge.appeal) {
       appealStatement = content.get(challenge.challenge.appeal.appealStatementURI!);
     }
   }

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -34,20 +34,14 @@ class ListingChallengeStatement extends React.Component<
     super(props);
   }
   public async componentDidMount(): Promise<void> {
-    const { listing } = this.props;
-    if (listing && listing.data.challenge) {
-      this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
-    }
+    await this.getContents();
   }
 
   public async componentDidUpdate(
     prevProps: ListingChallengeStatementProps & ListingChallengeStatementReduxProps,
   ): Promise<void> {
     if (prevProps.listing !== this.props.listing) {
-      const { listing } = this.props;
-      if (listing && listing.data.challenge) {
-        this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
-      }
+      await this.getContents();
     }
   }
 
@@ -58,6 +52,17 @@ class ListingChallengeStatement extends React.Component<
         {this.renderAppealStatement()}
       </>
     );
+  }
+
+  private async getContents(): Promise<void> {
+    const { listing } = this.props;
+    if (listing && listing.data.challenge) {
+      this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
+      const { challenge } = listing.data;
+      if (challenge.appeal) {
+        this.props.dispatch!(await getBareContent(challenge.appeal.appealStatementURI!));
+      }
+    }
   }
 
   private renderAppealStatement = (): JSX.Element => {
@@ -145,8 +150,8 @@ const mapToStateToProps = (
   if (challenge) {
     challengeStatement = content.get(challenge.challenge.challengeStatementURI!);
 
-    if (challenge.challenge.appeal && challenge.challenge.appeal.statement) {
-      appealStatement = challenge.challenge.appeal.statement;
+    if (challenge.challenge.appeal && challenge.challenge.appeal) {
+      appealStatement = content.get(challenge.challenge.appeal.appealStatementURI!);
     }
   }
   return {

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -39,6 +39,18 @@ class ListingChallengeStatement extends React.Component<
       this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
     }
   }
+
+  public async componentDidUpdate(
+    prevProps: ListingChallengeStatementProps & ListingChallengeStatementReduxProps,
+  ): Promise<void> {
+    if (prevProps.listing !== this.props.listing) {
+      const { listing } = this.props;
+      if (listing && listing.data.challenge) {
+        this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
+      }
+    }
+  }
+
   public render(): JSX.Element {
     return (
       <>

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { connect } from "react-redux";
+import { connect, DispatchProp } from "react-redux";
 import * as sanitizeHtml from "sanitize-html";
 import styled from "styled-components";
 import { State } from "../../redux/reducers";
 import { ListingTabHeading } from "./styledComponents";
 import { getChallengeByListingAddress } from "../../selectors";
 import { NewsroomWrapper, ListingWrapper } from "@joincivil/core";
+import { getBareContent } from "../../redux/actionCreators/newsrooms";
 
 const StyledChallengeStatementComponent = styled.div`
   margin: 0 0 56px;
@@ -23,16 +24,21 @@ export interface ListingChallengeStatementProps {
 
 export interface ListingChallengeStatementReduxProps {
   appealStatement: any;
-  challengeStatement: any;
+  challengeStatement?: any;
 }
 
 class ListingChallengeStatement extends React.Component<
-  ListingChallengeStatementProps & ListingChallengeStatementReduxProps
+  ListingChallengeStatementProps & ListingChallengeStatementReduxProps & DispatchProp<any>
 > {
-  constructor(props: ListingChallengeStatementProps & ListingChallengeStatementReduxProps) {
+  constructor(props: ListingChallengeStatementProps & ListingChallengeStatementReduxProps & DispatchProp<any>) {
     super(props);
   }
-
+  public async componentDidMount(): Promise<void> {
+    const { listing } = this.props;
+    if (listing && listing.data.challenge) {
+      this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
+    }
+  }
   public render(): JSX.Element {
     return (
       <>
@@ -121,10 +127,11 @@ const mapToStateToProps = (
   ownProps: ListingChallengeStatementProps,
 ): ListingChallengeStatementProps & ListingChallengeStatementReduxProps => {
   const challenge = getChallengeByListingAddress(state, ownProps);
+  const { content } = state.networkDependent;
   let challengeStatement: any = "";
   let appealStatement: any = "";
   if (challenge) {
-    challengeStatement = challenge.challenge.statement;
+    challengeStatement = content.get(challenge.challenge.challengeStatementURI!);
 
     if (challenge.challenge.appeal && challenge.challenge.appeal.statement) {
       appealStatement = challenge.challenge.appeal.statement;

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -33,10 +33,19 @@ class ListingListItem extends React.Component<ListingListItemOwnProps & ListingL
     }
     const { listing } = this.props;
     if (listing && listing.data.challenge) {
-      console.log("GO GET CONTENT: ", listing.data.challenge.challengeStatementURI);
       this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
     }
   }
+
+  public async componentDidUpdate(prevProps: ListingListItemOwnProps & ListingListItemReduxProps): Promise<void> {
+    if (prevProps.listing !== this.props.listing) {
+      const { listing } = this.props;
+      if (listing && listing.data.challenge) {
+        this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
+      }
+    }
+  }
+
   public render(): JSX.Element {
     const { listing, newsroom, listingPhaseState } = this.props;
     const listingExists = listing && listing.data && newsroom && listingPhaseState;

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -91,10 +91,12 @@ class ListingListItem extends React.Component<ListingListItemOwnProps & ListingL
       try {
         challengeStatementSummary = JSON.parse(this.props.challengeStatement as string).summary;
       } catch (ex) {
+        // TODO: clean this up once new charter format is in
         console.log("something bad: ", ex);
         try {
           challengeStatementSummary = this.props.challengeStatement.summary;
         } catch (ex1) {
+          // TODO: clean this up once new charter format is in
           console.log("something worse: ", ex1);
         }
       }

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -24,6 +24,7 @@ export interface ListingListItemReduxProps {
   listingPhaseState?: any;
   charter?: any;
   challengeStatement?: any;
+  appealStatement?: any;
 }
 
 class ListingListItem extends React.Component<ListingListItemOwnProps & ListingListItemReduxProps & DispatchProp<any>> {
@@ -85,7 +86,6 @@ class ListingListItem extends React.Component<ListingListItemOwnProps & ListingL
     const unstakedDeposit = listing && getFormattedTokenBalance(listing.data.unstakedDeposit);
     const challengeStake = listingData.challenge && getFormattedTokenBalance(listingData.challenge.stake);
     const challengeID = challenge && listingData.challengeID.toString();
-    console.log("this.props.challengeStatement: ", this.props.challengeStatement);
     let challengeStatementSummary;
     if (this.props.challengeStatement) {
       try {
@@ -101,7 +101,8 @@ class ListingListItem extends React.Component<ListingListItemOwnProps & ListingL
     }
 
     const appeal = challenge && challenge.appeal;
-    const appealStatementSummary = appeal && appeal.statement && JSON.parse(appeal.statement as string).summary;
+    const appealStatementSummary =
+      this.props.appealStatement && JSON.parse(this.props.appealStatement as string).summary;
     const appealPhaseExpiry = appeal && appeal.appealPhaseExpiry;
     const appealOpenToChallengeExpiry = appeal && appeal.appealOpenToChallengeExpiry;
 
@@ -174,16 +175,21 @@ const mapStateToProps = (
   const { content } = state.networkDependent;
   let charter;
   let challengeStatement;
+  let appealStatement;
   if (ownProps.newsroom && ownProps.newsroom.data.charterHeader) {
     charter = content.get(ownProps.newsroom.data.charterHeader.uri);
   }
   if (ownProps.listing && ownProps.listing.data.challenge) {
     challengeStatement = content.get(ownProps.listing.data.challenge.challengeStatementURI!);
+    if (ownProps.listing.data.challenge.appeal) {
+      appealStatement = content.get(ownProps.listing.data.challenge.appeal.appealStatementURI!);
+    }
   }
   return {
     listingPhaseState: getListingPhaseState(ownProps.listing),
     charter,
     challengeStatement,
+    appealStatement,
     ...ownProps,
   };
 };

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -36,6 +36,7 @@ export interface ListingReduxProps {
 
 class Listings extends React.Component<ListingProps & ListingReduxProps> {
   public render(): JSX.Element {
+    console.log("listings 0");
     const { listingType } = this.props.match.params;
     let activeIndex = 0;
     let hero;

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -36,7 +36,6 @@ export interface ListingReduxProps {
 
 class Listings extends React.Component<ListingProps & ListingReduxProps> {
   public render(): JSX.Element {
-    console.log("listings 0");
     const { listingType } = this.props.match.params;
     let activeIndex = 0;
     let hero;

--- a/packages/dapp/src/components/listinglist/ListingsInProgressContainer.tsx
+++ b/packages/dapp/src/components/listinglist/ListingsInProgressContainer.tsx
@@ -62,7 +62,7 @@ class ListingsInProgressContainer extends React.Component<
           pollInterval={1000}
         >
           {({ loading, error, data }: any): JSX.Element => {
-            if (loading) {
+            if (loading && !data) {
               return <></>;
             }
             if (error) {

--- a/packages/dapp/src/components/listinglist/WhitelistedListingItem.tsx
+++ b/packages/dapp/src/components/listinglist/WhitelistedListingItem.tsx
@@ -3,9 +3,9 @@ import { connect, DispatchProp } from "react-redux";
 import { ListingSummaryApprovedComponent } from "@joincivil/components";
 import { getFormattedTokenBalance } from "@joincivil/utils";
 import { State } from "../../redux/reducers";
-import { setupListingWhitelistedSubscription } from "../../redux/actionCreators/listings";
 import { getListingPhaseState, makeGetLatestWhitelistedTimestamp } from "../../selectors";
 import { ListingListItemOwnProps, ListingListItemReduxProps } from "./ListingListItem";
+import { getContent, getBareContent } from "../../redux/actionCreators/newsrooms";
 
 export interface WhitelistedCardReduxProps extends ListingListItemReduxProps {
   whitelistedTimestamp?: number;
@@ -16,7 +16,13 @@ class WhitelistedListingItem extends React.Component<
   ListingListItemOwnProps & WhitelistedCardReduxProps & DispatchProp<any>
 > {
   public async componentDidMount(): Promise<void> {
-    this.props.dispatch!(await setupListingWhitelistedSubscription(this.props.listingAddress!));
+    if (this.props.newsroom) {
+      this.props.dispatch!(await getContent(this.props.newsroom.data.charterHeader!));
+    }
+    const { listing } = this.props;
+    if (listing && listing.data.challenge) {
+      this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
+    }
   }
 
   public render(): JSX.Element {
@@ -34,7 +40,7 @@ class WhitelistedListingItem extends React.Component<
     const challenge = listingData.challenge;
     const challengeID = challenge && listingData.challengeID.toString();
     const challengeStatementSummary =
-      challenge && challenge.statement && JSON.parse(challenge.statement as string).summary;
+      this.props.challengeStatement && JSON.parse(this.props.challengeStatement as string).summary;
 
     const pollData = challenge && challenge.poll;
     const commitEndDate = pollData && pollData.commitEndDate.toNumber();

--- a/packages/dapp/src/components/listinglist/WhitelistedListingItem.tsx
+++ b/packages/dapp/src/components/listinglist/WhitelistedListingItem.tsx
@@ -58,7 +58,8 @@ class WhitelistedListingItem extends React.Component<
     const challengeStake = listingData.challenge && getFormattedTokenBalance(listingData.challenge.stake);
 
     const appeal = challenge && challenge.appeal;
-    const appealStatementSummary = appeal && appeal.statement && JSON.parse(appeal.statement as string).summary;
+    const appealStatementSummary =
+      this.props.appealStatement && JSON.parse(this.props.appealStatement as string).summary;
     const appealPhaseExpiry = appeal && appeal.appealPhaseExpiry;
     const appealOpenToChallengeExpiry = appeal && appeal.appealOpenToChallengeExpiry;
 
@@ -104,13 +105,23 @@ const makeMapStateToProps = () => {
     const { content } = state.networkDependent;
     const whitelistedTimestamp = getLatestWhitelistedTimestamp(state, ownProps);
     let charter;
+    let challengeStatement;
+    let appealStatement;
     if (ownProps.newsroom && ownProps.newsroom.data.charterHeader) {
       charter = content.get(ownProps.newsroom.data.charterHeader.uri);
+    }
+    if (ownProps.listing && ownProps.listing.data.challenge) {
+      challengeStatement = content.get(ownProps.listing.data.challenge.challengeStatementURI!);
+      if (ownProps.listing.data.challenge.appeal) {
+        appealStatement = content.get(ownProps.listing.data.challenge.appeal.appealStatementURI!);
+      }
     }
     return {
       listingPhaseState: getListingPhaseState(ownProps.listing),
       whitelistedTimestamp,
       charter,
+      challengeStatement,
+      appealStatement,
       ...ownProps,
     };
   };

--- a/packages/dapp/src/components/listinglist/WhitelistedListingItem.tsx
+++ b/packages/dapp/src/components/listinglist/WhitelistedListingItem.tsx
@@ -25,6 +25,15 @@ class WhitelistedListingItem extends React.Component<
     }
   }
 
+  public async componentDidUpdate(prevProps: ListingListItemOwnProps & WhitelistedCardReduxProps): Promise<void> {
+    if (prevProps.listing !== this.props.listing) {
+      const { listing } = this.props;
+      if (listing && listing.data.challenge) {
+        this.props.dispatch!(await getBareContent(listing.data.challenge.challengeStatementURI!));
+      }
+    }
+  }
+
   public render(): JSX.Element {
     const { listingAddress, listing, newsroom, listingPhaseState, charter } = this.props;
     const listingData = listing!.data;

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -1,4 +1,4 @@
-import { EthAddress, getNextTimerExpiry, ListingWrapper, EthContentHeader } from "@joincivil/core";
+import { EthAddress, getNextTimerExpiry, ListingWrapper, StorageHeader } from "@joincivil/core";
 import { addNewsroom } from "@joincivil/newsroom-manager";
 import { getDefaultFromBlock } from "@joincivil/utils";
 import { BigNumber } from "bignumber.js";
@@ -114,7 +114,7 @@ export async function getNewsroom(dispatch: Dispatch<any>, address: EthAddress):
   }
 }
 
-export async function getIPFSContent(header: EthContentHeader, dispatch: Dispatch<any>): Promise<void> {
+export async function getIPFSContent(header: StorageHeader, dispatch: Dispatch<any>): Promise<void> {
   const civil = getCivil();
   const content = await civil.getContent(header);
   if (content) {

--- a/packages/dapp/src/helpers/queryTransformations.ts
+++ b/packages/dapp/src/helpers/queryTransformations.ts
@@ -146,7 +146,7 @@ export function transformGraphQLDataIntoAppeal(queryAppealData: any): AppealData
       appealChallengeID: new BigNumber(queryAppealData.appealChallengeID),
       appealTxData: undefined,
       appealChallenge: transformGraphQLDataIntoAppealChallenge(queryAppealData.appealChallenge),
-      statement: "",
+      appealStatementURI: queryAppealData.statement,
     };
   } else {
     return undefined;
@@ -170,6 +170,7 @@ export function transformGraphQLDataIntoAppealChallenge(
         votesFor: new BigNumber(queryAppealChallengeData.poll.votesFor),
         votesAgainst: new BigNumber(queryAppealChallengeData.poll.votesAgainst),
       },
+      appealChallengeStatementURI: queryAppealChallengeData.statement,
     };
   } else {
     return undefined;

--- a/packages/dapp/src/helpers/queryTransformations.ts
+++ b/packages/dapp/src/helpers/queryTransformations.ts
@@ -114,7 +114,7 @@ export function transformGraphQLDataIntoListing(listing: any, listingAddress: st
 export function transformGraphQLDataIntoChallenge(queryChallengeData: any): ChallengeData | undefined {
   if (queryChallengeData) {
     return {
-      statement: "",
+      challengeStatementURI: queryChallengeData.statement,
       rewardPool: new BigNumber(queryChallengeData.rewardPool),
       challenger: queryChallengeData.challenger,
       resolved: queryChallengeData.resolved,

--- a/packages/dapp/src/redux/actionCreators/newsrooms.ts
+++ b/packages/dapp/src/redux/actionCreators/newsrooms.ts
@@ -1,5 +1,5 @@
 import { AnyAction } from "redux";
-import { EthAddress, EthContentHeader, ContentData } from "@joincivil/core";
+import { EthAddress, ContentData, StorageHeader } from "@joincivil/core";
 import { getIPFSContent } from "../../helpers/listingEvents";
 
 export enum newsroomActions {
@@ -15,7 +15,7 @@ export const addUserNewsroom = (address: EthAddress): AnyAction => {
   };
 };
 
-export const addContent = (header: EthContentHeader, content: ContentData): AnyAction => {
+export const addContent = (header: StorageHeader, content: ContentData): AnyAction => {
   return {
     type: newsroomActions.ADD_CONTENT,
     data: {
@@ -25,19 +25,29 @@ export const addContent = (header: EthContentHeader, content: ContentData): AnyA
   };
 };
 
-export const fetchContent = (header: EthContentHeader): AnyAction => {
+export const fetchContent = (header: StorageHeader): AnyAction => {
   return {
     type: newsroomActions.FETCH_CONTENT,
     data: header,
   };
 };
 
-export const getContent = (header: EthContentHeader): any => {
+export const getContent = (header: StorageHeader): any => {
   return async (dispatch: any, getState: any): Promise<AnyAction | void> => {
     const contentFetched = getState().networkDependent.contentFetched;
     if (!contentFetched.has(header)) {
       await getIPFSContent(header, dispatch);
       dispatch(fetchContent(header));
+    }
+  };
+};
+
+export const getBareContent = (uri: string): any => {
+  return async (dispatch: any, getState: any): Promise<AnyAction | void> => {
+    const contentFetched = getState().networkDependent.contentFetched;
+    if (!contentFetched.has({ uri })) {
+      await getIPFSContent({ uri }, dispatch);
+      dispatch(fetchContent({ uri }));
     }
   };
 };

--- a/packages/dapp/src/redux/reducers/newsrooms.ts
+++ b/packages/dapp/src/redux/reducers/newsrooms.ts
@@ -1,7 +1,7 @@
 import { Set, Map } from "immutable";
 import { AnyAction } from "redux";
 import { newsroomActions } from "../actionCreators/newsrooms";
-import { EthContentHeader, ContentData } from "@joincivil/core";
+import { StorageHeader, ContentData } from "@joincivil/core";
 
 export function currentUserNewsrooms(state: Set<string> = Set<string>(), action: AnyAction): Set<string> {
   switch (action.type) {
@@ -13,9 +13,9 @@ export function currentUserNewsrooms(state: Set<string> = Set<string>(), action:
 }
 
 export function contentFetched(
-  state: Set<EthContentHeader> = Set<EthContentHeader>(),
+  state: Set<StorageHeader> = Set<StorageHeader>(),
   action: AnyAction,
-): Set<EthContentHeader> {
+): Set<StorageHeader> {
   switch (action.type) {
     case newsroomActions.FETCH_CONTENT:
       return state.add(action.data);

--- a/packages/newsroom-manager/src/contentViewer/Revision.tsx
+++ b/packages/newsroom-manager/src/contentViewer/Revision.tsx
@@ -128,7 +128,7 @@ class RevisionComponent extends React.Component<RevisionProps & DispatchProp<any
           </Tr>
           <Tr>
             <Td>block number: {this.props.revision.blockNumber}</Td>
-            <Td>time stamp: {this.props.revision.timestamp.toDateString()}</Td>
+            <Td>time stamp: {this.props.revision.timestamp!.toDateString()}</Td>
           </Tr>
           <Tr>
             <Td>transaction hash: {this.props.revision.transactionHash}</Td>
@@ -140,7 +140,7 @@ class RevisionComponent extends React.Component<RevisionProps & DispatchProp<any
   }
   private onClick = (): void => {
     this.props.dispatch!(
-      fetchRevisionJson(this.props.revision.uri, this.props.revision.contentId, this.props.revision.revisionId!),
+      fetchRevisionJson(this.props.revision.uri, this.props.revision.contentId!, this.props.revision.revisionId!),
     );
   };
 }


### PR DESCRIPTION
just return URI associated with statements in `core` and then get the actual content in the dapp, whether URI came from `core` or `graphql`