### PR TITLE
Various Dapp bug fixes

### DIFF
--- a/packages/components/src/FullscreenModal.tsx
+++ b/packages/components/src/FullscreenModal.tsx
@@ -13,7 +13,7 @@ export const ModalWrapper = styled.div`
   left: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.4);
-  z-index: 1;
+  z-index: 2;
 `;
 
 export const ModalInner = styled.div`

--- a/packages/components/src/ListingDetailPhaseCard/CommitVote.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/CommitVote.tsx
@@ -233,6 +233,12 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
   };
 
   private setNumTokens = (name: string, value: string | null): void => {
+    let cleanValue = value && parseFloat(value);
+    if (cleanValue) {
+      cleanValue = Math.abs(cleanValue as number);
+      this.props.onInputChange({ numTokens: cleanValue });
+      return;
+    }
     this.props.onInputChange({ numTokens: value });
   };
 

--- a/packages/dapp/src/components/listing/AppealChallengeCommitVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeCommitVote.tsx
@@ -100,7 +100,6 @@ class AppealChallengeCommitVote extends React.Component<
     this.state = {
       isReviewVoteModalOpen: false,
       voteOption: undefined,
-      salt: fetchSalt(this.props.challengeID, this.props.user),
       numTokens: undefined,
       key: new Date().valueOf(),
     };
@@ -127,6 +126,7 @@ class AppealChallengeCommitVote extends React.Component<
     const votingTokenBalanceDisplay = this.props.votingBalance
       ? getFormattedTokenBalance(this.props.votingBalance)
       : "";
+    const salt = fetchSalt(this.props.challengeID, this.props.user);
 
     const userHasCommittedVote =
       this.props.userAppealChallengeData && !!this.props.userAppealChallengeData.didUserCommit;
@@ -162,7 +162,7 @@ class AppealChallengeCommitVote extends React.Component<
       votingTokenBalance,
       tokenBalanceDisplay,
       votingTokenBalanceDisplay,
-      salt: this.state.salt,
+      salt,
       numTokens: this.state.numTokens,
       onInputChange: this.updateCommitVoteState,
       onReviewVote: this.handleReviewVote,
@@ -200,12 +200,14 @@ class AppealChallengeCommitVote extends React.Component<
 
     const listingDetailURL = `https://${window.location.hostname}/listing/${this.props.listingAddress}`;
 
+    const salt = fetchSalt(this.props.challengeID, this.props.user);
+
     const props: ReviewVoteProps = {
       newsroomName: "this newsroom",
       listingDetailURL,
       challengeID: this.props.appealChallengeID.toString(),
       open: this.state.isReviewVoteModalOpen,
-      salt: this.state.salt,
+      salt,
       numTokens: this.state.numTokens,
       voteOption: this.state.voteOption,
       userAccount: this.props.user,
@@ -302,7 +304,8 @@ class AppealChallengeCommitVote extends React.Component<
 
   private commitVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
     const voteOption: BigNumber = new BigNumber(this.state.voteOption as string);
-    const salt: BigNumber = new BigNumber(this.state.salt as string);
+    const saltStr = fetchSalt(this.props.challengeID, this.props.user);
+    const salt: BigNumber = new BigNumber(saltStr as string);
     const numTokens: BigNumber = new BigNumber(this.state.numTokens as string).mul(1e18);
     saveVote(this.props.challengeID, this.props.user, voteOption);
     return commitVote(this.props.challengeID, voteOption, salt, numTokens);

--- a/packages/dapp/src/components/listing/AppealChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeDetail.tsx
@@ -31,7 +31,6 @@ export interface AppealChallengeDetailProps {
 
 export interface ChallengeVoteState {
   voteOption?: string;
-  salt?: string;
   numTokens?: string;
   isReviewVoteModalOpen: boolean;
 }

--- a/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
@@ -60,15 +60,8 @@ class AppealChallengeRevealVote extends React.Component<
 > {
   constructor(props: AppealChallengeDetailProps & InjectedTransactionStatusModalProps) {
     super(props);
-    const fetchedVote = fetchVote(this.props.challengeID, this.props.user);
-    let voteOption;
-    if (fetchedVote) {
-      voteOption = fetchedVote.toString();
-    }
     this.state = {
       isReviewVoteModalOpen: false,
-      voteOption,
-      salt: fetchSalt(this.props.challengeID, this.props.user), // TODO(jorgelo): This should probably be in redux.
       numTokens: undefined,
     };
   }
@@ -136,6 +129,9 @@ class AppealChallengeRevealVote extends React.Component<
       .mul(100)
       .toFixed(0);
 
+    const voteOption = this.getVoteOption();
+    const salt = fetchSalt(this.props.challengeID, this.props.user);
+
     return (
       <>
         <AppealChallengeRevealVoteCard
@@ -148,8 +144,8 @@ class AppealChallengeRevealVote extends React.Component<
           userHasRevealedVote={userHasRevealedVote}
           userHasCommittedVote={userHasCommittedVote}
           stake={stake}
-          voteOption={this.state.voteOption}
-          salt={this.state.salt}
+          voteOption={voteOption}
+          salt={salt}
           totalVotes={getFormattedTokenBalance(totalVotes)}
           votesFor={votesFor}
           votesAgainst={votesAgainst}
@@ -216,9 +212,19 @@ class AppealChallengeRevealVote extends React.Component<
     ];
   };
 
+  private getVoteOption(): string | undefined {
+    const fetchedVote = fetchVote(this.props.challengeID, this.props.user);
+    let voteOption;
+    if (fetchedVote) {
+      voteOption = fetchedVote.toString();
+    }
+    return voteOption;
+  }
+
   private revealVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
-    const voteOption: BigNumber = new BigNumber(this.state.voteOption as string);
-    const salt: BigNumber = new BigNumber(this.state.salt as string);
+    const voteOption: BigNumber = new BigNumber(this.getVoteOption() as string);
+    const saltStr = fetchSalt(this.props.challengeID, this.props.user);
+    const salt: BigNumber = new BigNumber(saltStr as string);
     return revealVote(this.props.challengeID, voteOption, salt);
   };
 

--- a/packages/dapp/src/components/listing/ChallengeCommitVote.tsx
+++ b/packages/dapp/src/components/listing/ChallengeCommitVote.tsx
@@ -99,7 +99,6 @@ class ChallengeCommitVote extends React.Component<
     this.state = {
       isReviewVoteModalOpen: false,
       voteOption: undefined,
-      salt: fetchSalt(this.props.challengeID, this.props.user),
       numTokens: undefined,
       key: new Date().valueOf(),
     };
@@ -124,6 +123,7 @@ class ChallengeCommitVote extends React.Component<
     if (!challenge) {
       return null;
     }
+    const salt = fetchSalt(this.props.challengeID, this.props.user);
     const props = {
       endTime,
       phaseLength,
@@ -140,7 +140,7 @@ class ChallengeCommitVote extends React.Component<
       votingTokenBalance,
       tokenBalanceDisplay,
       votingTokenBalanceDisplay,
-      salt: this.state.salt,
+      salt,
       numTokens: this.state.numTokens,
       key: this.state.key,
     };
@@ -174,13 +174,14 @@ class ChallengeCommitVote extends React.Component<
 
     const { challenge } = this.props;
     const listingDetailURL = `https://${window.location.hostname}/listing/${this.props.listingAddress}`;
+    const salt = fetchSalt(this.props.challengeID, this.props.user);
 
     const props: ReviewVoteProps = {
       newsroomName: "this newsroom",
       listingDetailURL,
       challengeID: this.props.challengeID.toString(),
       open: this.state.isReviewVoteModalOpen!,
-      salt: this.state.salt,
+      salt,
       numTokens: this.state.numTokens,
       voteOption: this.state.voteOption,
       userAccount: this.props.user,
@@ -269,7 +270,8 @@ class ChallengeCommitVote extends React.Component<
 
   private commitVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
     const voteOption: BigNumber = new BigNumber(this.state.voteOption as string);
-    const salt: BigNumber = new BigNumber(this.state.salt as string);
+    const saltStr = fetchSalt(this.props.challengeID, this.props.user);
+    const salt: BigNumber = new BigNumber(saltStr as string);
     const numTokens: BigNumber = new BigNumber(this.state.numTokens as string).mul(1e18);
     saveVote(this.props.challengeID, this.props.user, voteOption);
     return commitVote(this.props.challengeID, voteOption, salt, numTokens);

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -36,9 +36,7 @@ import {
   getChallengeState,
 } from "../../selectors";
 import { fetchAndAddChallengeData } from "../../redux/actionCreators/challenges";
-import { fetchSalt } from "../../helpers/salt";
 import { ChallengeContainerProps, connectChallengeResults } from "../utility/HigherOrderComponents";
-import { fetchVote } from "../../helpers/vote";
 
 const withChallengeResults = (
   WrappedComponent: React.ComponentType<
@@ -111,7 +109,6 @@ export interface ChallengeDetailProps {
 export interface ChallengeVoteState {
   isReviewVoteModalOpen?: boolean;
   voteOption?: string;
-  salt?: string;
   numTokens?: string;
   requestAppealSummaryValue?: string;
   requestAppealCiteConstitutionValue?: any;
@@ -129,34 +126,7 @@ export interface ProgressModalPropsState {
 
 // A container encapsultes the Commit Vote, Reveal Vote and Rewards phases for a Challenge.
 // @TODO(jon): Clean this up... by maybe separating into separate containers for each phase card component
-class ChallengeDetail extends React.Component<ChallengeDetailProps, ChallengeVoteState & ProgressModalPropsState> {
-  constructor(props: any) {
-    super(props);
-    const fetchedVote = fetchVote(this.props.challengeID, this.props.user);
-    let voteOption;
-    if (fetchedVote) {
-      voteOption = fetchedVote.toString();
-    }
-    this.state = {
-      isReviewVoteModalOpen: false,
-      voteOption,
-      salt: fetchSalt(this.props.challengeID, this.props.user), // TODO(jorgelo): This should probably be in redux.
-      numTokens: undefined,
-    };
-  }
-
-  public componentDidMount(): void {
-    if (!this.state.numTokens && this.props.balance && this.props.votingBalance) {
-      this.setInitNumTokens();
-    }
-  }
-
-  public componentDidUpdate(prevProps: ChallengeDetailProps): void {
-    if (!this.state.numTokens && (this.props.balance && this.props.votingBalance)) {
-      this.setInitNumTokens();
-    }
-  }
-
+class ChallengeDetail extends React.Component<ChallengeDetailProps> {
   public render(): JSX.Element {
     const { challenge, userChallengeData, userAppealChallengeData } = this.props;
     const { inCommitPhase, inRevealPhase } = this.props.challengeState;
@@ -180,20 +150,6 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps, ChallengeVot
         {canShowAppealChallengeRewardsFrom && this.renderAppealChallengeRewardsDetail()}
       </>
     );
-  }
-
-  private setInitNumTokens(): void {
-    let initNumTokens: BigNumber;
-    if (!this.props.votingBalance!.isZero()) {
-      initNumTokens = this.props.votingBalance!;
-    } else {
-      initNumTokens = this.props.balance!.add(this.props.votingBalance!);
-    }
-    const initNumTokensString = initNumTokens
-      .div(1e18)
-      .toFixed(2)
-      .toString();
-    this.setState(() => ({ numTokens: initNumTokensString }));
   }
 
   private renderAppeal(): JSX.Element {

--- a/packages/dapp/src/components/listing/ChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/ChallengeRevealVote.tsx
@@ -60,15 +60,8 @@ class ChallengeRevealVote extends React.Component<
 > {
   constructor(props: ChallengeDetailProps & InjectedTransactionStatusModalProps) {
     super(props);
-    const fetchedVote = fetchVote(this.props.challengeID, this.props.user);
-    let voteOption;
-    if (fetchedVote) {
-      voteOption = fetchedVote.toString();
-    }
     this.state = {
       isReviewVoteModalOpen: false,
-      voteOption,
-      salt: fetchSalt(this.props.challengeID, this.props.user), // TODO(jorgelo): This should probably be in redux.
       numTokens: undefined,
     };
   }
@@ -94,6 +87,9 @@ class ChallengeRevealVote extends React.Component<
       return null;
     }
 
+    const voteOption = this.getVoteOption();
+    const salt = fetchSalt(this.props.challengeID, this.props.user);
+
     return (
       <>
         <ChallengeRevealVoteCard
@@ -104,8 +100,8 @@ class ChallengeRevealVote extends React.Component<
           challenger={challenge!.challenger.toString()}
           rewardPool={getFormattedTokenBalance(challenge!.rewardPool)}
           stake={getFormattedTokenBalance(challenge!.stake)}
-          voteOption={this.state.voteOption}
-          salt={this.state.salt}
+          voteOption={voteOption}
+          salt={salt}
           onInputChange={this.updateCommitVoteState}
           onMobileTransactionClick={this.props.onMobileTransactionClick}
           userHasRevealedVote={userHasRevealedVote}
@@ -114,6 +110,15 @@ class ChallengeRevealVote extends React.Component<
         />
       </>
     );
+  }
+
+  private getVoteOption(): string | undefined {
+    const fetchedVote = fetchVote(this.props.challengeID, this.props.user);
+    let voteOption;
+    if (fetchedVote) {
+      voteOption = fetchedVote.toString();
+    }
+    return voteOption;
   }
 
   private getTransactionSuccessContent = (): TransactionStatusModalContentMap => {
@@ -168,8 +173,9 @@ class ChallengeRevealVote extends React.Component<
   };
 
   private revealVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
-    const voteOption: BigNumber = new BigNumber(this.state.voteOption as string);
-    const salt: BigNumber = new BigNumber(this.state.salt as string);
+    const voteOption: BigNumber = new BigNumber(this.getVoteOption() as string);
+    const saltStr = fetchSalt(this.props.challengeID, this.props.user);
+    const salt: BigNumber = new BigNumber(saltStr as string);
     return revealVote(this.props.challengeID, voteOption, salt);
   };
 

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -48,7 +48,16 @@ export interface ListingReduxProps {
   useGraphQL: boolean;
 }
 
-class ListingPageComponent extends React.Component<ListingReduxProps & DispatchProp<any> & ListingPageComponentProps> {
+interface ListingPageComponentState {
+  activeTab: number;
+}
+
+class ListingPageComponent extends React.Component<ListingReduxProps & DispatchProp<any> & ListingPageComponentProps, ListingPageComponentState> {
+  constructor(props: ListingReduxProps & DispatchProp<any> & ListingPageComponentProps) {
+    super(props);
+    this.state = { activeTab: 0 };
+  }
+
   public async componentDidUpdate(): Promise<void> {
     if (!this.props.listing && !this.props.listingDataRequestStatus && !this.props.useGraphQL) {
       this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress));
@@ -67,11 +76,16 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
     }
   }
 
+  public componentWillMount(): void {
+    const listing = this.props.listing;
+    const activeTab = listing && listing.data.challenge ? 1 : 0;
+    this.setState({ activeTab });
+  }
+
   public render(): JSX.Element {
     const listing = this.props.listing;
     const newsroom = this.props.newsroom;
     const listingExistsAsNewsroom = listing && newsroom;
-    const activeTab = listing && listing.data.challenge ? 1 : 0;
 
     return (
       <>
@@ -109,7 +123,7 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
           <StyledLeftContentWell>
             {!listingExistsAsNewsroom && this.renderListingNotFound()}
 
-            <Tabs TabComponent={StyledTab} activeIndex={activeTab}>
+            <Tabs TabComponent={StyledTab} activeIndex={this.state.activeTab} onActiveTabChange={this.onTabChange}>
               {(listingExistsAsNewsroom && (
                 <Tab title="About">
                   <ListingTabContent>
@@ -157,6 +171,10 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
 
   private renderListingNotFound(): JSX.Element {
     return <>NOT FOUND</>;
+  }
+
+  private onTabChange = (newActiveTab: number): void => {
+    this.setState({ activeTab: newActiveTab });
   }
 }
 

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -52,7 +52,10 @@ interface ListingPageComponentState {
   activeTab: number;
 }
 
-class ListingPageComponent extends React.Component<ListingReduxProps & DispatchProp<any> & ListingPageComponentProps, ListingPageComponentState> {
+class ListingPageComponent extends React.Component<
+  ListingReduxProps & DispatchProp<any> & ListingPageComponentProps,
+  ListingPageComponentState
+> {
   constructor(props: ListingReduxProps & DispatchProp<any> & ListingPageComponentProps) {
     super(props);
     this.state = { activeTab: 0 };
@@ -175,7 +178,7 @@ class ListingPageComponent extends React.Component<ListingReduxProps & DispatchP
 
   private onTabChange = (newActiveTab: number): void => {
     this.setState({ activeTab: newActiveTab });
-  }
+  };
 }
 
 const makeMapStateToProps = () => {


### PR DESCRIPTION
This update includes:

- Fix for broken tab functionality on the Listing Detail page, when a listing has an active challenge
- Fix "bleed through" of Listing History event SVG points through the 'Review Vote' modal backdrop (#723)
- Fixes various issues caused by a race condition that prevented the `salt` from being loaded from localstorage (#725, #726)
- Fixes issue where negative token amounts were allowed when commiting a vote (#724)