### PR TITLE
Authenticated routes 

### DIFF
--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -34,8 +34,6 @@ export const AuthenticatedRoute = ({
 }: AuthenticatedRouteProps) => {
   const auth = getApolloSession();
 
-  console.log("AuthenticatedRoute:", { auth });
-
   const hasAuthToken = !!(auth && auth.token);
 
   if (onlyAllowUnauthenicated === hasAuthToken) {

--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { BrowserRouter as Router, Route, RouteProps, Redirect } from "react-router-dom";
+import { getApolloSession } from "@joincivil/utils";
+import gql from "graphql-tag";
+import { Query } from "react-apollo";
+
+export interface AuthenticatedRouteProps extends RouteProps {
+  component: React.ComponentType;
+  redirectTo: string;
+  onlyAllowUnauthenicated?: boolean;
+  children?: any[];
+}
+
+const userQuery = gql`
+  query {
+    currentUser {
+      uid
+      email
+      ethAddress
+      onfidoApplicantId
+      onfidoCheckID
+      kycStatus
+      quizPayload
+      quizStatus
+    }
+  }
+`;
+
+export const AuthenticatedRoute = ({
+  component: Component,
+  redirectTo,
+  onlyAllowUnauthenicated = false,
+  ...other
+}: AuthenticatedRouteProps) => {
+  const auth = getApolloSession();
+
+  console.log("AuthenticatedRoute:", { auth });
+
+  const hasAuthToken = !!(auth && auth.token);
+
+  if (onlyAllowUnauthenicated === hasAuthToken) {
+    return <Redirect to={redirectTo} />;
+  }
+
+  return (
+    <Query query={userQuery}>
+      {({ loading, error, data }) => {
+        if (loading) {
+          return "Loading....";
+        }
+
+        console.log({ error });
+        if (error) {
+          return <Redirect to={redirectTo} />;
+        }
+
+        return <Component {...other} />;
+      }}
+    </Query>
+  );
+};
+
+export const UnauthenticatedRoute = (props: AuthenticatedRouteProps) => (
+  <AuthenticatedRoute onlyAllowUnauthenicated={true} {...props} />
+);

--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -15,9 +15,6 @@ const userQuery = gql`
       uid
       email
       ethAddress
-      onfidoApplicantId
-      onfidoCheckID
-      kycStatus
       quizPayload
       quizStatus
     }

--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -1,14 +1,12 @@
 import * as React from "react";
-import { BrowserRouter as Router, Route, RouteProps, Redirect } from "react-router-dom";
+import { Route, RouteProps, Redirect } from "react-router-dom";
 import { getApolloSession } from "@joincivil/utils";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
 
 export interface AuthenticatedRouteProps extends RouteProps {
-  component: React.ComponentType;
   redirectTo: string;
   onlyAllowUnauthenicated?: boolean;
-  children?: any[];
 }
 
 const userQuery = gql`
@@ -30,7 +28,7 @@ export const AuthenticatedRoute = ({
   component: Component,
   redirectTo,
   onlyAllowUnauthenicated = false,
-  ...other
+  ...otherProps
 }: AuthenticatedRouteProps) => {
   const auth = getApolloSession();
 
@@ -41,20 +39,27 @@ export const AuthenticatedRoute = ({
   }
 
   return (
-    <Query query={userQuery}>
-      {({ loading, error, data }) => {
-        if (loading) {
-          return "Loading....";
-        }
+    <Route {...otherProps}>
+      <Query query={userQuery}>
+        {({ loading, error, data }) => {
+          if (loading) {
+            return null;
+          }
 
-        console.log({ error });
-        if (error) {
-          return <Redirect to={redirectTo} />;
-        }
+          if (error) {
+            return <Redirect to={redirectTo} />;
+          }
 
-        return <Component {...other} />;
-      }}
-    </Query>
+          if (Component) {
+            // TODO(jorgelo): Get the line below working without the ts-ignore
+            // @ts-ignore
+            return <Component {...otherProps} />;
+          }
+
+          return null;
+        }}
+      </Query>
+    </Route>
   );
 };
 

--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -6,7 +6,7 @@ import { Query } from "react-apollo";
 
 export interface AuthenticatedRouteProps extends RouteProps {
   redirectTo: string;
-  onlyAllowUnauthenicated?: boolean;
+  onlyAllowUnauthenticated?: boolean;
 }
 
 const userQuery = gql`
@@ -27,14 +27,14 @@ const userQuery = gql`
 export const AuthenticatedRoute = ({
   component: Component,
   redirectTo,
-  onlyAllowUnauthenicated = false,
+  onlyAllowUnauthenticated = false,
   ...otherProps
 }: AuthenticatedRouteProps) => {
   const auth = getApolloSession();
 
   const hasAuthToken = auth !== null && auth.token !== null;
 
-  if (onlyAllowUnauthenicated === hasAuthToken) {
+  if (onlyAllowUnauthenticated === hasAuthToken) {
     return <Redirect to={redirectTo} />;
   }
 
@@ -46,7 +46,7 @@ export const AuthenticatedRoute = ({
             return null;
           }
 
-          if (error && !onlyAllowUnauthenicated) {
+          if (error && !onlyAllowUnauthenticated) {
             return <Redirect to={redirectTo} />;
           }
 
@@ -64,5 +64,5 @@ export const AuthenticatedRoute = ({
 };
 
 export const UnauthenticatedRoute = (props: AuthenticatedRouteProps) => (
-  <AuthenticatedRoute onlyAllowUnauthenicated={true} {...props} />
+  <AuthenticatedRoute onlyAllowUnauthenticated={true} {...props} />
 );

--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -32,7 +32,7 @@ export const AuthenticatedRoute = ({
 }: AuthenticatedRouteProps) => {
   const auth = getApolloSession();
 
-  const hasAuthToken = !!(auth && auth.token);
+  const hasAuthToken = auth !== null && auth.token !== null;
 
   if (onlyAllowUnauthenicated === hasAuthToken) {
     return <Redirect to={redirectTo} />;

--- a/packages/components/src/AuthenticatedRoute.tsx
+++ b/packages/components/src/AuthenticatedRoute.tsx
@@ -46,7 +46,7 @@ export const AuthenticatedRoute = ({
             return null;
           }
 
-          if (error) {
+          if (error && !onlyAllowUnauthenicated) {
             return <Redirect to={redirectTo} />;
           }
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -52,3 +52,4 @@ export * from "./DAppMessageContent";
 export * from "./EmailSignup";
 export * from "./Tokens";
 export * from "./ExecuteOnMount";
+export * from "./AuthenticatedRoute";

--- a/packages/dapp/src/components/Account/UserInfo.tsx
+++ b/packages/dapp/src/components/Account/UserInfo.tsx
@@ -8,9 +8,6 @@ const userQuery = gql`
       uid
       email
       ethAddress
-      onfidoApplicantId
-      onfidoCheckID
-      kycStatus
       quizPayload
       quizStatus
     }

--- a/packages/dapp/src/components/Account/UserInfo.tsx
+++ b/packages/dapp/src/components/Account/UserInfo.tsx
@@ -13,7 +13,6 @@ const userQuery = gql`
       kycStatus
       quizPayload
       quizStatus
-      isTokenFoundryRegistered
     }
   }
 `;

--- a/packages/dapp/src/components/Account/index.tsx
+++ b/packages/dapp/src/components/Account/index.tsx
@@ -59,7 +59,12 @@ export default class AccountRouter extends React.Component<RouteComponentProps> 
               )}
             />
           </AuthenticatedRoute>
-          <Route path={`${match.path}`} exact={true} component={AccountHome} />
+          <AuthenticatedRoute
+            redirectTo={`${match.path}/auth/login`}
+            path={`${match.path}`}
+            exact={true}
+            component={AccountHome}
+          />
         </Switch>
       </>
     );

--- a/packages/dapp/src/components/Account/index.tsx
+++ b/packages/dapp/src/components/Account/index.tsx
@@ -17,7 +17,7 @@ export default class AccountRouter extends React.Component<RouteComponentProps> 
       <>
         <Switch>
           {/* Login Routes */}
-          <AuthenticatedRoute onlyAllowUnauthenicated redirectTo="/account" path={`${match.path}/auth`}>
+          <AuthenticatedRoute onlyAllowUnauthenticated redirectTo="/account" path={`${match.path}/auth`}>
             <Route
               redirectTo="/account"
               path={`${match.path}/auth/login`}

--- a/packages/dapp/src/components/Account/index.tsx
+++ b/packages/dapp/src/components/Account/index.tsx
@@ -17,46 +17,48 @@ export default class AccountRouter extends React.Component<RouteComponentProps> 
       <>
         <Switch>
           {/* Login Routes */}
-          <AuthenticatedRoute
-            redirectTo="/token"
-            path={`${match.path}/auth/login`}
-            exact={true}
-            component={(props: any) => (
-              <AccountEmailAuth isNewUser={false} {...props} onEmailSend={this.handleAuthEmail} />
-            )}
-          />
-          <Route
-            path={`${match.path}/auth/login/check-email`}
-            component={(props: any) => <AccountEmailSent {...props} isNewUser={false} />}
-          />
-          <Route
-            path={`${match.path}/auth/login/verify-token/:token`}
-            exact
-            component={(props: AccountVerifyTokenProps) => (
-              <AccountVerifyToken isNewUser={false} {...props} onAuthentication={this.handleOnAuthentication} />
-            )}
-          />
+          <AuthenticatedRoute onlyAllowUnauthenicated redirectTo="/account" path={`${match.path}/auth`}>
+            <Route
+              redirectTo="/account"
+              path={`${match.path}/auth/login`}
+              exact={true}
+              component={(props: any) => (
+                <AccountEmailAuth isNewUser={false} {...props} onEmailSend={this.handleAuthEmail} />
+              )}
+            />
+            <Route
+              path={`${match.path}/auth/login/check-email`}
+              component={(props: any) => <AccountEmailSent {...props} isNewUser={false} />}
+            />
+            <Route
+              path={`${match.path}/auth/login/verify-token/:token`}
+              exact
+              component={(props: AccountVerifyTokenProps) => (
+                <AccountVerifyToken isNewUser={false} {...props} onAuthentication={this.handleOnAuthentication} />
+              )}
+            />
 
-          {/* SignUp Routes */}
-          <Route
-            path={`${match.path}/auth/signup`}
-            exact={true}
-            component={(props: any) => (
-              <AccountEmailAuth isNewUser={true} {...props} onEmailSend={this.handleAuthEmail} />
-            )}
-          />
-          <Route
-            path={`${match.path}/auth/signup/check-email`}
-            exact
-            component={(props: any) => <AccountEmailSent {...props} isNewUser={true} />}
-          />
-          <Route
-            path={`${match.path}/auth/signup/verify-token/:token`}
-            exact
-            component={(props: AccountVerifyTokenProps) => (
-              <AccountVerifyToken isNewUser={true} {...props} onAuthentication={this.handleOnAuthentication} />
-            )}
-          />
+            {/* SignUp Routes */}
+            <Route
+              path={`${match.path}/auth/signup`}
+              exact={true}
+              component={(props: any) => (
+                <AccountEmailAuth isNewUser={true} {...props} onEmailSend={this.handleAuthEmail} />
+              )}
+            />
+            <Route
+              path={`${match.path}/auth/signup/check-email`}
+              exact
+              component={(props: any) => <AccountEmailSent {...props} isNewUser={true} />}
+            />
+            <Route
+              path={`${match.path}/auth/signup/verify-token/:token`}
+              exact
+              component={(props: AccountVerifyTokenProps) => (
+                <AccountVerifyToken isNewUser={true} {...props} onAuthentication={this.handleOnAuthentication} />
+              )}
+            />
+          </AuthenticatedRoute>
           <Route path={`${match.path}`} exact={true} component={AccountHome} />
         </Switch>
       </>

--- a/packages/dapp/src/components/Account/index.tsx
+++ b/packages/dapp/src/components/Account/index.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { Route, Switch, RouteComponentProps } from "react-router-dom";
-import { AccountEmailAuth, AccountEmailSent, AccountVerifyToken, AccountVerifyTokenProps } from "@joincivil/components";
+import {
+  AccountEmailAuth,
+  AccountEmailSent,
+  AccountVerifyToken,
+  AccountVerifyTokenProps,
+  AuthenticatedRoute,
+} from "@joincivil/components";
 import { setApolloSession } from "@joincivil/utils";
 import { AccountHome } from "./Home";
 
@@ -11,7 +17,8 @@ export default class AccountRouter extends React.Component<RouteComponentProps> 
       <>
         <Switch>
           {/* Login Routes */}
-          <Route
+          <AuthenticatedRoute
+            redirectTo="/token"
             path={`${match.path}/auth/login`}
             exact={true}
             component={(props: any) => (


### PR DESCRIPTION
* Adds a helper that redirects if a user is not authenticated.
* Also has a param that reverses this functionality and only allows if they are *not* authenticated.
* Maybe a bit of overkill, but it calls the `currentUser` graphql query and redirects on (any) error.