### PR TITLE
Restore/add proper page `<title>` elements where applicable to the dapp

### DIFF
--- a/packages/dapp/src/components/Dashboard/Dashboard.tsx
+++ b/packages/dapp/src/components/Dashboard/Dashboard.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
+import { Helmet } from "react-helmet";
+
 import { UserDashboardHeader } from "@joincivil/components";
 
 import ScrollToTopOnMount from "../utility/ScrollToTop";
@@ -22,6 +24,9 @@ export interface DashboardProps {
 export const Dashboard: React.SFC<DashboardProps> = props => {
   return (
     <>
+      <Helmet>
+        <title>My Dashboard - The Civil Registry</title>
+      </Helmet>
       <ScrollToTopOnMount />
       <UserDashboardHeader>
         <UserInfoSummary />

--- a/packages/dapp/src/components/Parameterizer/index.tsx
+++ b/packages/dapp/src/components/Parameterizer/index.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import styled from "styled-components";
 import { connect, DispatchProp } from "react-redux";
 import { BigNumber } from "bignumber.js";
+import { Helmet } from "react-helmet";
+
 import { TwoStepEthTransaction, ParamProposalState } from "@joincivil/core";
 import {
   colors,
@@ -205,6 +207,9 @@ class Parameterizer extends React.Component<ParameterizerPageProps & DispatchPro
     return (
       <>
         <ScrollToTopOnMount />
+        <Helmet>
+          <title>Registry Parameters - The Civil Registry</title>
+        </Helmet>
         <GridRow>
           <StyledTitle>Civil Registry Parameters</StyledTitle>
           <StyledDescriptionP>

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -1,18 +1,8 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-import { EthAddress, ListingWrapper, NewsroomWrapper, CharterData } from "@joincivil/core";
+import { Helmet } from "react-helmet";
 
-import ListingOwnerActions from "./ListingOwnerActions";
-import ListingDiscourse from "./ListingDiscourse";
-import ListingHistory from "./ListingHistory";
-import ListingHeader from "./ListingHeader";
-import ListingCharter from "./ListingCharter";
-import ListingPhaseActions from "./ListingPhaseActions";
-import ListingChallengeStatement from "./ListingChallengeStatement";
-import { State } from "../../redux/reducers";
-import { fetchAndAddListingData, setupListingHistorySubscription } from "../../redux/actionCreators/listings";
-import { getListingPhaseState, makeGetListingExpiry, getIsUserNewsroomOwner } from "../../selectors";
-import { ListingTabContent } from "./styledComponents";
+import { EthAddress, ListingWrapper, NewsroomWrapper, CharterData } from "@joincivil/core";
 import {
   Tabs,
   Tab,
@@ -21,7 +11,20 @@ import {
   StyledLeftContentWell,
   StyledRightContentWell,
 } from "@joincivil/components";
+
+import { State } from "../../redux/reducers";
+import { fetchAndAddListingData, setupListingHistorySubscription } from "../../redux/actionCreators/listings";
+import { getListingPhaseState, makeGetListingExpiry, getIsUserNewsroomOwner } from "../../selectors";
 import { getContent } from "../../redux/actionCreators/newsrooms";
+
+import ListingOwnerActions from "./ListingOwnerActions";
+import ListingDiscourse from "./ListingDiscourse";
+import ListingHistory from "./ListingHistory";
+import ListingHeader from "./ListingHeader";
+import ListingCharter from "./ListingCharter";
+import ListingPhaseActions from "./ListingPhaseActions";
+import ListingChallengeStatement from "./ListingChallengeStatement";
+import { ListingTabContent } from "./styledComponents";
 
 export interface ListingPageComponentProps {
   listingAddress: EthAddress;
@@ -73,6 +76,10 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
       <>
         {listingExistsAsNewsroom && (
           <>
+            <Helmet>
+              <title>{newsroom!.data.name} - The Civil Registry</title>
+            </Helmet>
+
             <ListingHeader
               userAccount={this.props.userAccount}
               listing={listing!}

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { connect } from "react-redux";
+import { Helmet } from "react-helmet";
+
 import {
   Hero,
   HomepageHero,
@@ -72,6 +74,9 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
           >
             <Tab title={<ApprovedNewsroomsTabText />}>
               <StyledPageContent>
+                <Helmet>
+                  <title>The Civil Registry - Participate in credible, trustworthy journalism</title>
+                </Helmet>
                 <StyledListingCopy>
                   All approved Newsrooms should align with the Civil Constitution, and are subject to Civil community
                   review. By participating in our governance, you can help curate high-quality, trustworthy journalism.
@@ -86,6 +91,9 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
             </Tab>
             <Tab title={<RejectedNewsroomsTabText />}>
               <StyledPageContent>
+                <Helmet>
+                  <title>Rejected Newsrooms - The Civil Registry</title>
+                </Helmet>
                 <StyledListingCopy>
                   Rejected Newsrooms have been removed from the Civil Registry due to a breach of the Civil
                   Constitution. Rejected Newsrooms can reapply to the Registry at any time. Learn how to reapply.

--- a/packages/dapp/src/components/listinglist/ListingsInProgress.tsx
+++ b/packages/dapp/src/components/listinglist/ListingsInProgress.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
+import { Helmet } from "react-helmet";
 import { Set } from "immutable";
+
+import { NewsroomListing } from "@joincivil/core";
 import {
   Tabs,
   Tab,
@@ -14,10 +17,10 @@ import {
   ListingSummaryReadyToUpdateComponent,
 } from "@joincivil/components";
 
+import { StyledListingCopy } from "../utility/styledComponents";
+
 import ListingList from "./ListingList";
 import { EmptyRegistryTabContentComponent, REGISTRY_PHASE_TAB_TYPES } from "./EmptyRegistryTabContent";
-import { StyledListingCopy } from "../utility/styledComponents";
-import { NewsroomListing } from "@joincivil/core";
 
 export interface ListingProps {
   match?: any;
@@ -82,6 +85,9 @@ class ListingsInProgress extends React.Component<ListingProps & ListingsInProgre
       >
         <Tab title={newApplicationsTab}>
           <>
+            <Helmet>
+              <title>New Applications - The Civil Registry</title>
+            </Helmet>
             <StyledListingCopy>
               New applications are subject to Civil community review for alignment with the Civil Constitution. By
               participating in our governance, you can help curate high-quality, trustworthy journalism.
@@ -91,6 +97,10 @@ class ListingsInProgress extends React.Component<ListingProps & ListingsInProgre
         </Tab>
         <Tab title={underChallengeTab}>
           <>
+            <Helmet>
+              <title>Newsrooms Under Challenge - The Civil Registry</title>
+            </Helmet>
+
             <StyledListingCopy>
               Applications “under challenge” require the Civil community vote to remain on the Registry due to a
               potential breach of the Civil Constitution. Help us curate high quality, trustworthy journalism, and earn
@@ -101,6 +111,9 @@ class ListingsInProgress extends React.Component<ListingProps & ListingsInProgre
         </Tab>
         <Tab title={appealToCouncilTab}>
           <>
+            <Helmet>
+              <title>Newsrooms Under Appeal - The Civil Registry</title>
+            </Helmet>
             <StyledListingCopy>
               Appeal to the Civil Council has been requested for these Newsrooms. The Civil Council will review whether
               these Newsrooms breached the Civil Constitution, and a decision will be announced X days after the appeal
@@ -111,6 +124,9 @@ class ListingsInProgress extends React.Component<ListingProps & ListingsInProgre
         </Tab>
         <Tab title={challengeCouncilAppealTab}>
           <>
+            <Helmet>
+              <title>Newsrooms Under Appeal Challenge - The Civil Registry</title>
+            </Helmet>
             <StyledListingCopy>
               Newsrooms under “Challenge Council Appeal” require the Civil community's vote to veto the Council decision
               in order to remain on the Registry. Help us curate high quality, trustworthy journalism, and earn CVL
@@ -121,6 +137,9 @@ class ListingsInProgress extends React.Component<ListingProps & ListingsInProgre
         </Tab>
         <Tab title={readyToUpdateTab}>
           <>
+            <Helmet>
+              <title>Newsrooms Ready To Update - The Civil Registry</title>
+            </Helmet>
             <StyledListingCopy>
               The Civil community has spoken and the vote results are in. However, in order for the decision to take
               effect, the status of the newsroom must be updated. Thank you for helping the community curate


### PR DESCRIPTION
This update adds (or restores) basic page titles, for improved usability. These page titles are also used by Coral Talk's admin interface that lists threads that need moderation.

Addresses issue #672 