### PR TITLE
Small Parameterizer UI cleanup

### DIFF
--- a/packages/core/src/contracts/tcr/parameterizer.ts
+++ b/packages/core/src/contracts/tcr/parameterizer.ts
@@ -33,6 +33,9 @@ export const enum Parameters {
   pDispensationPct = "pDispensationPct",
   voteQuorum = "voteQuorum",
   pVoteQuorum = "pVoteQuorum",
+  challengeAppealLen = "challengeAppealLen",
+  challengeAppealCommitLen = "challengeAppealCommitLen",
+  challengeAppealRevealLen = "challengeAppealRevealLen",
 }
 
 /**

--- a/packages/dapp/src/components/Parameterizer/constants.ts
+++ b/packages/dapp/src/components/Parameterizer/constants.ts
@@ -9,7 +9,6 @@ export const durationParams: string[] = [
   Parameters.pCommitStageLen,
   Parameters.revealStageLen,
   Parameters.pRevealStageLen,
-  Parameters.pProcessBy,
   Parameters.challengeAppealLen,
   Parameters.challengeAppealCommitLen,
   Parameters.challengeAppealRevealLen,

--- a/packages/dapp/src/components/Parameterizer/index.tsx
+++ b/packages/dapp/src/components/Parameterizer/index.tsx
@@ -120,7 +120,6 @@ export interface ParameterizerProps {
   [Parameters.pDispensationPct]: BigNumber;
   [Parameters.voteQuorum]: BigNumber;
   [Parameters.pVoteQuorum]: BigNumber;
-  [Parameters.pProcessBy]: BigNumber;
   [Parameters.challengeAppealLen]: BigNumber;
   [Parameters.challengeAppealCommitLen]: BigNumber;
   [Parameters.challengeAppealRevealLen]: BigNumber;

--- a/packages/utils/src/civilHelpers.ts
+++ b/packages/utils/src/civilHelpers.ts
@@ -85,7 +85,6 @@ export enum Parameters {
   pDispensationPct = "pDispensationPct",
   voteQuorum = "voteQuorum",
   pVoteQuorum = "pVoteQuorum",
-  pProcessBy = "pProcessBy",
   challengeAppealLen = "challengeAppealLen",
   challengeAppealCommitLen = "challengeAppealCommitLen",
   challengeAppealRevealLen = "challengeAppealRevealLen",

--- a/packages/utils/src/viewHelpers.tsx
+++ b/packages/utils/src/viewHelpers.tsx
@@ -105,7 +105,6 @@ export const durationParams: string[] = [
   Parameters.pCommitStageLen,
   Parameters.revealStageLen,
   Parameters.pRevealStageLen,
-  Parameters.pProcessBy,
   Parameters.challengeAppealLen,
   Parameters.challengeAppealCommitLen,
   Parameters.challengeAppealRevealLen,


### PR DESCRIPTION
- removing pProcessBy parameter where necessary since it's no longer a parameter, but rather a constant