### PR TITLE
Scroll user to top of window on navigation change, when applicable

### DIFF
--- a/packages/dapp/src/components/Dashboard/Dashboard.tsx
+++ b/packages/dapp/src/components/Dashboard/Dashboard.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import styled from "styled-components";
 import { UserDashboardHeader } from "@joincivil/components";
+
+import ScrollToTopOnMount from "../utility/ScrollToTop";
+
 import UserInfoSummary from "./UserInfoSummary";
 import DashboardActivity from "./DashboardActivity";
 
@@ -19,6 +22,7 @@ export interface DashboardProps {
 export const Dashboard: React.SFC<DashboardProps> = props => {
   return (
     <>
+      <ScrollToTopOnMount />
       <UserDashboardHeader>
         <UserInfoSummary />
       </UserDashboardHeader>

--- a/packages/dapp/src/components/Parameterizer/index.tsx
+++ b/packages/dapp/src/components/Parameterizer/index.tsx
@@ -37,6 +37,7 @@ import {
   ProcessProposal,
 } from "@joincivil/components";
 import { getFormattedParameterValue, Parameters, GovernmentParameters } from "@joincivil/utils";
+
 import { getCivil } from "../../helpers/civilInstance";
 import { State } from "../../redux/reducers";
 import ListingDiscourse from "../listing/ListingDiscourse";
@@ -48,6 +49,8 @@ import {
   updateReparameterizationProp,
 } from "../../apis/civilTCR";
 import { getIsMemberOfAppellate } from "../../selectors";
+import ScrollToTopOnMount from "../utility/ScrollToTop";
+
 import { amountParams, durationParams, percentParams } from "./constants";
 import { Parameter } from "./Parameter";
 import ChallengeContainer from "./ChallengeProposalDetail";
@@ -168,6 +171,7 @@ class Parameterizer extends React.Component<ParameterizerPageProps & DispatchPro
 
     return (
       <>
+        <ScrollToTopOnMount />
         <GridRow>
           <StyledTitle>Civil Registry Parameters</StyledTitle>
           <StyledDescriptionP>

--- a/packages/dapp/src/components/listing/Listing.tsx
+++ b/packages/dapp/src/components/listing/Listing.tsx
@@ -1,16 +1,20 @@
 import * as React from "react";
-import ListingReduxContainer from "./ListingReduxContainer";
-import ListingRedux from "./ListingRedux";
-import { State } from "../../redux/reducers";
 import { connect } from "react-redux";
 import { Query } from "react-apollo";
 import { EthAddress, ListingWrapper } from "@joincivil/core";
 import { NewsroomState } from "@joincivil/newsroom-manager";
+
+import { State } from "../../redux/reducers";
 import {
   LISTING_QUERY,
   transformGraphQLDataIntoNewsroom,
   transformGraphQLDataIntoListing,
 } from "../../helpers/queryTransformations";
+import ScrollToTopOnMount from "../utility/ScrollToTop";
+
+import ListingReduxContainer from "./ListingReduxContainer";
+import ListingRedux from "./ListingRedux";
+
 export interface ListingPageProps {
   match: any;
   listingAddress: EthAddress;
@@ -40,12 +44,22 @@ class ListingPageComponent extends React.Component<ListingPageProps & ListingPag
             }
             const newsroom = transformGraphQLDataIntoNewsroom(data.listing, this.props.listingAddress);
             const listing = transformGraphQLDataIntoListing(data.listing, this.props.listingAddress);
-            return <ListingRedux listingAddress={listingAddress} newsroom={newsroom} listing={listing} />;
+            return (
+              <>
+                <ScrollToTopOnMount />
+                <ListingRedux listingAddress={listingAddress} newsroom={newsroom} listing={listing} />
+              </>
+            );
           }}
         </Query>
       );
     } else {
-      return <ListingReduxContainer listingAddress={listingAddress} />;
+      return (
+        <>
+          <ScrollToTopOnMount />
+          <ListingReduxContainer listingAddress={listingAddress} />
+        </>
+      );
     }
   }
 }

--- a/packages/dapp/src/components/listing/RequestAppeal.tsx
+++ b/packages/dapp/src/components/listing/RequestAppeal.tsx
@@ -20,6 +20,7 @@ import {
   hasTransactionStatusModals,
   TransactionStatusModalContentMap,
 } from "../utility/TransactionStatusModalsHOC";
+import ScrollToTopOnMount from "../utility/ScrollToTop";
 
 export interface RequestAppealPageProps {
   match: any;
@@ -137,6 +138,7 @@ class RequestAppealComponent extends React.Component<
 
     return (
       <>
+        <ScrollToTopOnMount />
         {isInsufficientBalance &&
           appealFee && <InsufficientBalanceSnackBar minDeposit={appealFee} buyCVLURL="https://civil.co" />}
         <RequestAppealStatementComponent {...props} />

--- a/packages/dapp/src/components/listing/SubmitChallenge.tsx
+++ b/packages/dapp/src/components/listing/SubmitChallenge.tsx
@@ -20,6 +20,7 @@ import {
   hasTransactionStatusModals,
   TransactionStatusModalContentMap,
 } from "../utility/TransactionStatusModalsHOC";
+import ScrollToTopOnMount from "../utility/ScrollToTop";
 
 export interface SubmitChallengePageProps {
   match: any;
@@ -144,6 +145,7 @@ class SubmitChallengeComponent extends React.Component<
 
     return (
       <>
+        <ScrollToTopOnMount />
         {isInsufficientBalance &&
           minDeposit && <InsufficientBalanceSnackBar minDeposit={minDeposit!} buyCVLURL="https://civil.co" />}
         <SubmitChallengeStatementComponent {...props} />

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -12,12 +12,15 @@ import {
   RejectedNewsroomsTabText,
 } from "@joincivil/components";
 import { getFormattedTokenBalance } from "@joincivil/utils";
+
 import { getCivil } from "../../helpers/civilInstance";
 import * as heroImgUrl from "../images/img-hero-listings.png";
-import WhitelistedListingListContainer from "./WhitelistedListingListContainer";
-import RejectedListingListContainer from "./RejectedListingListContainer";
+import ScrollToTopOnMount from "../utility/ScrollToTop";
 import { State } from "../../redux/reducers";
 import { StyledPageContent, StyledListingCopy } from "../utility/styledComponents";
+
+import WhitelistedListingListContainer from "./WhitelistedListingListContainer";
+import RejectedListingListContainer from "./RejectedListingListContainer";
 import ListingsInProgressContainer from "./ListingsInProgressContainer";
 
 const TABS: string[] = ["whitelisted", "in-progress", "rejected"];
@@ -57,6 +60,7 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
     }
     return (
       <>
+        <ScrollToTopOnMount />
         {hero}
         {!this.props.loadingFinished && "loading..."}
         {this.props.loadingFinished && (

--- a/packages/dapp/src/components/utility/ScrollToTop.tsx
+++ b/packages/dapp/src/components/utility/ScrollToTop.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+class ScrollToTopOnMount extends React.Component {
+  public componentDidMount(): void {
+    window.scrollTo(0, 0);
+  }
+
+  public render(): null {
+    return null;
+  }
+}
+
+export default ScrollToTopOnMount;


### PR DESCRIPTION
Add helper component to scroll the user back to the top of the window when they navigate to views that need that behavior

Implemented per React Router's documentation suggestion:
https://reacttraining.com/react-router/web/guides/scroll-restoration

Addresses Issue #634 