### PR TITLE
Refactor and bugfixes for contract member and roster management

### DIFF
--- a/packages/newsroom-manager/src/CompleteYourProfile.tsx
+++ b/packages/newsroom-manager/src/CompleteYourProfile.tsx
@@ -5,7 +5,6 @@ import {
   colors,
   DetailTransactionButton,
   fonts,
-  QuestionToolTip,
   StepDescription,
   StepHeader,
   StepFormSection,
@@ -23,7 +22,7 @@ import styled from "styled-components";
 import { fetchNewsroom } from "./actionCreators";
 import { CivilContext, CivilContextValue } from "./CivilContext";
 import { NewsroomUser, UserTypes } from "./NewsroomUser";
-import { FormTitle } from "./styledComponents";
+import { FormTitle, QuestionToolTip } from "./styledComponents";
 import { StateWithNewsroom } from "./reducers";
 import { getUserObject } from "./utils";
 import { UserData } from "./types";
@@ -84,11 +83,6 @@ const AddButton = styled(BorderlessButton)`
 
 const Description = styled(StepDescription)`
   font-size: 14px;
-`;
-
-const QuestionToolTipWrapper = styled.span`
-  position: relative;
-  top: 3px;
 `;
 
 class CompleteYourProfileComponent extends React.Component<
@@ -315,13 +309,11 @@ class CompleteYourProfileComponent extends React.Component<
         <Description>
           Add additional officers and members to your newsroom smart contract. You will need their public wallet
           addresses. This step is optional, but recommended.
-          <QuestionToolTipWrapper>
-            <QuestionToolTip
-              explainerText={
-                "If you lose access to your wallet, only a Civil Officer can add you back to the smart contract with a new address. You can always add Officers and Members later."
-              }
-            />
-          </QuestionToolTipWrapper>
+          <QuestionToolTip
+            explainerText={
+              "If you lose access to your wallet, only a Civil Officer can add you back to the smart contract with a new address. You can always add Officers and Members later."
+            }
+          />
         </Description>
         <StepFormSection>
           <FormTitleSection>

--- a/packages/newsroom-manager/src/CreateCharterPartOne.tsx
+++ b/packages/newsroom-manager/src/CreateCharterPartOne.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-import { find, findIndex, findLastIndex } from "lodash";
+import { find, findIndex } from "lodash";
 import styled from "styled-components";
-import { isValidAddress } from "ethereumjs-util";
 import { colors, StepHeader, StepProps, StepDescription, QuestionToolTip } from "@joincivil/components";
 import { EthAddress, CharterData, RosterMember as RosterMemberInterface } from "@joincivil/core";
 import { isValidHttpUrl } from "@joincivil/utils";
@@ -225,9 +224,10 @@ class CreateCharterPartOneComponent extends React.Component<CreateCharterPartOne
 
   private addRosterMember = (e: any) => {
     e.preventDefault();
+    const newMember = {};
     this.props.updateCharter({
       ...this.props.charter,
-      roster: (this.props.charter.roster || []).concat({} as RosterMemberInterface),
+      roster: (this.props.charter.roster || []).concat(newMember as RosterMemberInterface),
     });
   };
 
@@ -236,7 +236,7 @@ class CreateCharterPartOneComponent extends React.Component<CreateCharterPartOne
     newVal: Partial<RosterMemberInterface>,
     deleteMember?: boolean,
   ) => {
-    let roster = (this.props.charter.roster || []).slice();
+    const roster = (this.props.charter.roster || []).slice();
 
     if (
       newVal.ethAddress &&

--- a/packages/newsroom-manager/src/NewsroomUser.tsx
+++ b/packages/newsroom-manager/src/NewsroomUser.tsx
@@ -11,11 +11,10 @@ import {
   ModalHeading,
   TransactionButtonInnerProps,
   ClipLoader,
-  QuestionToolTip,
 } from "@joincivil/components";
 import { EthAddress, NewsroomRoles, TxHash } from "@joincivil/core";
 import styled, { StyledComponentClass } from "styled-components";
-import { TertiaryButton as _TertiaryButton, FormSubhead } from "./styledComponents";
+import { TertiaryButton as _TertiaryButton, FormSubhead, QuestionToolTip } from "./styledComponents";
 import { StateWithNewsroom } from "./reducers";
 import { connect, DispatchProp } from "react-redux";
 import { CivilContext, CivilContextValue } from "./CivilContext";

--- a/packages/newsroom-manager/src/NewsroomUser.tsx
+++ b/packages/newsroom-manager/src/NewsroomUser.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
   colors,
+  fonts,
   Modal,
   Button,
   TransactionButtonNoModal,
@@ -38,13 +39,18 @@ const Wrapper: StyledComponentClass<{}, "div"> = styled.div`
   border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
 `;
 
+const Address = styled.p`
+  font-family: ${fonts.MONOSPACE};
+  letter-spacing: -0.15px;
+`;
+
 const NameSection = styled.div`
-  margin-right: 80px;
-  width: 120px;
+  margin-right: 20px;
+  width: 180px;
 `;
 
 const ButtonWrapper = styled.div`
-  width: 72px;
+  min-width: 72px;
   margin-left: 15px;
 `;
 
@@ -233,7 +239,7 @@ export class NewsroomUserComponent extends React.Component<
           </NameSection>
           <div>
             <FormSubhead>Wallet Address</FormSubhead>
-            <p>{this.props.address}</p>
+            <Address>{this.props.address}</Address>
           </div>
           <ButtonWrapper>
             {this.props.address !== this.props.profileWalletAddress &&

--- a/packages/newsroom-manager/src/NewsroomUser.tsx
+++ b/packages/newsroom-manager/src/NewsroomUser.tsx
@@ -11,6 +11,7 @@ import {
   ModalHeading,
   TransactionButtonInnerProps,
   ClipLoader,
+  QuestionToolTip,
 } from "@joincivil/components";
 import { EthAddress, NewsroomRoles, TxHash } from "@joincivil/core";
 import styled, { StyledComponentClass } from "styled-components";
@@ -222,7 +223,14 @@ export class NewsroomUserComponent extends React.Component<
         <Wrapper>
           <NameSection>
             <FormSubhead>Name</FormSubhead>
-            <p>{this.props.name || "Could not find a user with that address"}</p>
+            <p>
+              {this.props.name || (
+                <>
+                  <i>unknown address</i>
+                  <QuestionToolTip explainerText="No WordPress user was found with this address. If the owner of this address does have an account on your site, they will need to add it to their profile in order to use the Civil Publisher." />
+                </>
+              )}
+            </p>
           </NameSection>
           <div>
             <FormSubhead>Wallet Address</FormSubhead>

--- a/packages/newsroom-manager/src/actionCreators.ts
+++ b/packages/newsroom-manager/src/actionCreators.ts
@@ -152,15 +152,15 @@ export const updateCharter = (address: EthAddress, charter: Partial<CharterData>
   );
 };
 
-export const fetchNewsroom = (address: EthAddress): any => async (dispatch: any, getState: any): Promise<AnyAction> => {
+export const fetchNewsroom = (address: EthAddress): any => async (dispatch: any, getState: any) => {
   const { newsrooms }: StateWithNewsroom = getState();
   const newsroom = newsrooms.get(address);
   const wrapper = await newsroom.newsroom!.getNewsroomWrapper();
+  await dispatch(updateNewsroom(address, { ...newsroom, wrapper }));
   // might have additional owners now, so:
   wrapper.data.owners.forEach((userAddress: EthAddress) => {
     dispatch(initContractMember(address, userAddress));
   });
-  return dispatch(updateNewsroom(address, { ...newsroom, wrapper }));
 };
 
 export const addGetCmsUserDataForAddress = (func: (address: EthAddress) => Promise<CmsUserData>): AnyAction => {

--- a/packages/newsroom-manager/src/actionCreators.ts
+++ b/packages/newsroom-manager/src/actionCreators.ts
@@ -35,9 +35,8 @@ export const getEditors = (address: EthAddress, civil: Civil): any => async (
   dispatch: any,
   getState: any,
 ): Promise<void> => {
-  const state = getState();
   const newsroom = await civil.newsroomAtUntrusted(address);
-  await newsroom.editors().forEach(async val => {
+  newsroom.editors().forEach(val => {
     dispatch(initContractMember(address, val));
     dispatch(addEditor(address, val));
   });
@@ -49,7 +48,7 @@ export const getNewsroom = (address: EthAddress, civil: Civil): any => async (
 ): Promise<AnyAction> => {
   const newsroom = await civil.newsroomAtUntrusted(address);
   const wrapper = await newsroom.getNewsroomWrapper();
-  wrapper.data.owners.forEach(async (userAddress: EthAddress): Promise<void> => {
+  wrapper.data.owners.forEach((userAddress: EthAddress) => {
     dispatch(initContractMember(address, userAddress));
   });
   return dispatch(updateNewsroom(address, { wrapper, newsroom }));
@@ -158,7 +157,7 @@ export const fetchNewsroom = (address: EthAddress): any => async (dispatch: any,
   const newsroom = newsrooms.get(address);
   const wrapper = await newsroom.newsroom!.getNewsroomWrapper();
   // might have additional owners now, so:
-  wrapper.data.owners.forEach(async (userAddress: EthAddress): Promise<void> => {
+  wrapper.data.owners.forEach((userAddress: EthAddress) => {
     dispatch(initContractMember(address, userAddress));
   });
   return dispatch(updateNewsroom(address, { ...newsroom, wrapper }));

--- a/packages/newsroom-manager/src/actionCreators.ts
+++ b/packages/newsroom-manager/src/actionCreators.ts
@@ -157,6 +157,10 @@ export const fetchNewsroom = (address: EthAddress): any => async (dispatch: any,
   const { newsrooms }: StateWithNewsroom = getState();
   const newsroom = newsrooms.get(address);
   const wrapper = await newsroom.newsroom!.getNewsroomWrapper();
+  // might have additional owners now, so:
+  wrapper.data.owners.forEach(async (userAddress: EthAddress): Promise<void> => {
+    dispatch(initContractMember(address, userAddress));
+  });
   return dispatch(updateNewsroom(address, { ...newsroom, wrapper }));
 };
 

--- a/packages/newsroom-manager/src/reducers.ts
+++ b/packages/newsroom-manager/src/reducers.ts
@@ -89,7 +89,7 @@ export function newsroomUsers(
   action: AnyAction,
 ): Map<EthAddress, CmsUserData> {
   switch (action.type) {
-    case userActions.ADD_USER:
+    case userActions.STORE_USER_DATA:
       return state.set(action.data.address, action.data.userData);
     default:
       return state;

--- a/packages/newsroom-manager/src/styledComponents.tsx
+++ b/packages/newsroom-manager/src/styledComponents.tsx
@@ -1,4 +1,4 @@
-import { colors, fonts, Button, ButtonProps, TextInput, TextareaInput, InputProps } from "@joincivil/components";
+import { colors, fonts, Button, ButtonProps, TextInput, TextareaInput, InputProps, QuestionToolTip as _QuestionToolTip, ToolTipProps } from "@joincivil/components";
 // tslint:disable-next-line:no-unused-variable
 import * as React from "react"; // needed to export styled components
 import styled, { StyledComponentClass } from "styled-components";
@@ -91,4 +91,9 @@ export const StyledTextareaInput: StyledComponentClass<InputProps, any> = styled
     right: 15px;
     text-align: right;
   }
+`;
+
+export const QuestionToolTip = styled(_QuestionToolTip)`
+  position: relative;
+  top: 2px;
 `;

--- a/packages/newsroom-manager/src/styledComponents.tsx
+++ b/packages/newsroom-manager/src/styledComponents.tsx
@@ -1,4 +1,14 @@
-import { colors, fonts, Button, ButtonProps, TextInput, TextareaInput, InputProps, QuestionToolTip as _QuestionToolTip, ToolTipProps } from "@joincivil/components";
+import {
+  colors,
+  fonts,
+  Button,
+  ButtonProps,
+  TextInput,
+  TextareaInput,
+  InputProps,
+  QuestionToolTip as _QuestionToolTip,
+  ToolTipProps,
+} from "@joincivil/components";
 // tslint:disable-next-line:no-unused-variable
 import * as React from "react"; // needed to export styled components
 import styled, { StyledComponentClass } from "styled-components";
@@ -93,7 +103,7 @@ export const StyledTextareaInput: StyledComponentClass<InputProps, any> = styled
   }
 `;
 
-export const QuestionToolTip = styled(_QuestionToolTip)`
+export const QuestionToolTip: StyledComponentClass<ToolTipProps, any> = styled(_QuestionToolTip)`
   position: relative;
   top: 2px;
 `;


### PR DESCRIPTION
Various things that a) fix bugs, and b) should make probable transition to unified contract member/roster member interface smoother.

- Support roster members with no wallet address [ch2659]
- Ensure user data (name/bio/avatar/etc) is loaded properly for addresses that have just been added to contract [ch2689] [ch2690]
- Fix bug with duplicate members on roster [ch2674] and overall better/less buggy handling of relationship between contract members and roster members
- All contract members are now required to be on the roster
- Misc redux refactoring
- Some style/copy cleanup for contract members listing