### PR TITLE
Improve behavior of Top Nav User Drawer

### DIFF
--- a/packages/components/src/NavBar/NavBar.tsx
+++ b/packages/components/src/NavBar/NavBar.tsx
@@ -27,7 +27,7 @@ export class NavBar extends React.Component<NavProps, NavState> {
   constructor(props: NavProps) {
     super(props);
 
-    this.state = { isOpen: false };
+    this.state = { isUserDrawerOpen: false };
   }
 
   public render(): JSX.Element {
@@ -65,13 +65,13 @@ export class NavBar extends React.Component<NavProps, NavState> {
               </CvlContainer>
               <AvatarContainer>
                 <UserAvatar />
-                <Arrow isOpen={this.state.isOpen} />
+                <Arrow isOpen={this.state.isUserDrawerOpen} />
               </AvatarContainer>
             </NavUser>
           </NavInner>
 
           {this.props.userAccount &&
-            this.state.isOpen && (
+            this.state.isUserDrawerOpen && (
               <NavDrawer
                 balance={this.props.balance}
                 votingBalance={this.props.votingBalance}
@@ -83,6 +83,7 @@ export class NavBar extends React.Component<NavProps, NavState> {
                 buyCvlUrl={this.props.buyCvlUrl}
                 useGraphQL={this.props.useGraphQL}
                 onLoadingPrefToggled={this.props.onLoadingPrefToggled}
+                handleOutsideClick={this.hideUserDrawer}
               />
             )}
         </NavOuter>
@@ -91,6 +92,10 @@ export class NavBar extends React.Component<NavProps, NavState> {
   }
 
   private toggle = () => {
-    this.setState({ isOpen: !this.state.isOpen });
+    this.setState({ isUserDrawerOpen: !this.state.isUserDrawerOpen });
+  };
+
+  private hideUserDrawer = () => {
+    this.setState({ isUserDrawerOpen: false });
   };
 }

--- a/packages/components/src/NavBar/NavDrawer.tsx
+++ b/packages/components/src/NavBar/NavDrawer.tsx
@@ -44,6 +44,7 @@ export interface NavDrawerProps {
   buyCvlUrl?: string;
   useGraphQL: boolean;
   onLoadingPrefToggled(): void;
+  handleOutsideClick(): void;
 }
 
 class NavDrawerComponent extends React.Component<NavDrawerProps> {
@@ -139,13 +140,23 @@ export class NavDrawer extends React.Component<NavDrawerProps> {
 
   public componentDidMount(): void {
     document.body.appendChild(this.bucket);
+    document.addEventListener("mousedown", this.handleClick, false);
   }
 
   public componentWillUnmount(): void {
     document.body.removeChild(this.bucket);
+    document.removeEventListener("mousedown", this.handleClick, false);
   }
 
   public render(): React.ReactPortal {
     return ReactDOM.createPortal(<NavDrawerComponent {...this.props} />, this.bucket);
   }
+
+  private handleClick = (event: any) => {
+    if (this.bucket.contains(event.target)) {
+      return;
+    }
+
+    this.props.handleOutsideClick();
+  };
 }

--- a/packages/components/src/NavBar/types.ts
+++ b/packages/components/src/NavBar/types.ts
@@ -13,7 +13,7 @@ export interface NavProps {
 }
 
 export interface NavState {
-  isOpen: boolean;
+  isUserDrawerOpen: boolean;
 }
 
 export interface NavArrowProps {


### PR DESCRIPTION
Add event listener that closes the Top Nav User Drawer if the user clicks outside of the drawer.

Addresses issue #635 