### PR TITLE
Fix text for Request Appeal form

### DIFF
--- a/packages/components/src/UserStatement/RequestAppealStatement.tsx
+++ b/packages/components/src/UserStatement/RequestAppealStatement.tsx
@@ -93,7 +93,7 @@ export class RequestAppealStatement extends React.Component<RequestAppealStateme
 
             <SectionForm>
               <SectionFormHeader>
-                Write 1-2 sentences about why you’re challenging this newsroom (required)
+                Write 1-2 sentences about why you’re appealing this challenge (required)
               </SectionFormHeader>
               <SectionFormCopyHelper>Max character limit: {SUMMARY_MAX_LENGTH.toString()}</SectionFormCopyHelper>
 

--- a/packages/components/src/UserStatement/RequestAppealStatement.tsx
+++ b/packages/components/src/UserStatement/RequestAppealStatement.tsx
@@ -45,7 +45,6 @@ export interface RequestAppealStatementProps {
 
 export interface RequestAppealStatementState {
   summaryValue: string;
-  citeConstitutionValue: any;
   detailsValue: any;
 }
 
@@ -56,7 +55,6 @@ export class RequestAppealStatement extends React.Component<RequestAppealStateme
     super(props);
     this.state = {
       summaryValue: "",
-      citeConstitutionValue: RichTextEditor.createEmptyValue(),
       detailsValue: RichTextEditor.createEmptyValue(),
     };
   }
@@ -99,29 +97,10 @@ export class RequestAppealStatement extends React.Component<RequestAppealStateme
 
               <StyledTextareaContainer>
                 <TextareaInput
-                  name="challenge_statement_summary"
+                  name="request_appeal_statement_summary"
                   value={this.state.summaryValue}
                   onChange={this.handleSummaryValueChange}
                   maxLength={SUMMARY_MAX_LENGTH.toString()}
-                />
-              </StyledTextareaContainer>
-            </SectionForm>
-
-            <SectionForm>
-              <SectionFormHeader>
-                Please cite the section or principles of the Civil Constitution that you believe the Newsroom has
-                violated. (required)
-              </SectionFormHeader>
-              <SectionFormCopyHelper>
-                <StyledLink href={this.props.constitutionURI} target="_blank">
-                  See Civil Constitution
-                </StyledLink>
-              </SectionFormCopyHelper>
-
-              <StyledTextareaContainer>
-                <RichTextEditor
-                  value={this.state.citeConstitutionValue}
-                  onChange={this.handleCiteConstitutionValueChange}
                 />
               </StyledTextareaContainer>
             </SectionForm>
@@ -169,12 +148,11 @@ export class RequestAppealStatement extends React.Component<RequestAppealStateme
   }
 
   private isFormInvalid = (): boolean => {
-    const { summaryValue, citeConstitutionValue, detailsValue } = this.state;
+    const { summaryValue, detailsValue } = this.state;
     const citeConstitution = document.createElement("div");
-    citeConstitution.innerHTML = citeConstitutionValue.toString("html");
     const details = document.createElement("div");
     details.innerHTML = detailsValue.toString("html");
-    return !summaryValue || !summaryValue.length || !citeConstitution.innerText.length || !details.innerText.length;
+    return !summaryValue || !summaryValue.length || !details.innerText.length;
   };
 
   private renderHelperMessage = (): JSX.Element => {
@@ -187,11 +165,6 @@ export class RequestAppealStatement extends React.Component<RequestAppealStateme
   private handleSummaryValueChange = (name: string, summaryValue: string) => {
     this.setState({ summaryValue });
     this.props.updateStatementValue("summary", summaryValue);
-  };
-
-  private handleCiteConstitutionValueChange = (citeConstitutionValue: any) => {
-    this.setState({ citeConstitutionValue });
-    this.props.updateStatementValue("citeConstitution", citeConstitutionValue);
   };
 
   private handleDetailsValueChange = (detailsValue: any) => {

--- a/packages/components/src/UserStatement/RequestAppealStatement.tsx
+++ b/packages/components/src/UserStatement/RequestAppealStatement.tsx
@@ -149,7 +149,6 @@ export class RequestAppealStatement extends React.Component<RequestAppealStateme
 
   private isFormInvalid = (): boolean => {
     const { summaryValue, detailsValue } = this.state;
-    const citeConstitution = document.createElement("div");
     const details = document.createElement("div");
     details.innerHTML = detailsValue.toString("html");
     return !summaryValue || !summaryValue.length || !details.innerText.length;

--- a/packages/components/src/UserStatement/SubmitAppealChallengeStatement.tsx
+++ b/packages/components/src/UserStatement/SubmitAppealChallengeStatement.tsx
@@ -46,7 +46,6 @@ export interface SubmitAppealChallengeStatementProps {
 
 export interface SubmitAppealChallengeStatementState {
   summaryValue: string;
-  citeConstitutionValue: any;
   detailsValue: any;
 }
 
@@ -60,7 +59,6 @@ export class SubmitAppealChallengeStatement extends React.Component<
     super(props);
     this.state = {
       summaryValue: "",
-      citeConstitutionValue: RichTextEditor.createEmptyValue(),
       detailsValue: RichTextEditor.createEmptyValue(),
     };
   }
@@ -100,35 +98,16 @@ export class SubmitAppealChallengeStatement extends React.Component<
 
             <SectionForm>
               <SectionFormHeader>
-                Write 1-2 sentences about why you’re challenging this newsroom (required)
+                Write 1-2 sentences about why you’re challenging this granted appeal (required)
               </SectionFormHeader>
               <SectionFormCopyHelper>Max character limit: {SUMMARY_MAX_LENGTH.toString()}</SectionFormCopyHelper>
 
               <StyledTextareaContainer>
                 <TextareaInput
-                  name="challenge_statement_summary"
+                  name="appeal_challenge_statement_summary"
                   value={this.state.summaryValue}
                   onChange={this.handleSummaryValueChange}
                   maxLength={SUMMARY_MAX_LENGTH.toString()}
-                />
-              </StyledTextareaContainer>
-            </SectionForm>
-
-            <SectionForm>
-              <SectionFormHeader>
-                Please cite the section or principles of the Civil Constitution that you believe the Newsroom has
-                violated. (required)
-              </SectionFormHeader>
-              <SectionFormCopyHelper>
-                <StyledLink href={this.props.constitutionURI} target="_blank">
-                  See Civil Constitution
-                </StyledLink>
-              </SectionFormCopyHelper>
-
-              <StyledTextareaContainer>
-                <RichTextEditor
-                  value={this.state.citeConstitutionValue}
-                  onChange={this.handleCiteConstitutionValueChange}
                 />
               </StyledTextareaContainer>
             </SectionForm>
@@ -178,22 +157,15 @@ export class SubmitAppealChallengeStatement extends React.Component<
   }
 
   private isFormInvalid = (): boolean => {
-    const { summaryValue, citeConstitutionValue, detailsValue } = this.state;
-    const citeConstitution = document.createElement("div");
-    citeConstitution.innerHTML = citeConstitutionValue.toString("html");
+    const { summaryValue, detailsValue } = this.state;
     const details = document.createElement("div");
     details.innerHTML = detailsValue.toString("html");
-    return !summaryValue || !summaryValue.length || !citeConstitution.innerText.length || !details.innerText.length;
+    return !summaryValue || !summaryValue.length || !details.innerText.length;
   };
 
   private handleSummaryValueChange = (name: string, summaryValue: string) => {
     this.setState({ summaryValue });
     this.props.updateStatementValue("summary", summaryValue);
-  };
-
-  private handleCiteConstitutionValueChange = (citeConstitutionValue: any) => {
-    this.setState({ citeConstitutionValue });
-    this.props.updateStatementValue("citeConstitution", citeConstitutionValue);
   };
 
   private handleDetailsValueChange = (detailsValue: any) => {

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -25,6 +25,7 @@ export interface ListingChallengeStatementProps {
 export interface ListingChallengeStatementReduxProps {
   appealStatement: any;
   challengeStatement?: any;
+  appealChallengeStatement?: any;
 }
 
 class ListingChallengeStatement extends React.Component<
@@ -50,6 +51,7 @@ class ListingChallengeStatement extends React.Component<
       <>
         {this.renderChallengeStatement()}
         {this.renderAppealStatement()}
+        {this.renderAppealChallengeStatement()}
       </>
     );
   }
@@ -71,9 +73,6 @@ class ListingChallengeStatement extends React.Component<
     }
     const parsed = JSON.parse(this.props.appealStatement);
     const summary = parsed.summary;
-    const cleanCiteConstitution = sanitizeHtml(parsed.citeConstitution, {
-      allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(["bzz"]),
-    });
     const cleanDetails = sanitizeHtml(parsed.details, {
       allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(["bzz"]),
     });
@@ -85,10 +84,6 @@ class ListingChallengeStatement extends React.Component<
         <StyledChallengeStatementSection>
           <b>Summary</b>
           <div>{summary}</div>
-        </StyledChallengeStatementSection>
-        <StyledChallengeStatementSection>
-          <b>Evidence From Civil Constitution</b>
-          <div dangerouslySetInnerHTML={{ __html: cleanCiteConstitution }} />
         </StyledChallengeStatementSection>
         <StyledChallengeStatementSection>
           <b>Additional Details</b>
@@ -137,6 +132,36 @@ class ListingChallengeStatement extends React.Component<
       </StyledChallengeStatementComponent>
     );
   };
+
+  private renderAppealChallengeStatement = (): JSX.Element => {
+    if (!this.props.appealChallengeStatement) {
+      return <></>;
+    }
+    const parsed = JSON.parse(this.props.appealChallengeStatement);
+    const summary = parsed.summary || "";
+    const cleanDetails = parsed.details
+      ? sanitizeHtml(parsed.details, {
+          allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(["bzz"]),
+        })
+      : "";
+    return (
+      <StyledChallengeStatementComponent>
+        <ListingTabHeading>Newsroom listing is under challenge</ListingTabHeading>
+        <p>
+          Should the granted appeal be overturned? Read the challenger’s statement below and vote with your CVL tokens.
+        </p>
+        <ListingTabHeading>Appeal Challenge Statement</ListingTabHeading>
+        <StyledChallengeStatementSection>
+          <b>Summary</b>
+          <div>{summary}</div>
+        </StyledChallengeStatementSection>
+        <StyledChallengeStatementSection>
+          <b>Additional Details</b>
+          <div dangerouslySetInnerHTML={{ __html: cleanDetails }} />
+        </StyledChallengeStatementSection>
+      </StyledChallengeStatementComponent>
+    );
+  };
 }
 
 const mapToStateToProps = (
@@ -147,17 +172,23 @@ const mapToStateToProps = (
   const { content } = state.networkDependent;
   let challengeStatement: any = "";
   let appealStatement: any = "";
+  let appealChallengeStatement: any = "";
   if (challenge) {
     challengeStatement = content.get(challenge.challenge.challengeStatementURI!);
 
     if (challenge.challenge.appeal) {
       appealStatement = content.get(challenge.challenge.appeal.appealStatementURI!);
+
+      if (challenge.challenge.appeal.appealChallenge) {
+        appealChallengeStatement = content.get(challenge.challenge.appeal.appealChallenge.appealChallengeStatementURI!);
+      }
     }
   }
   return {
     ...ownProps,
     challengeStatement,
     appealStatement,
+    appealChallengeStatement,
   };
 };
 

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -71,6 +71,7 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
     const listing = this.props.listing;
     const newsroom = this.props.newsroom;
     const listingExistsAsNewsroom = listing && newsroom;
+    const activeTab = listing && listing.data.challenge ? 1 : 0;
 
     return (
       <>
@@ -108,7 +109,7 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
           <StyledLeftContentWell>
             {!listingExistsAsNewsroom && this.renderListingNotFound()}
 
-            <Tabs TabComponent={StyledTab}>
+            <Tabs TabComponent={StyledTab} activeIndex={activeTab}>
               {(listingExistsAsNewsroom && (
                 <Tab title="About">
                   <ListingTabContent>

--- a/packages/dapp/src/components/listing/RequestAppeal.tsx
+++ b/packages/dapp/src/components/listing/RequestAppeal.tsx
@@ -45,7 +45,6 @@ interface RequestAppealReduxProps {
 
 interface RequestAppealState {
   appealStatementSummaryValue?: string;
-  appealStatementCiteConstitutionValue?: any;
   appealStatementDetailsValue?: any;
 }
 
@@ -220,14 +219,9 @@ class RequestAppealComponent extends React.Component<
 
   // Transactions
   private appeal = async (): Promise<TwoStepEthTransaction<any>> => {
-    const {
-      appealStatementSummaryValue,
-      appealStatementCiteConstitutionValue,
-      appealStatementDetailsValue,
-    } = this.state;
+    const { appealStatementSummaryValue, appealStatementDetailsValue } = this.state;
     const jsonToSave = {
       summary: appealStatementSummaryValue,
-      citeConstitution: appealStatementCiteConstitutionValue.toString("html"),
       details: appealStatementDetailsValue.toString("html"),
     };
     return appealChallenge(this.props.listingAddress, JSON.stringify(jsonToSave));


### PR DESCRIPTION
Addresses #519 

Additionally, this update:

- fixes the rendering of Appeal Statement and Appeal Challenge Statement in the DApp
- makes the 'Discussions' tab the initially active tab, if a challenge is active for the listing