### PR TITLE
Fixes and clean up for Reveal Vote 

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/CommitVote.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/CommitVote.tsx
@@ -36,9 +36,7 @@ import {
 } from "./textComponents";
 
 export interface CommitVoteState {
-  voteOption?: number;
   numTokensError?: string;
-  saltError?: string;
 }
 
 export interface CommitVoteStepState {
@@ -49,16 +47,14 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
   constructor(props: CommitVoteProps) {
     super(props);
     this.state = {
-      voteOption: undefined,
       numTokensError: undefined,
-      saltError: undefined,
       displayStep: 0,
     };
   }
 
   public render(): JSX.Element {
     const canReview =
-      this.state.voteOption !== undefined &&
+      this.props.voteOption !== undefined &&
       this.props.numTokens &&
       typeof parseInt(this.props.numTokens, 10) === "number";
     return (
@@ -77,7 +73,7 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
           </VoteOptionsContainer>
 
           <Button
-            disabled={this.state.voteOption === undefined}
+            disabled={this.props.voteOption === undefined}
             onClick={() => this.setState({ displayStep: 1 })}
             size={buttonSizes.MEDIUM}
             theme={buttonTheme}
@@ -129,34 +125,29 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
 
   private renderVoteButton = (options: any): JSX.Element => {
     let buttonText;
-    let onClick;
-    if (options.voteOption === 1) {
+    const { voteOption } = options;
+    const ButtonComponent = this.props.voteOption === voteOption ? Button : DarkButton;
+    const onClick = () => {
+      this.props.onInputChange({ voteOption });
+    };
+    if (voteOption === "1") {
       buttonText = (
         <>
           ✔ <WhitelistActionText />
         </>
       );
-      onClick = this.setVoteToRemain;
     } else if (options.voteOption === 0) {
       buttonText = (
         <>
           ✖ <RemoveActionText />
         </>
       );
-      onClick = this.setVoteToRemove;
-    }
-    if (this.state.voteOption === options.voteOption) {
-      return (
-        <Button onClick={onClick} size={buttonSizes.MEDIUM} theme={buttonTheme}>
-          {buttonText}
-        </Button>
-      );
     }
 
     return (
-      <DarkButton onClick={onClick} size={buttonSizes.MEDIUM} theme={buttonTheme}>
+      <ButtonComponent onClick={onClick} size={buttonSizes.MEDIUM} theme={buttonTheme}>
         {buttonText}
-      </DarkButton>
+      </ButtonComponent>
     );
   };
 
@@ -240,19 +231,5 @@ export class CommitVote extends React.Component<CommitVoteProps, CommitVoteState
       return;
     }
     this.props.onInputChange({ numTokens: value });
-  };
-
-  private setVoteToRemain = (): void => {
-    // A "remain" vote is a vote that doesn't support the
-    // challenge, so `voteOption === 1`
-    this.props.onInputChange({ voteOption: "1" });
-    this.setState(() => ({ voteOption: 1 }));
-  };
-
-  private setVoteToRemove = (): void => {
-    // A "remove" vote is a vote that supports the
-    // challenge, so `voteOption === 0`
-    this.props.onInputChange({ voteOption: "0" });
-    this.setState(() => ({ voteOption: 0 }));
   };
 }

--- a/packages/components/src/ListingDetailPhaseCard/RevealVote.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/RevealVote.tsx
@@ -7,20 +7,12 @@ import { WhitelistActionText, RemoveActionText, VoteCallToActionText, RevealVote
 import { RevealVoteProps } from "./types";
 
 export interface RevealVoteState {
-  voteOption?: number;
   saltError?: string;
 }
 
 export class RevealVote extends React.Component<RevealVoteProps, RevealVoteState> {
-  constructor(props: RevealVoteProps) {
-    super(props);
-    this.state = {
-      voteOption: this.props.voteOption ? Number.parseInt(this.props.voteOption, 10) : undefined,
-    };
-  }
-
   public render(): JSX.Element {
-    const canReveal = this.state.voteOption !== undefined && !this.state.saltError;
+    const canReveal = this.props.voteOption !== undefined && !this.state.saltError;
     return (
       <>
         <FormQuestion>
@@ -28,12 +20,19 @@ export class RevealVote extends React.Component<RevealVoteProps, RevealVoteState
         </FormQuestion>
 
         <VoteOptionsContainer>
-          {this.renderVoteButton({ voteOption: 1 })}
+          {this.renderVoteButton({ voteOption: "1" })}
           <StyledOrText>or</StyledOrText>
-          {this.renderVoteButton({ voteOption: 0 })}
+          {this.renderVoteButton({ voteOption: "0" })}
         </VoteOptionsContainer>
 
-        <SaltInput salt={this.props.salt} label="Enter your salt" name="salt" onChange={this.onChange} />
+        <SaltInput
+          salt={this.props.salt}
+          label="Enter your salt"
+          name="salt"
+          onChange={this.onChange}
+          invalid={!!this.state.saltError}
+          invalidMessage={this.state.saltError}
+        />
 
         <TransactionButtonNoModal
           transactions={this.props.transactions}
@@ -48,49 +47,30 @@ export class RevealVote extends React.Component<RevealVoteProps, RevealVoteState
 
   private renderVoteButton = (options: any): JSX.Element => {
     let buttonText;
-    let onClick;
-    if (options.voteOption === 1) {
+    const { voteOption } = options;
+    const ButtonComponent = this.props.voteOption === voteOption ? Button : DarkButton;
+    const onClick = () => {
+      this.props.onInputChange({ voteOption });
+    };
+    if (voteOption === "1") {
       buttonText = (
         <>
           ✔ <WhitelistActionText />
         </>
       );
-      onClick = this.setVoteToRemain;
-    } else if (options.voteOption === 0) {
+    } else if (voteOption === "0") {
       buttonText = (
         <>
           ✖ <RemoveActionText />
         </>
       );
-      onClick = this.setVoteToRemove;
-    }
-    if (this.state.voteOption === options.voteOption) {
-      return (
-        <Button onClick={onClick} size={buttonSizes.MEDIUM} theme={buttonTheme}>
-          {buttonText}
-        </Button>
-      );
     }
 
     return (
-      <DarkButton onClick={onClick} size={buttonSizes.MEDIUM} theme={buttonTheme}>
+      <ButtonComponent onClick={onClick} size={buttonSizes.MEDIUM} theme={buttonTheme}>
         {buttonText}
-      </DarkButton>
+      </ButtonComponent>
     );
-  };
-
-  private setVoteToRemain = (): void => {
-    // A "remain" vote is a vote that doesn't support the
-    // challenge, so `voteOption === 1`
-    this.props.onInputChange({ voteOption: "1" });
-    this.setState(() => ({ voteOption: 1 }));
-  };
-
-  private setVoteToRemove = (): void => {
-    // A "remove" vote is a vote that supports the
-    // challenge, so `voteOption === 0`
-    this.props.onInputChange({ voteOption: "0" });
-    this.setState(() => ({ voteOption: 0 }));
   };
 
   private validateSalt = (): boolean => {

--- a/packages/components/src/ListingDetailPhaseCard/types.ts
+++ b/packages/components/src/ListingDetailPhaseCard/types.ts
@@ -40,6 +40,7 @@ export interface CommitVoteProps {
   votingTokenBalance: number;
   tokenBalanceDisplay: string;
   votingTokenBalanceDisplay: string;
+  voteOption?: string;
   salt?: string;
   numTokens?: string;
   userHasCommittedVote?: boolean;
@@ -53,8 +54,8 @@ export interface CommitVoteProps {
 
 export interface RevealVoteProps {
   newsroomName?: string;
-  salt: string | undefined;
-  voteOption: string | undefined;
+  salt?: string;
+  voteOption?: string;
   transactions: any[];
   modalContentComponents?: any;
   onInputChange(propsData: any, validateFn?: () => boolean): void;

--- a/packages/components/src/input/SaltInput.tsx
+++ b/packages/components/src/input/SaltInput.tsx
@@ -7,6 +7,8 @@ export interface SaltInputProps {
   label?: string;
   placeholder?: string;
   salt?: string;
+  invalid?: boolean;
+  invalidMessage?: string;
   onChange(name: string, value: string): void;
 }
 
@@ -28,10 +30,20 @@ export class SaltInput extends React.Component<SaltInputProps, SaltInputState> {
   }
 
   public render(): JSX.Element {
-    const { name, label, placeholder } = this.props;
+    const { name, label, placeholder, invalid, invalidMessage } = this.props;
     const { value } = this.state;
 
-    return <TextInput label={label} placeholder={placeholder} name={name} onChange={this.handleChange} value={value} />;
+    const inputProps = {
+      name,
+      label,
+      placeholder,
+      invalid,
+      invalidMessage,
+      value,
+      onChange: this.handleChange,
+    };
+
+    return <TextInput {...inputProps} />;
   }
 
   private handleChange = (name: string, value: string): void => {

--- a/packages/dapp/src/components/listing/AppealChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeDetail.tsx
@@ -32,6 +32,7 @@ export interface AppealChallengeDetailProps {
 export interface ChallengeVoteState {
   voteOption?: string;
   numTokens?: string;
+  salt?: string;
   isReviewVoteModalOpen: boolean;
 }
 
@@ -54,7 +55,7 @@ class AppealChallengeDetail extends React.Component<AppealChallengeDetailProps> 
   }
 
   private renderRevealStage(): JSX.Element {
-    return <AppealChallengeRevealVote {...this.props} />;
+    return <AppealChallengeRevealVote {...this.props} key={this.props.user} />;
   }
 
   private renderResolveAppealChallenge(): JSX.Element {

--- a/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
@@ -71,6 +71,8 @@ class AppealChallengeRevealVote extends React.Component<
   constructor(props: AppealChallengeDetailProps & InjectedTransactionStatusModalProps) {
     super(props);
     this.state = {
+      voteOption: this.getVoteOption(),
+      salt: fetchSalt(this.props.challengeID, this.props.user),
       isReviewVoteModalOpen: false,
       numTokens: undefined,
       key: new Date().valueOf(),
@@ -98,36 +100,7 @@ class AppealChallengeRevealVote extends React.Component<
     const phaseLength = this.props.parameters[Parameters.challengeAppealRevealLen];
     const secondaryPhaseLength = this.props.parameters[Parameters.challengeAppealCommitLen];
 
-    const transactions = [
-      {
-        transaction: async () => {
-          this.props.updateTransactionStatusModalsState({
-            isWaitingTransactionModalOpen: true,
-            isTransactionProgressModalOpen: false,
-            isTransactionSuccessModalOpen: false,
-            transactionType: TransactionTypes.REVEAL_VOTE,
-          });
-          return this.revealVoteOnChallenge();
-        },
-        handleTransactionHash: (txHash: TxHash) => {
-          this.props.updateTransactionStatusModalsState({
-            isWaitingTransactionModalOpen: false,
-            isTransactionProgressModalOpen: true,
-          });
-        },
-        postTransaction: () => {
-          this.props.updateTransactionStatusModalsState({
-            isWaitingTransactionModalOpen: false,
-            isTransactionProgressModalOpen: false,
-            isTransactionSuccessModalOpen: true,
-          });
-        },
-        handleTransactionError: this.props.handleTransactionError,
-      },
-    ];
-
-    const voteOption = this.getVoteOption();
-    const salt = fetchSalt(this.props.challengeID, this.props.user);
+    const transactions = this.getTransactions();
 
     const AppealChallengeRevealVoteCard = compose<
       React.ComponentClass<ChallengeContainerProps & Partial<AppealChallengeRevealVoteCardProps>>
@@ -142,9 +115,9 @@ class AppealChallengeRevealVote extends React.Component<
           challengeID={this.props.challengeID.toString()}
           userHasRevealedVote={userHasRevealedVote}
           userHasCommittedVote={userHasCommittedVote}
-          voteOption={voteOption}
-          salt={salt}
-          onInputChange={this.updateCommitVoteState}
+          voteOption={this.state.voteOption}
+          salt={this.state.salt}
+          onInputChange={this.updateRevealVoteState}
           transactions={transactions}
           appealChallengeID={this.props.appealChallengeID.toString()}
           appealGranted={this.props.appeal.appealGranted}
@@ -223,12 +196,11 @@ class AppealChallengeRevealVote extends React.Component<
   private revealVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
     const voteOption: BigNumber = new BigNumber(this.getVoteOption() as string);
     const pollID = this.props.appealChallengeID;
-    const saltStr = fetchSalt(pollID, this.props.user);
-    const salt: BigNumber = new BigNumber(saltStr as string);
+    const salt: BigNumber = new BigNumber(this.state.salt as string);
     return revealVote(pollID, voteOption, salt);
   };
 
-  private updateCommitVoteState = (data: any, callback?: () => void): void => {
+  private updateRevealVoteState = (data: any, callback?: () => void): void => {
     if (callback) {
       this.setState({ ...data }, callback);
     } else {

--- a/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
@@ -72,7 +72,7 @@ class AppealChallengeRevealVote extends React.Component<
     super(props);
     this.state = {
       voteOption: this.getVoteOption(),
-      salt: fetchSalt(this.props.challengeID, this.props.user),
+      salt: fetchSalt(this.props.appealChallengeID, this.props.user),
       isReviewVoteModalOpen: false,
       numTokens: undefined,
       key: new Date().valueOf(),

--- a/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
@@ -194,8 +194,8 @@ class AppealChallengeRevealVote extends React.Component<
   }
 
   private revealVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
-    const voteOption: BigNumber = new BigNumber(this.getVoteOption() as string);
     const pollID = this.props.appealChallengeID;
+    const voteOption: BigNumber = new BigNumber(this.state.voteOption as string);
     const salt: BigNumber = new BigNumber(this.state.salt as string);
     return revealVote(pollID, voteOption, salt);
   };

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -113,6 +113,7 @@ export interface ChallengeVoteState {
   isReviewVoteModalOpen?: boolean;
   voteOption?: string;
   numTokens?: string;
+  salt?: string;
   requestAppealSummaryValue?: string;
   requestAppealCiteConstitutionValue?: any;
   requestAppealDetailsValue?: any;
@@ -182,7 +183,7 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps> {
   }
 
   private renderRevealStage(): JSX.Element | null {
-    return <ChallengeRevealVote {...this.props} />;
+    return <ChallengeRevealVote {...this.props} key={this.props.user} />;
   }
 
   private renderRequestAppealStage(): JSX.Element {

--- a/packages/dapp/src/components/listing/ChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/ChallengeRevealVote.tsx
@@ -65,6 +65,8 @@ class ChallengeRevealVote extends React.Component<
   constructor(props: ChallengeDetailProps & InjectedTransactionStatusModalProps) {
     super(props);
     this.state = {
+      voteOption: this.getVoteOption(),
+      salt: fetchSalt(this.props.challengeID, this.props.user),
       isReviewVoteModalOpen: false,
       numTokens: undefined,
       key: new Date().valueOf(),
@@ -93,9 +95,6 @@ class ChallengeRevealVote extends React.Component<
       return null;
     }
 
-    const voteOption = this.getVoteOption();
-    const salt = fetchSalt(this.props.challengeID, this.props.user);
-
     return (
       <>
         <ChallengeRevealVoteCard
@@ -107,9 +106,9 @@ class ChallengeRevealVote extends React.Component<
           isViewingUserChallenger={challenge!.challenger.toString() === this.props.user}
           rewardPool={getFormattedTokenBalance(challenge!.rewardPool)}
           stake={getFormattedTokenBalance(challenge!.stake)}
-          voteOption={voteOption}
-          salt={salt}
-          onInputChange={this.updateCommitVoteState}
+          voteOption={this.state.voteOption}
+          salt={this.state.salt}
+          onInputChange={this.updateRevealVoteState}
           onMobileTransactionClick={this.props.onMobileTransactionClick}
           userHasRevealedVote={userHasRevealedVote}
           userHasCommittedVote={userHasCommittedVote}
@@ -186,13 +185,12 @@ class ChallengeRevealVote extends React.Component<
   };
 
   private revealVoteOnChallenge = async (): Promise<TwoStepEthTransaction<any>> => {
-    const voteOption: BigNumber = new BigNumber(this.getVoteOption() as string);
-    const saltStr = fetchSalt(this.props.challengeID, this.props.user);
-    const salt: BigNumber = new BigNumber(saltStr as string);
+    const voteOption: BigNumber = new BigNumber(this.state.voteOption as string);
+    const salt: BigNumber = new BigNumber(this.state.salt as string);
     return revealVote(this.props.challengeID, voteOption, salt);
   };
 
-  private updateCommitVoteState = (data: any, callback?: () => void): void => {
+  private updateRevealVoteState = (data: any, callback?: () => void): void => {
     if (callback) {
       this.setState({ ...data }, callback);
     } else {


### PR DESCRIPTION
This update fixes an issue where a user could not reveal a vote, if the vote / salt were not saved in localStorage.

Additionally, it includes:

- Refactoring of how the Reveal Vote cards get `salt` and `voteOption` from localStorage and set those values into local state for the relevant components
- Introduces use of the `user` prop as a `key` prop for Reveal Vote card components. When a `key` changes, the component is re-instantiated, so initializing the `salt` and `voteOption` in the constructor happens again, once the `user` prop is loaded from Redux. This is a slightly better fix for the race condition issue where the `user` prop would not be available to the component during initialization, so the `salt` and `voteOption` would not populate for those views.
- Refactoring and cleanup of Commit / Reveal vote form views