### PR TITLE
GraphQL Network Updates

### DIFF
--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -7,7 +7,7 @@ import { connect, DispatchProp } from "react-redux";
 import { Route, RouteComponentProps, Switch, withRouter } from "react-router-dom";
 import { setNetwork, setNetworkName } from "../redux/actionCreators/network";
 import { addUser } from "../redux/actionCreators/userAccount";
-import { getCivil } from "../helpers/civilInstance";
+import { getCivil, isGraphQLSupportedOnNetwork } from "../helpers/civilInstance";
 import {
   initializeGovernment,
   initializeGovernmentParamSubscription,
@@ -29,7 +29,7 @@ import Parameterizer from "./Parameterizer";
 import Government from "./council/Government";
 import SubmitChallengePage from "./listing/SubmitChallenge";
 import RequestAppealPage from "./listing/RequestAppeal";
-import { initialize } from "../redux/actionCreators/ui";
+import { initialize, disableGraphQL } from "../redux/actionCreators/ui";
 
 class Main extends React.Component<DispatchProp<any> & RouteComponentProps<any>> {
   public async componentDidMount(): Promise<void> {
@@ -41,6 +41,9 @@ class Main extends React.Component<DispatchProp<any> & RouteComponentProps<any>>
 
   public onNetworkUpdated = async (civil: Civil, network: number): Promise<void> => {
     this.props.dispatch!(setNetwork(network.toString()));
+    if (!isGraphQLSupportedOnNetwork(network.toString())) {
+      this.props.dispatch!(disableGraphQL());
+    }
 
     await civil.accountStream.first().forEach(this.onAccountUpdated.bind(this, civil));
     try {

--- a/packages/dapp/src/helpers/civilInstance.ts
+++ b/packages/dapp/src/helpers/civilInstance.ts
@@ -37,3 +37,15 @@ export const getTCR = async () => {
   }
   return tcr;
 };
+
+export const isGraphQLSupportedOnNetwork = (network: string): boolean => {
+  if (network === "1") {
+    // mainnet
+    return false; // TODO: should be true once production tcr is deployed with graphql support
+  } else if (network === "4") {
+    // rinkeby
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/packages/dapp/src/redux/actionCreators/ui.ts
+++ b/packages/dapp/src/redux/actionCreators/ui.ts
@@ -2,11 +2,14 @@ import { AnyAction } from "redux";
 import { Dispatch } from "react-redux";
 import { clearListingSubscriptions, initializeSubscriptions } from "../../helpers/listingEvents";
 import { clearAllListingData } from "./listings";
+import { isGraphQLSupportedOnNetwork } from "../../helpers/civilInstance";
 
 export enum uiActions {
   ADD_OR_UPDATE_UI_STATE = "ADD_OR_UPDATE_UI_STATE",
   SET_LOADING_FINISHED = "SET_LOADING_FINISHED",
   TOGGLE_USE_GRAPH_QL = "TOGGLE_USE_GRAPH_QL",
+  DISABLE_GRAPHL_QL = "DISABLE_GRAPH_QL",
+  TRIED_TO_ENABLE_GRAPH_QL_ON_UNSUPPORTED_NETWORK = "TRIED_TO_ENABLE_GRAPH_QL_ON_UNSUPPORTED_NETWORK",
 }
 
 export const addOrUpdateUIState = (key: string, value: any): AnyAction => {
@@ -27,23 +30,38 @@ export const initialize = async (): Promise<any> => {
   };
 };
 
-export const toggleUseGraphQL = async (): Promise<any> => {
-  return async (dispatch: Dispatch<any>, getState: any): Promise<AnyAction> => {
-    const { useGraphQL } = getState();
-
-    if (!useGraphQL) {
-      // going to graphQL loading
-      clearListingSubscriptions();
-      dispatch(clearAllListingData());
-    } else {
-      // going to web3 loading
-      await initializeSubscriptions(dispatch);
-    }
-    return dispatch(toggleUseGraphQLSimple());
+export const disableGraphQL = (): AnyAction => {
+  return {
+    type: uiActions.DISABLE_GRAPHL_QL,
   };
 };
 
-export const toggleUseGraphQLSimple = (): any => {
+export const toggleUseGraphQL = async (): Promise<any> => {
+  return async (dispatch: Dispatch<any>, getState: any): Promise<AnyAction> => {
+    const { useGraphQL, network } = getState();
+    if (isGraphQLSupportedOnNetwork(network)) {
+      if (!useGraphQL) {
+        // going to graphQL loading
+        clearListingSubscriptions();
+        dispatch(clearAllListingData());
+      } else {
+        // going to web3 loading
+        await initializeSubscriptions(dispatch);
+      }
+      return dispatch(toggleUseGraphQLSimple());
+    } else {
+      return dispatch(triedToEnableGraphQL()); // if network is not supported, graphql current disabled and cannot be enabled
+    }
+  };
+};
+
+export const triedToEnableGraphQL = (): AnyAction => {
+  return {
+    type: uiActions.TRIED_TO_ENABLE_GRAPH_QL_ON_UNSUPPORTED_NETWORK,
+  };
+};
+
+export const toggleUseGraphQLSimple = (): AnyAction => {
   return {
     type: uiActions.TOGGLE_USE_GRAPH_QL,
   };

--- a/packages/dapp/src/redux/reducers/network.ts
+++ b/packages/dapp/src/redux/reducers/network.ts
@@ -1,7 +1,7 @@
 import { AnyAction } from "redux";
 import { networkActions } from "../actionCreators/network";
 
-export function network(state: string = "0", action: AnyAction): string {
+export function network(state: string = "4", action: AnyAction): string {
   switch (action.type) {
     case networkActions.SET_NETWORK:
       return action.data;
@@ -10,7 +10,7 @@ export function network(state: string = "0", action: AnyAction): string {
   }
 }
 
-export function networkName(state: string = "0", action: AnyAction): string {
+export function networkName(state: string = "rinkeby", action: AnyAction): string {
   switch (action.type) {
     case networkActions.SET_NETWORK_NAME:
       return action.data;

--- a/packages/dapp/src/redux/reducers/ui.ts
+++ b/packages/dapp/src/redux/reducers/ui.ts
@@ -15,6 +15,8 @@ export function useGraphQL(state: boolean = true, action: AnyAction): boolean {
   switch (action.type) {
     case uiActions.TOGGLE_USE_GRAPH_QL:
       return !state;
+    case uiActions.DISABLE_GRAPHL_QL:
+      return false;
     default:
       return state;
   }


### PR DESCRIPTION
- set default network to rinkeby instead of "0". 
- when network changes, disable graphql if it's not supported
- prevent toggling graphql on if network not supported.