### PR TITLE
Confirm Appeal with GraphQL

### DIFF
--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -5,7 +5,7 @@ import { getDefaultFromBlock } from "@joincivil/utils";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { AppealData } from "../../types";
 import { AppealChallenge } from "./appealChallenge";
-import { EthAddress, TxDataAll } from "@joincivil/typescript-types";
+import { EthAddress } from "@joincivil/typescript-types";
 
 const debug = Debug("civil:appeal");
 
@@ -13,13 +13,11 @@ export class Appeal {
   private ethApi: EthApi;
   private tcrInstance: CivilTCRContract;
   private challengeId: BigNumber;
-  private listingAddress: EthAddress;
 
-  constructor(ethApi: EthApi, instance: CivilTCRContract, challengeId: BigNumber, listingAddress: EthAddress) {
+  constructor(ethApi: EthApi, instance: CivilTCRContract, challengeId: BigNumber) {
     this.ethApi = ethApi;
     this.tcrInstance = instance;
     this.challengeId = challengeId;
-    this.listingAddress = listingAddress;
   }
 
   public async getAppealData(): Promise<AppealData> {

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -5,7 +5,6 @@ import { getDefaultFromBlock } from "@joincivil/utils";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { AppealData } from "../../types";
 import { AppealChallenge } from "./appealChallenge";
-import { EthAddress } from "@joincivil/typescript-types";
 
 const debug = Debug("civil:appeal");
 

--- a/packages/core/src/contracts/tcr/appeal.ts
+++ b/packages/core/src/contracts/tcr/appeal.ts
@@ -5,7 +5,7 @@ import { getDefaultFromBlock } from "@joincivil/utils";
 import { CivilTCRContract } from "../generated/wrappers/civil_t_c_r";
 import { AppealData } from "../../types";
 import { AppealChallenge } from "./appealChallenge";
-import { EthAddress } from "@joincivil/typescript-types";
+import { EthAddress, TxDataAll } from "@joincivil/typescript-types";
 
 const debug = Debug("civil:appeal");
 
@@ -40,7 +40,6 @@ export class Appeal {
     if (!appealPhaseExpiry.isZero()) {
       appealStatementURI = await this.getAppealURI();
     }
-    const appealTxData = await this.tcrInstance.grantAppeal.getRaw(this.listingAddress, "", { gas: 0 });
     return {
       requester,
       appealFeePaid,
@@ -48,7 +47,6 @@ export class Appeal {
       appealGranted,
       appealOpenToChallengeExpiry,
       appealChallengeID,
-      appealTxData,
       appealChallenge,
       appealStatementURI,
     };

--- a/packages/core/src/contracts/tcr/challenge.ts
+++ b/packages/core/src/contracts/tcr/challenge.ts
@@ -35,7 +35,7 @@ export class Challenge {
     if (!listingAddress) {
       listingAddress = await this.getListingIdForChallenge();
     }
-    const appealInstance = new Appeal(this.ethApi, this.tcrInstance, this.challengeId, listingAddress);
+    const appealInstance = new Appeal(this.ethApi, this.tcrInstance, this.challengeId);
     const appeal = await appealInstance.getAppealData();
 
     return {

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -34,6 +34,7 @@ import { Government } from "./government";
 import { Listing } from "./listing";
 import { Parameterizer } from "./parameterizer";
 import { Voting } from "./voting";
+import { TxDataAll } from "@joincivil/typescript-types";
 
 const debug = Debug("civil:tcr");
 
@@ -481,6 +482,10 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
 
   public getListing(listingAddress: EthAddress): Listing {
     return new Listing(this.ethApi, this.instance, listingAddress);
+  }
+
+  public async getRawGrantAppealTxData(listingAddress: EthAddress): Promise<TxDataAll> {
+    return this.instance.grantAppeal.getRaw(listingAddress, "", { gas: 0 });
   }
 
   /*

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,7 +5,6 @@ import {
   EthAddress,
   Hex,
   TxHash,
-  TxDataAll,
 } from "@joincivil/typescript-types";
 import BigNumber from "bignumber.js";
 import { CivilLogs } from "./contracts/generated/events";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -201,7 +201,6 @@ export interface AppealData {
   appealGranted: boolean;
   appealOpenToChallengeExpiry: BigNumber;
   appealChallengeID: BigNumber;
-  appealTxData?: TxDataAll;
   appealChallenge?: AppealChallengeData;
   appealStatementURI?: string;
 }

--- a/packages/dapp/src/helpers/queryTransformations.ts
+++ b/packages/dapp/src/helpers/queryTransformations.ts
@@ -173,7 +173,6 @@ export function transformGraphQLDataIntoAppeal(queryAppealData: any): AppealData
       appealGranted: queryAppealData.appealGranted,
       appealOpenToChallengeExpiry: new BigNumber(queryAppealData.appealOpenToChallengeExpiry),
       appealChallengeID: new BigNumber(queryAppealData.appealChallengeID),
-      appealTxData: undefined,
       appealChallenge: transformGraphQLDataIntoAppealChallenge(queryAppealData.appealChallenge),
       appealStatementURI: queryAppealData.statement,
     };

--- a/packages/dapp/src/redux/actionCreators/challenges.ts
+++ b/packages/dapp/src/redux/actionCreators/challenges.ts
@@ -1,4 +1,4 @@
-import { EthAddress, UserChallengeData, WrappedChallengeData } from "@joincivil/core";
+import { EthAddress, UserChallengeData, WrappedChallengeData, TxDataAll } from "@joincivil/core";
 import { Dispatch } from "react-redux";
 import { AnyAction } from "redux";
 import { ensureWeb3BigNumber } from "../../apis/civilTCR";
@@ -9,11 +9,21 @@ export enum challengeActions {
   ADD_OR_UPDATE_USER_CHALLENGE_DATA = "ADD_OR_UPDATE_USER_CHALLENGE_DATA",
   ADD_OR_UPDATE_USER_APPEAL_CHALLENGE_DATA = "ADD_OR_UPDATE_USER_APPEAL_CHALLENGE_DATA",
   ADD_USER_CHALLENGE_STARTED = "ADD_USER_CHALLENGE_STARTED",
+  ADD_GRANT_APPEAL_TX = "ADD_GRANT_APPEAL_TX",
   FETCH_CHALLENGE_DATA = "FETCH_CHALLENGE_DATA",
   FETCH_CHALLENGE_DATA_COMPLETE = "FETCH_CHALLENGE_DATA_COMPLETE",
   FETCH_CHALLENGE_DATA_IN_PROGRESS = "FETCH_CHALLENGE_DATA_IN_PROGRESS",
+  FETCH_GRANT_APPEAL_TX = "FETCH_GRANT_APPEAL_TX",
   FETCH_AND_ADD_CHALLENGE_DATA = "FETCH_AND_ADD_CHALLENGE_DATA",
+  FETCH_AND_ADD_GRANT_APPEAL_TX = "FETCH_AND_ADD_GRANT_APPEAL_TX",
 }
+
+export const addGrantAppealTx = (listingAddress: EthAddress, txData: TxDataAll): AnyAction => {
+  return {
+    type: challengeActions.ADD_GRANT_APPEAL_TX,
+    data: { listingAddress, txData },
+  };
+};
 
 export const addChallenge = (wrappedChallenge: WrappedChallengeData): AnyAction => {
   return {
@@ -44,6 +54,13 @@ export const addUserAppealChallengeData = (
   return {
     type: challengeActions.ADD_OR_UPDATE_USER_APPEAL_CHALLENGE_DATA,
     data: { challengeID, user, userChallengeData },
+  };
+};
+
+export const fetchGrantAppealTx = (listingAddress: EthAddress) => {
+  return {
+    type: challengeActions.FETCH_GRANT_APPEAL_TX,
+    data: { listingAddress },
   };
 };
 
@@ -102,5 +119,15 @@ export const fetchAndAddChallengeData = (challengeID: string): any => {
     } else {
       return dispatch(fetchChallengeComplete(challengeID));
     }
+  };
+};
+
+export const fetchAndAddGrantAppealTx = (listingAddress: string): any => {
+  return async (dispatch: Dispatch<any>): Promise<AnyAction> => {
+    dispatch(fetchGrantAppealTx(listingAddress));
+    const tcr = await getTCR();
+    const grantAppealTx = await tcr.getRawGrantAppealTxData(listingAddress);
+
+    return dispatch(addGrantAppealTx(listingAddress, grantAppealTx));
   };
 };

--- a/packages/dapp/src/redux/reducers/challenges.ts
+++ b/packages/dapp/src/redux/reducers/challenges.ts
@@ -1,6 +1,6 @@
 import { Map, Set } from "immutable";
 import { AnyAction } from "redux";
-import { WrappedChallengeData, UserChallengeData } from "@joincivil/core";
+import { WrappedChallengeData, UserChallengeData, TxDataAll } from "@joincivil/core";
 import { challengeActions } from "../actionCreators/challenges";
 
 export function challenges(
@@ -10,6 +10,30 @@ export function challenges(
   switch (action.type) {
     case challengeActions.ADD_OR_UPDATE_CHALLENGE:
       return state.set(action.data.challengeID.toString(), action.data);
+    default:
+      return state;
+  }
+}
+
+export function grantAppealTxs(
+  state: Map<string, TxDataAll> = Map<string, TxDataAll>(),
+  action: AnyAction,
+): Map<string, TxDataAll> {
+  switch (action.type) {
+    case challengeActions.ADD_GRANT_APPEAL_TX:
+      return state.set(action.data.listingAddress, action.data.txData);
+    default:
+      return state;
+  }
+}
+
+export function grantAppealTxsFetching(
+  state: Map<string, boolean> = Map<string, boolean>(),
+  action: AnyAction,
+): Map<string, boolean> {
+  switch (action.type) {
+    case challengeActions.FETCH_GRANT_APPEAL_TX:
+      return state.set(action.data.listingAddress, true);
     default:
       return state;
   }

--- a/packages/dapp/src/redux/reducers/index.ts
+++ b/packages/dapp/src/redux/reducers/index.ts
@@ -38,6 +38,8 @@ import {
   challengesVotedOnByUser,
   challengesStartedByUser,
   challengeUserData,
+  grantAppealTxs,
+  grantAppealTxsFetching,
 } from "./challenges";
 import {
   government,
@@ -61,6 +63,7 @@ import {
   MultisigTransaction,
   EthContentHeader,
   ContentData,
+  TxDataAll,
 } from "@joincivil/core";
 import { currentUserNewsrooms, content, contentFetched } from "./newsrooms";
 import { newsrooms, NewsroomState, newsroomUi, newsroomUsers } from "@joincivil/newsroom-manager";
@@ -111,6 +114,8 @@ export interface NetworkDependentState {
   challengesVotedOnByUser: Map<string, Set<string>>;
   challengesStartedByUser: Map<string, Set<string>>;
   challengeUserData: Map<string, Map<string, UserChallengeData>>;
+  grantAppealTxs: Map<string, TxDataAll>;
+  grantAppealTxsFetching: Map<string, boolean>;
   appealChallengeUserData: Map<string, Map<string, UserChallengeData>>;
   government: Map<string, string>;
   constitution: Map<string, string>;
@@ -157,6 +162,8 @@ const networkDependentReducers = combineReducers({
   challengesVotedOnByUser,
   challengesStartedByUser,
   challengeUserData,
+  grantAppealTxs,
+  grantAppealTxsFetching,
   appealChallengeUserData,
   government,
   constitution,


### PR DESCRIPTION
- refactoring how we get confirm appeal raw tx so it works whether loading via graphql or web3