### PR TITLE
*Rough* fix for appeal challenges my activity

### DIFF
--- a/packages/components/src/ListingSummary/styledComponents.tsx
+++ b/packages/components/src/ListingSummary/styledComponents.tsx
@@ -168,6 +168,8 @@ export const SmallNewsroomLogo = styled.img`
   height: 52px;
   min-width: 52px;
   min-height: 52px;
+  max-width: 52px;
+  max-heigh: 52px;
   object-fit: cover;
 `;
 

--- a/packages/components/src/ListingSummary/styledComponents.tsx
+++ b/packages/components/src/ListingSummary/styledComponents.tsx
@@ -168,8 +168,6 @@ export const SmallNewsroomLogo = styled.img`
   height: 52px;
   min-width: 52px;
   min-height: 52px;
-  max-width: 52px;
-  max-heigh: 52px;
   object-fit: cover;
 `;
 

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -35,7 +35,6 @@ import { Listing } from "./listing";
 import { Parameterizer } from "./parameterizer";
 import { Voting } from "./voting";
 import { TxDataAll } from "@joincivil/typescript-types";
-import { isChallengeInRevealStage, isChallengeInCommitStage } from "../../utils/listingDataHelpers/challengeHelper";
 import { isInCommitStage, isInRevealStage } from "../../utils/listingDataHelpers/pollHelper";
 
 const debug = Debug("civil:tcr");

--- a/packages/core/src/contracts/tcr/civilTCR.ts
+++ b/packages/core/src/contracts/tcr/civilTCR.ts
@@ -556,6 +556,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
     const pollData = await this.voting.getPoll(challengeID);
     let canUserReveal;
     let canUserRescue;
+    let canUserCollect;
     if (user) {
       didUserCommit = await this.voting.didCommitVote(user, challengeID);
       if (didUserCommit) {
@@ -567,13 +568,14 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
             numTokens = reveal!.args.numTokens;
             choice = reveal!.args.choice;
             didUserCollect = await this.instance.tokenClaims.callAsync(challengeID, user);
+            isVoterWinner = await this.voting.isVoterWinner(challengeID, user);
+            canUserCollect = isVoterWinner && !didUserCollect;
           } else {
             didUserRescue =
               !(await this.voting.canRescueTokens(user, challengeID)) &&
               !(await isInCommitStage(pollData)) &&
               !(await isInRevealStage(pollData));
           }
-          isVoterWinner = await this.voting.isVoterWinner(challengeID, user);
         } else {
           canUserReveal = !didUserReveal && (await isInRevealStage(pollData));
         }
@@ -590,6 +592,7 @@ export class CivilTCR extends BaseWrapper<CivilTCRContract> {
       didUserReveal,
       canUserReveal,
       didUserCollect,
+      canUserCollect,
       didUserRescue,
       canUserRescue,
       didCollectAmount,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,8 +181,10 @@ export interface ChallengeData {
 export interface UserChallengeData {
   didUserCommit?: boolean;
   didUserReveal?: boolean;
+  canUserReveal?: boolean;
   didUserCollect?: boolean;
   didUserRescue?: boolean;
+  canUserRescue?: boolean;
   didCollectAmount?: BigNumber;
   isVoterWinner?: boolean;
   salt?: BigNumber;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,6 +183,7 @@ export interface UserChallengeData {
   didUserReveal?: boolean;
   canUserReveal?: boolean;
   didUserCollect?: boolean;
+  canUserCollect?: boolean;
   didUserRescue?: boolean;
   canUserRescue?: boolean;
   didCollectAmount?: BigNumber;

--- a/packages/dapp/src/components/Dashboard/ActivityList.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityList.tsx
@@ -2,10 +2,15 @@ import * as React from "react";
 import { Set } from "immutable";
 import BigNumber from "bignumber.js";
 import { ChallengeActivityListItem, ActivityListItem, ResolvedChallengeActivityListItem } from "./ActivityListItem";
+import {
+  ResolvedAppealChallengeActivityListItem,
+  // AppealChallengeActivityListItem,
+} from "./ActivityListAppealChallengeItem";
 
 export interface ActivityListOwnProps {
   listings?: Set<string>;
   challenges?: Set<string>;
+  appealChallenges?: Set<string>;
   resolvedChallenges?: boolean;
   toggleChallengeSelect?(challengeID: string, isSelected: boolean, salt: BigNumber): void;
 }
@@ -37,11 +42,37 @@ class ActivityList extends React.Component<ActivityListOwnProps> {
               />
             );
           })}
+        {!!this.props.resolvedChallenges &&
+          this.props.appealChallenges &&
+          this.props.appealChallenges.map(c => {
+            index++;
+            return (
+              <ResolvedAppealChallengeActivityListItem
+                toggleSelect={this.props.toggleChallengeSelect!}
+                key={c}
+                challengeID={c!}
+                even={index % 2 === 0}
+              />
+            );
+          })}
         {!this.props.resolvedChallenges &&
           this.props.challenges &&
           this.props.challenges.map(c => {
             index++;
             return <ChallengeActivityListItem key={c} challengeID={c!} even={index % 2 === 0} />;
+          })}
+        {!this.props.resolvedChallenges &&
+          this.props.appealChallenges &&
+          this.props.appealChallenges.map(c => {
+            index++;
+            return (
+              <ResolvedAppealChallengeActivityListItem
+                toggleSelect={this.props.toggleChallengeSelect!}
+                key={c}
+                challengeID={c!}
+                even={index % 2 === 0}
+              />
+            );
           })}
       </>
     );

--- a/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
@@ -303,12 +303,10 @@ const makeChallengeMapStateToProps = () => {
     // const challengeState = getChallengeState(challenge!);
     const { even, user } = ownProps;
     const { listingsFetching, challenges, appealChallengeIDsToChallengeIDs } = state.networkDependent;
-    console.log("challenges: ", challenges);
     const parentChallengeID = appealChallengeIDsToChallengeIDs.get(ownProps.challengeID);
     const listingAddress = challenges.get(parentChallengeID)
       ? challenges.get(parentChallengeID)!.listingAddress
       : "unknown";
-    console.log("listingAddress: ", listingAddress);
     let listingDataRequestStatus;
     if (listingAddress) {
       listingDataRequestStatus = listingsFetching.get(listingAddress.toString());

--- a/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
@@ -1,0 +1,364 @@
+import * as React from "react";
+import { connect, DispatchProp } from "react-redux";
+// import { Link } from "react-router-dom";
+import BigNumber from "bignumber.js";
+import { ListingWrapper, WrappedChallengeData, UserChallengeData, CharterData } from "@joincivil/core";
+import { NewsroomState } from "@joincivil/newsroom-manager";
+import { DashboardActivityItem /*, PHASE_TYPE_NAMES*/ } from "@joincivil/components";
+// import { getFormattedTokenBalance } from "@joincivil/utils";
+import { State } from "../../redux/reducers";
+// import // getChallenge,
+// getListingPhaseState,
+// makeGetListing,
+// makeGetListingAddressByChallengeID,
+// makeGetUserChallengeData,
+// makeGetUnclaimedRewardAmount,
+// getChallengeState,
+// "../../selectors";
+// import { WinningChallengeResults } from "./WinningChallengeResults";
+// import { PhaseCountdownTimer } from "./PhaseCountdownTimer";
+// import { fetchAndAddListingData } from "../../redux/actionCreators/listings";
+// import { getContent } from "../../redux/actionCreators/newsrooms";
+
+export interface ActivityListAppealChallengeItemOwnProps {
+  listingAddress?: string;
+  even: boolean;
+  challenge?: WrappedChallengeData;
+  userChallengeData?: UserChallengeData;
+  unclaimedRewardAmount?: string;
+  challengeState?: any;
+  challengeID?: string;
+  user?: string;
+  listingDataRequestStatus?: any;
+}
+
+export interface AppealChallengeActivityListItemOwnProps {
+  challengeID: string;
+  even: boolean;
+  user?: string;
+}
+
+export interface ResolvedAppealChallengeActivityListItemProps {
+  toggleSelect?(challengeID: string, isSelected: boolean, salt: BigNumber): void;
+}
+
+export interface ActivityListAppealChallengeItemReduxProps {
+  newsroom?: NewsroomState;
+  charter?: CharterData;
+  listing?: ListingWrapper;
+  listingPhaseState?: any;
+  challengeState?: any;
+}
+
+class ActivityListAppealChallengeItemComponent extends React.Component<
+  ActivityListAppealChallengeItemOwnProps &
+    ResolvedAppealChallengeActivityListItemProps &
+    ActivityListAppealChallengeItemReduxProps &
+    DispatchProp<any>
+> {
+  public async componentDidUpdate(): Promise<void> {
+    // if (!this.props.listing && !this.props.listingDataRequestStatus) {
+    //   this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress!));
+    // }
+    // if (this.props.newsroom) {
+    //   this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
+    // }
+  }
+
+  public async componentDidMount(): Promise<void> {
+    // if (!this.props.listing && !this.props.listingDataRequestStatus) {
+    //   this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress!));
+    // }
+    // if (this.props.newsroom) {
+    //   this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
+    // }
+  }
+
+  public render(): JSX.Element {
+    console.log("AppealChallengeItem props: ", this.props);
+    // const { listingAddress: address, listing, newsroom, listingPhaseState, charter } = this.props;
+    // if (listing && listing.data && newsroom && listingPhaseState) {
+    //   const newsroomData = newsroom.wrapper.data;
+    //   let listingDetailURL = `/listing/${address}`;
+    //   if (this.props.challenge) {
+    //     listingDetailURL = `/listing/${address}/challenge/${this.props.challenge.challengeID}`;
+    //   }
+    //   const buttonTextTuple = this.getButtonText();
+    const props = {
+      newsroomName: "test", // newsroomData.name,
+      charter: undefined,
+      listingDetailURL: "test",
+      buttonText: "test", // buttonTextTuple[0],
+      buttonHelperText: "test", // buttonTextTuple[1],
+      challengeID: this.props.challengeID,
+      salt: this.props.userChallengeData && this.props.userChallengeData.salt,
+      toggleSelect: this.props.toggleSelect,
+    };
+
+    return <DashboardActivityItem {...props}>{this.renderActivityDetails()}</DashboardActivityItem>;
+    // } else {
+    // return <></>;
+    // }
+  }
+
+  private renderActivityDetails = (): JSX.Element => {
+    return <span>ok</span>;
+  };
+  //   const { listingPhaseState, challengeState } = this.props;
+  //   const {
+  //     isWhitelisted,
+  //     isInApplication,
+  //     isRejected,
+  //     isUnderChallenge,
+  //     canResolveChallenge,
+  //     isAwaitingAppealRequest,
+  //     inChallengeCommitVotePhase,
+  //     inChallengeRevealPhase,
+  //   } = listingPhaseState;
+
+  //   if (!this.props.challenge) {
+  //     if (isInApplication) {
+  //       return (
+  //         <>
+  //           <p>Awaiting Approval</p>
+  //         </>
+  //       );
+  //     } else if (isWhitelisted && !isUnderChallenge) {
+  //       return (
+  //         <>
+  //           <p>Accepted into Registry</p>
+  //         </>
+  //       );
+  //     } else if (!isRejected && !isInApplication && !isUnderChallenge) {
+  //       return (
+  //         <>
+  //           <p>Rejected from Registry</p>
+  //         </>
+  //       );
+  //     } else if (inChallengeCommitVotePhase) {
+  //       return (
+  //         <>
+  //           <p>Under Challenge > Accepting Votes</p>
+  //         </>
+  //       );
+  //     } else if (inChallengeRevealPhase) {
+  //       return (
+  //         <>
+  //           <p>Under Challenge > Revealing Votes</p>
+  //         </>
+  //       );
+  //     } else if (isAwaitingAppealRequest) {
+  //       return (
+  //         <>
+  //           <p>Under Challenge > Awaiting Appeal Request</p>
+  //         </>
+  //       );
+  //     } else if (canResolveChallenge) {
+  //       return (
+  //         <>
+  //           <p>Under Challenge > Complete</p>
+  //         </>
+  //       );
+  //     }
+  //   } else if (challengeState) {
+  //     if (listingPhaseState && inChallengeCommitVotePhase) {
+  //       return (
+  //         <PhaseCountdownTimer phaseType={PHASE_TYPE_NAMES.CHALLENGE_COMMIT_VOTE} challenge={this.props.challenge} />
+  //       );
+  //     }
+
+  //     if (listingPhaseState && inChallengeRevealPhase) {
+  //       return (
+  //         <PhaseCountdownTimer phaseType={PHASE_TYPE_NAMES.CHALLENGE_REVEAL_VOTE} challenge={this.props.challenge} />
+  //       );
+  //     }
+
+  //     if (listingPhaseState && isAwaitingAppealRequest) {
+  //       return (
+  //         <PhaseCountdownTimer
+  //           phaseType={PHASE_TYPE_NAMES.CHALLENGE_AWAITING_APPEAL_REQUEST}
+  //           challenge={this.props.challenge}
+  //         />
+  //       );
+  //     }
+
+  //     if (challengeState.isResolved) {
+  //       return (
+  //         <>
+  //           <WinningChallengeResults challengeID={this.props.challenge.challengeID} />
+  //         </>
+  //       );
+  //     }
+  //   }
+
+  //   return <></>;
+  // };
+
+  // private getButtonText = (): [string, string | JSX.Element | undefined] => {
+  //   const { listingAddress, listingPhaseState, userChallengeData } = this.props;
+
+  //   if (listingPhaseState && listingPhaseState.inChallengeRevealPhase && userChallengeData) {
+  //     if (userChallengeData.didUserCommit && !userChallengeData.didUserReveal) {
+  //       return ["Reveal Vote", undefined];
+  //     } else {
+  //       return ["View", "You revealed your vote"];
+  //     }
+  //   }
+
+  //   if (listingPhaseState && listingPhaseState.canResolveChallenge) {
+  //     return ["Resolve Challenge", undefined];
+  //   }
+
+  //   if (userChallengeData) {
+  //     const {
+  //       didUserCommit,
+  //       didUserReveal,
+  //       isVoterWinner,
+  //       didUserCollect,
+  //       didCollectAmount,
+  //       didUserRescue,
+  //     } = userChallengeData;
+
+  //     if (
+  //       listingPhaseState &&
+  //       !listingPhaseState.isUnderChallenge &&
+  //       didUserReveal &&
+  //       isVoterWinner &&
+  //       !didUserCollect
+  //     ) {
+  //       return ["Claim Rewards", `~${this.props.unclaimedRewardAmount} available`];
+  //     } else if (listingPhaseState && !listingPhaseState.isUnderChallenge && didUserReveal && !isVoterWinner) {
+  //       return ["View Results", "You did not vote for the winner"];
+  //     } else if (
+  //       listingPhaseState &&
+  //       !listingPhaseState.isUnderChallenge &&
+  //       didUserCommit &&
+  //       !didUserReveal &&
+  //       !didUserRescue
+  //     ) {
+  //       return ["Rescue Tokens", "You did not reveal your vote"];
+  //     } else if (listingPhaseState && !listingPhaseState.isUnderChallenge && didUserRescue) {
+  //       return ["View Results", "You rescued your tokens"];
+  //     } else if (didUserCollect) {
+  //       const reward = getFormattedTokenBalance(didCollectAmount!);
+  //       return ["View Results", `You collected ${reward}`];
+  //     }
+  //   }
+
+  //   // This is a listing
+  //   if (!userChallengeData && listingAddress) {
+  //     const manageNewsroomUrl = `/mgmt-v1/${this.props.listingAddress}`;
+  //     return ["View", <Link to={manageNewsroomUrl}>Manage Newsroom</Link>];
+  //   }
+
+  //   return ["View", undefined];
+  // };
+}
+
+const makeMapStateToProps = () => {
+  // const getListing = makeGetListing();
+
+  const mapStateToProps = (
+    state: State,
+    ownProps: ActivityListAppealChallengeItemOwnProps,
+  ): ActivityListAppealChallengeItemReduxProps & ActivityListAppealChallengeItemOwnProps => {
+    // const { newsrooms } = state;
+    // const { user, content } = state.networkDependent;
+    // const newsroom = ownProps.listingAddress ? newsrooms.get(ownProps.listingAddress) : undefined;
+    // const listing = getListing(state, ownProps);
+    // let charter;
+    // if (newsroom && newsroom.wrapper.data.charterHeader) {
+    //   charter = content.get(newsroom.wrapper.data.charterHeader.uri) as CharterData;
+    // }
+    // let userAcct = ownProps.user;
+    // if (!userAcct) {
+    //   userAcct = user.account.account;
+    // }
+
+    return {
+      // newsroom,
+      // charter,
+      // listing,
+      // listingPhaseState: getListingPhaseState(listing),
+      ...ownProps,
+    };
+  };
+
+  return mapStateToProps;
+};
+
+export const ActivityListAppealChallengeItem = connect(makeMapStateToProps)(ActivityListAppealChallengeItemComponent);
+
+const makeChallengeMapStateToProps = () => {
+  // const getListingAddressByChallengeID = makeGetListingAddressByChallengeID();
+  // const getUserChallengeData = makeGetUserChallengeData();
+  // const getUnclaimedRewardAmount = makeGetUnclaimedRewardAmount();
+
+  const mapStateToProps = (
+    state: State,
+    ownProps: AppealChallengeActivityListItemOwnProps,
+  ): ActivityListAppealChallengeItemOwnProps => {
+    // const listingAddress = getListingAddressByChallengeID(state, ownProps);
+    // const challenge = getChallenge(state, ownProps);
+    // const userChallengeData = getUserChallengeData(state, ownProps);
+    // const unclaimedRewardAmountBN = getUnclaimedRewardAmount(state, ownProps);
+    // const challengeState = getChallengeState(challenge!);
+    // const { even, user } = ownProps;
+    // const { listingsFetching } = state.networkDependent;
+    // let listingDataRequestStatus;
+    // if (listingAddress) {
+    //   listingDataRequestStatus = listingsFetching.get(listingAddress.toString());
+    // }
+
+    // let unclaimedRewardAmount = "";
+    // if (unclaimedRewardAmountBN) {
+    //   unclaimedRewardAmount = getFormattedTokenBalance(unclaimedRewardAmountBN);
+    // }
+
+    return {
+      // listingAddress,
+      // challenge,
+      // challengeState,
+      // userChallengeData,
+      // unclaimedRewardAmount,
+      // even,
+      // user,
+      // listingDataRequestStatus,
+      ...ownProps,
+    };
+  };
+
+  return mapStateToProps;
+};
+
+/**
+ * Container that renders a listing associated with the specified `ChallengeID`
+ */
+export class AppealChallengeListingItemComponent extends React.Component<
+  AppealChallengeActivityListItemOwnProps & ActivityListAppealChallengeItemOwnProps
+> {
+  public render(): JSX.Element {
+    return <ActivityListAppealChallengeItem {...this.props} />;
+  }
+}
+
+export const AppealChallengeActivityListItem = connect(makeChallengeMapStateToProps)(
+  AppealChallengeListingItemComponent,
+);
+
+/**
+ * Container that renders a listing associated with the specified `ChallengeID`
+ */
+export class ResolvedAppealChallengeListingItemComponent extends React.Component<
+  AppealChallengeActivityListItemOwnProps &
+    ResolvedAppealChallengeActivityListItemProps &
+    ActivityListAppealChallengeItemOwnProps
+> {
+  public render(): JSX.Element {
+    return <ActivityListAppealChallengeItem {...this.props} />;
+  }
+}
+
+export const ResolvedAppealChallengeActivityListItem = connect(makeChallengeMapStateToProps)(
+  ResolvedAppealChallengeListingItemComponent,
+);

--- a/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
@@ -1,24 +1,25 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-// import { Link } from "react-router-dom";
+import { Link } from "react-router-dom";
 import BigNumber from "bignumber.js";
 import { ListingWrapper, WrappedChallengeData, UserChallengeData, CharterData } from "@joincivil/core";
 import { NewsroomState } from "@joincivil/newsroom-manager";
-import { DashboardActivityItem /*, PHASE_TYPE_NAMES*/ } from "@joincivil/components";
-// import { getFormattedTokenBalance } from "@joincivil/utils";
+import { DashboardActivityItem, PHASE_TYPE_NAMES } from "@joincivil/components";
+import { getFormattedTokenBalance } from "@joincivil/utils";
 import { State } from "../../redux/reducers";
-// import // getChallenge,
-// getListingPhaseState,
-// makeGetListing,
-// makeGetListingAddressByChallengeID,
-// makeGetUserChallengeData,
-// makeGetUnclaimedRewardAmount,
-// getChallengeState,
-// "../../selectors";
-// import { WinningChallengeResults } from "./WinningChallengeResults";
-// import { PhaseCountdownTimer } from "./PhaseCountdownTimer";
-// import { fetchAndAddListingData } from "../../redux/actionCreators/listings";
-// import { getContent } from "../../redux/actionCreators/newsrooms";
+import {
+  // getChallenge,
+  getListingPhaseState,
+  makeGetListing,
+  // makeGetListingAddressByAppealChallengeID,
+  // makeGetUserChallengeData,
+  // makeGetUnclaimedRewardAmount,
+  // getChallengeState,
+} from "../../selectors";
+import { WinningChallengeResults } from "./WinningChallengeResults";
+import { PhaseCountdownTimer } from "./PhaseCountdownTimer";
+import { fetchAndAddListingData } from "../../redux/actionCreators/listings";
+import { getContent } from "../../redux/actionCreators/newsrooms";
 
 export interface ActivityListAppealChallengeItemOwnProps {
   listingAddress?: string;
@@ -57,229 +58,226 @@ class ActivityListAppealChallengeItemComponent extends React.Component<
     DispatchProp<any>
 > {
   public async componentDidUpdate(): Promise<void> {
-    // if (!this.props.listing && !this.props.listingDataRequestStatus) {
-    //   this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress!));
-    // }
-    // if (this.props.newsroom) {
-    //   this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
-    // }
+    if (!this.props.listing && !this.props.listingDataRequestStatus) {
+      this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress!));
+    }
+    if (this.props.newsroom) {
+      this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
+    }
   }
 
   public async componentDidMount(): Promise<void> {
-    // if (!this.props.listing && !this.props.listingDataRequestStatus) {
-    //   this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress!));
-    // }
-    // if (this.props.newsroom) {
-    //   this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
-    // }
+    if (!this.props.listing && !this.props.listingDataRequestStatus) {
+      this.props.dispatch!(fetchAndAddListingData(this.props.listingAddress!));
+    }
+    if (this.props.newsroom) {
+      this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
+    }
   }
 
   public render(): JSX.Element {
-    console.log("AppealChallengeItem props: ", this.props);
-    // const { listingAddress: address, listing, newsroom, listingPhaseState, charter } = this.props;
-    // if (listing && listing.data && newsroom && listingPhaseState) {
-    //   const newsroomData = newsroom.wrapper.data;
-    //   let listingDetailURL = `/listing/${address}`;
-    //   if (this.props.challenge) {
-    //     listingDetailURL = `/listing/${address}/challenge/${this.props.challenge.challengeID}`;
-    //   }
-    //   const buttonTextTuple = this.getButtonText();
-    const props = {
-      newsroomName: "test", // newsroomData.name,
-      charter: undefined,
-      listingDetailURL: "test",
-      buttonText: "test", // buttonTextTuple[0],
-      buttonHelperText: "test", // buttonTextTuple[1],
-      challengeID: this.props.challengeID,
-      salt: this.props.userChallengeData && this.props.userChallengeData.salt,
-      toggleSelect: this.props.toggleSelect,
-    };
+    const { listingAddress: address, listing, newsroom /*, listingPhaseState, charter*/ } = this.props;
+    if (listing && listing.data && newsroom /*&& listingPhaseState*/) {
+      const newsroomData = newsroom.wrapper.data;
+      let listingDetailURL = `/listing/${address}`;
+      if (this.props.challenge) {
+        listingDetailURL = `/listing/${address}/challenge/${this.props.challenge.challengeID}`;
+      }
+      const buttonTextTuple = this.getButtonText();
+      const props = {
+        newsroomName: newsroomData.name,
+        charter: undefined,
+        listingDetailURL,
+        buttonText: buttonTextTuple[0],
+        buttonHelperText: buttonTextTuple[1],
+        challengeID: this.props.challengeID,
+        salt: this.props.userChallengeData && this.props.userChallengeData.salt,
+        toggleSelect: this.props.toggleSelect,
+      };
 
-    return <DashboardActivityItem {...props}>{this.renderActivityDetails()}</DashboardActivityItem>;
-    // } else {
-    // return <></>;
-    // }
+      return <DashboardActivityItem {...props}>{this.renderActivityDetails()}</DashboardActivityItem>;
+    } else {
+      return <></>;
+    }
   }
 
   private renderActivityDetails = (): JSX.Element => {
-    return <span>ok</span>;
+    const { listingPhaseState, challengeState } = this.props;
+    const {
+      isWhitelisted,
+      isInApplication,
+      isRejected,
+      isUnderChallenge,
+      canResolveChallenge,
+      isAwaitingAppealRequest,
+      inChallengeCommitVotePhase,
+      inChallengeRevealPhase,
+    } = listingPhaseState;
+
+    if (!this.props.challenge) {
+      if (isInApplication) {
+        return (
+          <>
+            <p>Awaiting Approval</p>
+          </>
+        );
+      } else if (isWhitelisted && !isUnderChallenge) {
+        return (
+          <>
+            <p>Accepted into Registry</p>
+          </>
+        );
+      } else if (!isRejected && !isInApplication && !isUnderChallenge) {
+        return (
+          <>
+            <p>Rejected from Registry</p>
+          </>
+        );
+      } else if (inChallengeCommitVotePhase) {
+        return (
+          <>
+            <p>Under Challenge > Accepting Votes</p>
+          </>
+        );
+      } else if (inChallengeRevealPhase) {
+        return (
+          <>
+            <p>Under Challenge > Revealing Votes</p>
+          </>
+        );
+      } else if (isAwaitingAppealRequest) {
+        return (
+          <>
+            <p>Under Challenge > Awaiting Appeal Request</p>
+          </>
+        );
+      } else if (canResolveChallenge) {
+        return (
+          <>
+            <p>Under Challenge > Complete</p>
+          </>
+        );
+      }
+    } else if (challengeState) {
+      if (listingPhaseState && inChallengeCommitVotePhase) {
+        return (
+          <PhaseCountdownTimer phaseType={PHASE_TYPE_NAMES.CHALLENGE_COMMIT_VOTE} challenge={this.props.challenge} />
+        );
+      }
+
+      if (listingPhaseState && inChallengeRevealPhase) {
+        return (
+          <PhaseCountdownTimer phaseType={PHASE_TYPE_NAMES.CHALLENGE_REVEAL_VOTE} challenge={this.props.challenge} />
+        );
+      }
+
+      if (listingPhaseState && isAwaitingAppealRequest) {
+        return (
+          <PhaseCountdownTimer
+            phaseType={PHASE_TYPE_NAMES.CHALLENGE_AWAITING_APPEAL_REQUEST}
+            challenge={this.props.challenge}
+          />
+        );
+      }
+
+      if (challengeState.isResolved) {
+        return (
+          <>
+            <WinningChallengeResults challengeID={this.props.challenge.challengeID} />
+          </>
+        );
+      }
+    }
+
+    return <></>;
   };
-  //   const { listingPhaseState, challengeState } = this.props;
-  //   const {
-  //     isWhitelisted,
-  //     isInApplication,
-  //     isRejected,
-  //     isUnderChallenge,
-  //     canResolveChallenge,
-  //     isAwaitingAppealRequest,
-  //     inChallengeCommitVotePhase,
-  //     inChallengeRevealPhase,
-  //   } = listingPhaseState;
 
-  //   if (!this.props.challenge) {
-  //     if (isInApplication) {
-  //       return (
-  //         <>
-  //           <p>Awaiting Approval</p>
-  //         </>
-  //       );
-  //     } else if (isWhitelisted && !isUnderChallenge) {
-  //       return (
-  //         <>
-  //           <p>Accepted into Registry</p>
-  //         </>
-  //       );
-  //     } else if (!isRejected && !isInApplication && !isUnderChallenge) {
-  //       return (
-  //         <>
-  //           <p>Rejected from Registry</p>
-  //         </>
-  //       );
-  //     } else if (inChallengeCommitVotePhase) {
-  //       return (
-  //         <>
-  //           <p>Under Challenge > Accepting Votes</p>
-  //         </>
-  //       );
-  //     } else if (inChallengeRevealPhase) {
-  //       return (
-  //         <>
-  //           <p>Under Challenge > Revealing Votes</p>
-  //         </>
-  //       );
-  //     } else if (isAwaitingAppealRequest) {
-  //       return (
-  //         <>
-  //           <p>Under Challenge > Awaiting Appeal Request</p>
-  //         </>
-  //       );
-  //     } else if (canResolveChallenge) {
-  //       return (
-  //         <>
-  //           <p>Under Challenge > Complete</p>
-  //         </>
-  //       );
-  //     }
-  //   } else if (challengeState) {
-  //     if (listingPhaseState && inChallengeCommitVotePhase) {
-  //       return (
-  //         <PhaseCountdownTimer phaseType={PHASE_TYPE_NAMES.CHALLENGE_COMMIT_VOTE} challenge={this.props.challenge} />
-  //       );
-  //     }
+  private getButtonText = (): [string, string | JSX.Element | undefined] => {
+    const { listingAddress, listingPhaseState, userChallengeData } = this.props;
 
-  //     if (listingPhaseState && inChallengeRevealPhase) {
-  //       return (
-  //         <PhaseCountdownTimer phaseType={PHASE_TYPE_NAMES.CHALLENGE_REVEAL_VOTE} challenge={this.props.challenge} />
-  //       );
-  //     }
+    if (listingPhaseState && listingPhaseState.inChallengeRevealPhase && userChallengeData) {
+      if (userChallengeData.didUserCommit && !userChallengeData.didUserReveal) {
+        return ["Reveal Vote", undefined];
+      } else {
+        return ["View", "You revealed your vote"];
+      }
+    }
 
-  //     if (listingPhaseState && isAwaitingAppealRequest) {
-  //       return (
-  //         <PhaseCountdownTimer
-  //           phaseType={PHASE_TYPE_NAMES.CHALLENGE_AWAITING_APPEAL_REQUEST}
-  //           challenge={this.props.challenge}
-  //         />
-  //       );
-  //     }
+    if (listingPhaseState && listingPhaseState.canResolveChallenge) {
+      return ["Resolve Challenge", undefined];
+    }
 
-  //     if (challengeState.isResolved) {
-  //       return (
-  //         <>
-  //           <WinningChallengeResults challengeID={this.props.challenge.challengeID} />
-  //         </>
-  //       );
-  //     }
-  //   }
+    if (userChallengeData) {
+      const {
+        didUserCommit,
+        didUserReveal,
+        isVoterWinner,
+        didUserCollect,
+        didCollectAmount,
+        didUserRescue,
+      } = userChallengeData;
 
-  //   return <></>;
-  // };
+      if (
+        listingPhaseState &&
+        !listingPhaseState.isUnderChallenge &&
+        didUserReveal &&
+        isVoterWinner &&
+        !didUserCollect
+      ) {
+        return ["Claim Rewards", `~${this.props.unclaimedRewardAmount} available`];
+      } else if (listingPhaseState && !listingPhaseState.isUnderChallenge && didUserReveal && !isVoterWinner) {
+        return ["View Results", "You did not vote for the winner"];
+      } else if (
+        listingPhaseState &&
+        !listingPhaseState.isUnderChallenge &&
+        didUserCommit &&
+        !didUserReveal &&
+        !didUserRescue
+      ) {
+        return ["Rescue Tokens", "You did not reveal your vote"];
+      } else if (listingPhaseState && !listingPhaseState.isUnderChallenge && didUserRescue) {
+        return ["View Results", "You rescued your tokens"];
+      } else if (didUserCollect) {
+        const reward = getFormattedTokenBalance(didCollectAmount!);
+        return ["View Results", `You collected ${reward}`];
+      }
+    }
 
-  // private getButtonText = (): [string, string | JSX.Element | undefined] => {
-  //   const { listingAddress, listingPhaseState, userChallengeData } = this.props;
+    // This is a listing
+    if (!userChallengeData && listingAddress) {
+      const manageNewsroomUrl = `/mgmt-v1/${this.props.listingAddress}`;
+      return ["View", <Link to={manageNewsroomUrl}>Manage Newsroom</Link>];
+    }
 
-  //   if (listingPhaseState && listingPhaseState.inChallengeRevealPhase && userChallengeData) {
-  //     if (userChallengeData.didUserCommit && !userChallengeData.didUserReveal) {
-  //       return ["Reveal Vote", undefined];
-  //     } else {
-  //       return ["View", "You revealed your vote"];
-  //     }
-  //   }
-
-  //   if (listingPhaseState && listingPhaseState.canResolveChallenge) {
-  //     return ["Resolve Challenge", undefined];
-  //   }
-
-  //   if (userChallengeData) {
-  //     const {
-  //       didUserCommit,
-  //       didUserReveal,
-  //       isVoterWinner,
-  //       didUserCollect,
-  //       didCollectAmount,
-  //       didUserRescue,
-  //     } = userChallengeData;
-
-  //     if (
-  //       listingPhaseState &&
-  //       !listingPhaseState.isUnderChallenge &&
-  //       didUserReveal &&
-  //       isVoterWinner &&
-  //       !didUserCollect
-  //     ) {
-  //       return ["Claim Rewards", `~${this.props.unclaimedRewardAmount} available`];
-  //     } else if (listingPhaseState && !listingPhaseState.isUnderChallenge && didUserReveal && !isVoterWinner) {
-  //       return ["View Results", "You did not vote for the winner"];
-  //     } else if (
-  //       listingPhaseState &&
-  //       !listingPhaseState.isUnderChallenge &&
-  //       didUserCommit &&
-  //       !didUserReveal &&
-  //       !didUserRescue
-  //     ) {
-  //       return ["Rescue Tokens", "You did not reveal your vote"];
-  //     } else if (listingPhaseState && !listingPhaseState.isUnderChallenge && didUserRescue) {
-  //       return ["View Results", "You rescued your tokens"];
-  //     } else if (didUserCollect) {
-  //       const reward = getFormattedTokenBalance(didCollectAmount!);
-  //       return ["View Results", `You collected ${reward}`];
-  //     }
-  //   }
-
-  //   // This is a listing
-  //   if (!userChallengeData && listingAddress) {
-  //     const manageNewsroomUrl = `/mgmt-v1/${this.props.listingAddress}`;
-  //     return ["View", <Link to={manageNewsroomUrl}>Manage Newsroom</Link>];
-  //   }
-
-  //   return ["View", undefined];
-  // };
+    return ["View", undefined];
+  };
 }
 
 const makeMapStateToProps = () => {
-  // const getListing = makeGetListing();
+  const getListing = makeGetListing();
 
   const mapStateToProps = (
     state: State,
     ownProps: ActivityListAppealChallengeItemOwnProps,
   ): ActivityListAppealChallengeItemReduxProps & ActivityListAppealChallengeItemOwnProps => {
-    // const { newsrooms } = state;
-    // const { user, content } = state.networkDependent;
-    // const newsroom = ownProps.listingAddress ? newsrooms.get(ownProps.listingAddress) : undefined;
-    // const listing = getListing(state, ownProps);
-    // let charter;
-    // if (newsroom && newsroom.wrapper.data.charterHeader) {
-    //   charter = content.get(newsroom.wrapper.data.charterHeader.uri) as CharterData;
-    // }
-    // let userAcct = ownProps.user;
-    // if (!userAcct) {
-    //   userAcct = user.account.account;
-    // }
+    const { newsrooms } = state;
+    const { user, content } = state.networkDependent;
+    const newsroom = ownProps.listingAddress ? newsrooms.get(ownProps.listingAddress) : undefined;
+    const listing = getListing(state, ownProps);
+    let charter;
+    if (newsroom && newsroom.wrapper.data.charterHeader) {
+      charter = content.get(newsroom.wrapper.data.charterHeader.uri) as CharterData;
+    }
+    let userAcct = ownProps.user;
+    if (!userAcct) {
+      userAcct = user.account.account;
+    }
 
     return {
-      // newsroom,
-      // charter,
-      // listing,
-      // listingPhaseState: getListingPhaseState(listing),
+      newsroom,
+      charter,
+      listing,
+      listingPhaseState: getListingPhaseState(listing),
       ...ownProps,
     };
   };
@@ -290,7 +288,7 @@ const makeMapStateToProps = () => {
 export const ActivityListAppealChallengeItem = connect(makeMapStateToProps)(ActivityListAppealChallengeItemComponent);
 
 const makeChallengeMapStateToProps = () => {
-  // const getListingAddressByChallengeID = makeGetListingAddressByChallengeID();
+  // const getListingAddressByAppealChallengeID = makeGetListingAddressByAppealChallengeID();
   // const getUserChallengeData = makeGetUserChallengeData();
   // const getUnclaimedRewardAmount = makeGetUnclaimedRewardAmount();
 
@@ -298,17 +296,23 @@ const makeChallengeMapStateToProps = () => {
     state: State,
     ownProps: AppealChallengeActivityListItemOwnProps,
   ): ActivityListAppealChallengeItemOwnProps => {
-    // const listingAddress = getListingAddressByChallengeID(state, ownProps);
+    // const listingAddress = getListingAddressByAppealChallengeID(state, ownProps);
     // const challenge = getChallenge(state, ownProps);
     // const userChallengeData = getUserChallengeData(state, ownProps);
     // const unclaimedRewardAmountBN = getUnclaimedRewardAmount(state, ownProps);
     // const challengeState = getChallengeState(challenge!);
-    // const { even, user } = ownProps;
-    // const { listingsFetching } = state.networkDependent;
-    // let listingDataRequestStatus;
-    // if (listingAddress) {
-    //   listingDataRequestStatus = listingsFetching.get(listingAddress.toString());
-    // }
+    const { even, user } = ownProps;
+    const { listingsFetching, challenges, appealChallengeIDsToChallengeIDs } = state.networkDependent;
+    console.log("challenges: ", challenges);
+    const parentChallengeID = appealChallengeIDsToChallengeIDs.get(ownProps.challengeID);
+    const listingAddress = challenges.get(parentChallengeID)
+      ? challenges.get(parentChallengeID)!.listingAddress
+      : "unknown";
+    console.log("listingAddress: ", listingAddress);
+    let listingDataRequestStatus;
+    if (listingAddress) {
+      listingDataRequestStatus = listingsFetching.get(listingAddress.toString());
+    }
 
     // let unclaimedRewardAmount = "";
     // if (unclaimedRewardAmountBN) {
@@ -316,14 +320,14 @@ const makeChallengeMapStateToProps = () => {
     // }
 
     return {
-      // listingAddress,
+      listingAddress,
       // challenge,
       // challengeState,
       // userChallengeData,
       // unclaimedRewardAmount,
-      // even,
-      // user,
-      // listingDataRequestStatus,
+      even,
+      user,
+      listingDataRequestStatus,
       ...ownProps,
     };
   };

--- a/packages/dapp/src/components/Dashboard/ChallengesWithRewardsToClaim.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithRewardsToClaim.tsx
@@ -83,7 +83,7 @@ class ChallengesWithRewardsToClaim extends React.Component<
   }
 
   public render(): JSX.Element {
-    const isClaimRewardsButtonDisabled = !this.state.challengesToClaim.length;
+    const isClaimRewardsButtonDisabled = this.isEmpty(this.state.challengesToClaim);
     const transactions = this.getTransactions();
 
     return (
@@ -140,6 +140,15 @@ class ChallengesWithRewardsToClaim extends React.Component<
       },
     ];
   };
+
+  private isEmpty(obj: any): boolean {
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   private setChallengesToMultiClaim = (challengeID: string, isSelected: boolean, salt: BigNumber): void => {
     this.setState(() => ({

--- a/packages/dapp/src/components/Dashboard/ChallengesWithRewardsToClaim.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithRewardsToClaim.tsx
@@ -55,6 +55,7 @@ const transactionStatusModalConfig = {
 
 export interface ChallengesWithRewardsToClaimProps {
   challenges: any;
+  appealChallenges: any;
   onMobileTransactionClick?(): any;
 }
 
@@ -92,6 +93,7 @@ class ChallengesWithRewardsToClaim extends React.Component<
         </StyledDashboardActivityDescription>
         <ActivityList
           challenges={this.props.challenges}
+          appealChallenges={this.props.appealChallenges}
           resolvedChallenges={true}
           toggleChallengeSelect={this.setChallengesToMultiClaim}
         />

--- a/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
@@ -86,9 +86,6 @@ class ChallengesWithTokensToRescue extends React.Component<
   }
 
   public render(): JSX.Element {
-    console.log("this.state.challengesToRescue: ", this.state.challengesToRescue);
-    console.log("this.state.challengesToRescue.length: ", this.state.challengesToRescue.length);
-    console.log("this.state.challengesToRescue.isEmpty(): ", this.isEmpty(this.state.challengesToRescue));
     const isRescueTokensButtonDisabled = this.isEmpty(this.state.challengesToRescue);
     const transactions = this.getTransactions();
 

--- a/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
@@ -157,9 +157,6 @@ class ChallengesWithTokensToRescue extends React.Component<
   };
 
   private setChallengesToMultiRescue = (challengeID: string, isSelected: boolean, salt: BigNumber): void => {
-    console.log("set challenges to multi rescue. challengeID: ", challengeID);
-    console.log("set challenges to multi rescue. isSelected: ", isSelected);
-    console.log("set challenges to multi rescue. salt: ", salt);
     this.setState(() => ({
       challengesToRescue: { ...this.state.challengesToRescue, [challengeID]: [isSelected, new BigNumber(0)] },
     }));

--- a/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
@@ -58,6 +58,7 @@ const transactionStatusModalConfig = {
 
 export interface ChallengesWithTokensToRescueProps {
   challenges: any;
+  appealChallenges: any;
   onMobileTransactionClick?(): any;
 }
 
@@ -85,7 +86,10 @@ class ChallengesWithTokensToRescue extends React.Component<
   }
 
   public render(): JSX.Element {
-    const isRescueTokensButtonDisabled = !this.state.challengesToRescue.length;
+    console.log("this.state.challengesToRescue: ", this.state.challengesToRescue);
+    console.log("this.state.challengesToRescue.length: ", this.state.challengesToRescue.length);
+    console.log("this.state.challengesToRescue.isEmpty(): ", this.isEmpty(this.state.challengesToRescue));
+    const isRescueTokensButtonDisabled = this.isEmpty(this.state.challengesToRescue);
     const transactions = this.getTransactions();
 
     return (
@@ -95,6 +99,7 @@ class ChallengesWithTokensToRescue extends React.Component<
         </StyledDashboardActivityDescription>
         <ActivityList
           challenges={this.props.challenges}
+          appealChallenges={this.props.appealChallenges}
           resolvedChallenges={true}
           toggleChallengeSelect={this.setChallengesToMultiRescue}
         />
@@ -110,6 +115,15 @@ class ChallengesWithTokensToRescue extends React.Component<
         </StyledBatchButtonContainer>
       </>
     );
+  }
+
+  private isEmpty(obj: any): boolean {
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private getTransactions = (): any[] => {
@@ -143,8 +157,11 @@ class ChallengesWithTokensToRescue extends React.Component<
   };
 
   private setChallengesToMultiRescue = (challengeID: string, isSelected: boolean, salt: BigNumber): void => {
+    console.log("set challenges to multi rescue. challengeID: ", challengeID);
+    console.log("set challenges to multi rescue. isSelected: ", isSelected);
+    console.log("set challenges to multi rescue. salt: ", salt);
     this.setState(() => ({
-      challengesToRescue: { ...this.state.challengesToRescue, [challengeID]: [isSelected, salt] },
+      challengesToRescue: { ...this.state.challengesToRescue, [challengeID]: [isSelected, new BigNumber(0)] },
     }));
   };
 

--- a/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
@@ -155,7 +155,7 @@ class ChallengesWithTokensToRescue extends React.Component<
 
   private setChallengesToMultiRescue = (challengeID: string, isSelected: boolean, salt: BigNumber): void => {
     this.setState(() => ({
-      challengesToRescue: { ...this.state.challengesToRescue, [challengeID]: [isSelected, new BigNumber(0)] },
+      challengesToRescue: { ...this.state.challengesToRescue, [challengeID]: [isSelected, salt] },
     }));
   };
 

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -25,6 +25,7 @@ import {
   getUserChallengesWithRescueTokens,
   getChallengesStartedByUser,
   getChallengesVotedOnByUser,
+  getUserAppealChallengesWithRescueTokens,
 } from "../../selectors";
 
 import ActivityList from "./ActivityList";
@@ -165,7 +166,7 @@ class DashboardActivity extends React.Component<
           </Tab>
           <Tab title={rescueTokensTabTitle}>
             <ChallengesWithTokensToRescue
-              challenges={userChallengesWithUnclaimedRewards}
+              challenges={userChallengesWithRescueTokens}
               onMobileTransactionClick={this.showNoMobileTransactionsModal}
             />
           </Tab>
@@ -216,7 +217,13 @@ const mapStateToProps = (
   const currentUserChallengesStarted = getChallengesStartedByUser(state);
   const userChallengesWithUnclaimedRewards = getUserChallengesWithUnclaimedRewards(state);
   const userChallengesWithUnrevealedVotes = getUserChallengesWithUnrevealedVotes(state);
-  const userChallengesWithRescueTokens = getUserChallengesWithRescueTokens(state);
+
+  // console.log("getUserChallengesWithRescueTokens(state): ", getUserChallengesWithRescueTokens(state));
+  console.log("getUserAppealChallengesWithRescueTokens(state): ", getUserAppealChallengesWithRescueTokens(state));
+
+  const userChallengesWithRescueTokens = getUserChallengesWithRescueTokens(state)!.merge(
+    getUserAppealChallengesWithRescueTokens(state)!.toArray(),
+  );
 
   return {
     currentUserNewsrooms,

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -48,6 +48,7 @@ export interface DashboardActivityReduxProps {
   userChallengesWithUnclaimedRewards?: Set<string>;
   userChallengesWithUnrevealedVotes?: Set<string>;
   userChallengesWithRescueTokens?: Set<string>;
+  userAppealChallengesWithRescueTokens?: Set<string>;
   userAccount: EthAddress;
 }
 
@@ -76,6 +77,7 @@ export const StyledBatchButtonContainer = styled.div`
 // explicit type that describes this object that gets checked and that type has a field
 // called something like `isSelected` so this code is a bit clearer
 export const getChallengesToProcess = (challengeObj: ChallengesToProcess): BigNumber[] => {
+  console.log("getChallengesToProcess");
   const challengesToCheck = Object.entries(challengeObj);
   const challengesToProcess: BigNumber[] = challengesToCheck
     .map((challengeToProcess: [string, [boolean, BigNumber]]) => {
@@ -143,11 +145,16 @@ class DashboardActivity extends React.Component<
       userChallengesWithUnclaimedRewards,
       userChallengesWithUnrevealedVotes,
       userChallengesWithRescueTokens,
+      userAppealChallengesWithRescueTokens,
     } = this.props;
     const allVotesTabTitle = <AllChallengesDashboardTabTitle count={currentUserChallengesVotedOn.count()} />;
     const revealVoteTabTitle = <RevealVoteDashboardTabTitle count={userChallengesWithUnrevealedVotes!.count()} />;
     const claimRewardsTabTitle = <ClaimRewardsDashboardTabTitle count={userChallengesWithUnclaimedRewards!.count()} />;
-    const rescueTokensTabTitle = <RescueTokensDashboardTabTitle count={userChallengesWithRescueTokens!.count()} />;
+    const rescueTokensTabTitle = (
+      <RescueTokensDashboardTabTitle
+        count={userChallengesWithRescueTokens!.count() + userAppealChallengesWithRescueTokens!.count()}
+      />
+    );
 
     return (
       <>
@@ -167,6 +174,7 @@ class DashboardActivity extends React.Component<
           <Tab title={rescueTokensTabTitle}>
             <ChallengesWithTokensToRescue
               challenges={userChallengesWithRescueTokens}
+              appealChallenges={userAppealChallengesWithRescueTokens}
               onMobileTransactionClick={this.showNoMobileTransactionsModal}
             />
           </Tab>
@@ -219,11 +227,11 @@ const mapStateToProps = (
   const userChallengesWithUnrevealedVotes = getUserChallengesWithUnrevealedVotes(state);
 
   // console.log("getUserChallengesWithRescueTokens(state): ", getUserChallengesWithRescueTokens(state));
-  console.log("getUserAppealChallengesWithRescueTokens(state): ", getUserAppealChallengesWithRescueTokens(state));
+  // console.log("getUserAppealChallengesWithRescueTokens(state): ", getUserAppealChallengesWithRescueTokens(state));
 
-  const userChallengesWithRescueTokens = getUserChallengesWithRescueTokens(state)!.merge(
-    getUserAppealChallengesWithRescueTokens(state)!.toArray(),
-  );
+  const userChallengesWithRescueTokens = getUserChallengesWithRescueTokens(state);
+  const userAppealChallengesWithRescueTokens = getUserAppealChallengesWithRescueTokens(state);
+  console.log("userAppealChallengesWithRescueTokens: ", userAppealChallengesWithRescueTokens);
 
   return {
     currentUserNewsrooms,
@@ -232,6 +240,7 @@ const mapStateToProps = (
     userChallengesWithUnclaimedRewards,
     userChallengesWithUnrevealedVotes,
     userChallengesWithRescueTokens,
+    userAppealChallengesWithRescueTokens,
     userAccount: user.account.account,
     ...ownProps,
   };

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -77,7 +77,6 @@ export const StyledBatchButtonContainer = styled.div`
 // explicit type that describes this object that gets checked and that type has a field
 // called something like `isSelected` so this code is a bit clearer
 export const getChallengesToProcess = (challengeObj: ChallengesToProcess): BigNumber[] => {
-  console.log("getChallengesToProcess");
   const challengesToCheck = Object.entries(challengeObj);
   const challengesToProcess: BigNumber[] = challengesToCheck
     .map((challengeToProcess: [string, [boolean, BigNumber]]) => {
@@ -226,12 +225,8 @@ const mapStateToProps = (
   const userChallengesWithUnclaimedRewards = getUserChallengesWithUnclaimedRewards(state);
   const userChallengesWithUnrevealedVotes = getUserChallengesWithUnrevealedVotes(state);
 
-  // console.log("getUserChallengesWithRescueTokens(state): ", getUserChallengesWithRescueTokens(state));
-  // console.log("getUserAppealChallengesWithRescueTokens(state): ", getUserAppealChallengesWithRescueTokens(state));
-
   const userChallengesWithRescueTokens = getUserChallengesWithRescueTokens(state);
   const userAppealChallengesWithRescueTokens = getUserAppealChallengesWithRescueTokens(state);
-  console.log("userAppealChallengesWithRescueTokens: ", userAppealChallengesWithRescueTokens);
 
   return {
     currentUserNewsrooms,

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -26,6 +26,8 @@ import {
   getChallengesStartedByUser,
   getChallengesVotedOnByUser,
   getUserAppealChallengesWithRescueTokens,
+  getUserAppealChallengesWithUnrevealedVotes,
+  getUserAppealChallengesWithUnclaimedRewards,
 } from "../../selectors";
 
 import ActivityList from "./ActivityList";
@@ -48,7 +50,9 @@ export interface DashboardActivityReduxProps {
   userChallengesWithUnclaimedRewards?: Set<string>;
   userChallengesWithUnrevealedVotes?: Set<string>;
   userChallengesWithRescueTokens?: Set<string>;
+  userAppealChallengesWithUnclaimedRewards?: Set<string>;
   userAppealChallengesWithRescueTokens?: Set<string>;
+  userAppealChallengesWithUnrevealedVotes?: Set<string>;
   userAccount: EthAddress;
 }
 
@@ -145,10 +149,20 @@ class DashboardActivity extends React.Component<
       userChallengesWithUnrevealedVotes,
       userChallengesWithRescueTokens,
       userAppealChallengesWithRescueTokens,
+      userAppealChallengesWithUnrevealedVotes,
+      userAppealChallengesWithUnclaimedRewards,
     } = this.props;
     const allVotesTabTitle = <AllChallengesDashboardTabTitle count={currentUserChallengesVotedOn.count()} />;
-    const revealVoteTabTitle = <RevealVoteDashboardTabTitle count={userChallengesWithUnrevealedVotes!.count()} />;
-    const claimRewardsTabTitle = <ClaimRewardsDashboardTabTitle count={userChallengesWithUnclaimedRewards!.count()} />;
+    const revealVoteTabTitle = (
+      <RevealVoteDashboardTabTitle
+        count={userChallengesWithUnrevealedVotes!.count() + userAppealChallengesWithUnrevealedVotes!.count()}
+      />
+    );
+    const claimRewardsTabTitle = (
+      <ClaimRewardsDashboardTabTitle
+        count={userChallengesWithUnclaimedRewards!.count() + userAppealChallengesWithUnclaimedRewards!.count()}
+      />
+    );
     const rescueTokensTabTitle = (
       <RescueTokensDashboardTabTitle
         count={userChallengesWithRescueTokens!.count() + userAppealChallengesWithRescueTokens!.count()}
@@ -162,11 +176,15 @@ class DashboardActivity extends React.Component<
             <ActivityList challenges={currentUserChallengesVotedOn} />
           </Tab>
           <Tab title={revealVoteTabTitle}>
-            <ActivityList challenges={userChallengesWithUnrevealedVotes} />
+            <ActivityList
+              challenges={userChallengesWithUnrevealedVotes}
+              appealChallenges={userAppealChallengesWithUnrevealedVotes}
+            />
           </Tab>
           <Tab title={claimRewardsTabTitle}>
             <ChallengesWithRewardsToClaim
               challenges={userChallengesWithUnclaimedRewards}
+              appealChallenges={userAppealChallengesWithUnclaimedRewards}
               onMobileTransactionClick={this.showNoMobileTransactionsModal}
             />
           </Tab>
@@ -223,7 +241,9 @@ const mapStateToProps = (
   const currentUserChallengesVotedOn = getChallengesVotedOnByUser(state);
   const currentUserChallengesStarted = getChallengesStartedByUser(state);
   const userChallengesWithUnclaimedRewards = getUserChallengesWithUnclaimedRewards(state);
+  const userAppealChallengesWithUnclaimedRewards = getUserAppealChallengesWithUnclaimedRewards(state);
   const userChallengesWithUnrevealedVotes = getUserChallengesWithUnrevealedVotes(state);
+  const userAppealChallengesWithUnrevealedVotes = getUserAppealChallengesWithUnrevealedVotes(state);
 
   const userChallengesWithRescueTokens = getUserChallengesWithRescueTokens(state);
   const userAppealChallengesWithRescueTokens = getUserAppealChallengesWithRescueTokens(state);
@@ -235,6 +255,8 @@ const mapStateToProps = (
     userChallengesWithUnclaimedRewards,
     userChallengesWithUnrevealedVotes,
     userChallengesWithRescueTokens,
+    userAppealChallengesWithUnclaimedRewards,
+    userAppealChallengesWithUnrevealedVotes,
     userAppealChallengesWithRescueTokens,
     userAccount: user.account.account,
     ...ownProps,

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -9,6 +9,7 @@ import {
   addUserAppealChallengeData,
   addUserChallengeData,
   addUserChallengeStarted,
+  linkAppealChallengeToChallenge,
 } from "../redux/actionCreators/challenges";
 import { addListing, setLoadingFinished } from "../redux/actionCreators/listings";
 import { addUserNewsroom, addContent } from "../redux/actionCreators/newsrooms";
@@ -97,6 +98,7 @@ export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, 
       if (!pollID.equals(challengeId)) {
         const appealChallengeUserData = await tcr.getUserChallengeData(pollID, user);
         dispatch(addUserAppealChallengeData(pollID.toString(), user, appealChallengeUserData));
+        dispatch(linkAppealChallengeToChallenge(pollID.toString(), challengeId.toString()));
       }
     });
 

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -87,21 +87,15 @@ export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, 
     .getVoting()
     .votesCommitted(undefined, user)
     .subscribe(async (pollID: BigNumber) => {
-      console.log("vote committed pollID: " + pollID);
       const challengeId = await tcr.getChallengeIDForPollID(pollID);
       const wrappedChallenge = await tcr.getChallengeData(challengeId);
-      console.log("got challenge for pollID: " + pollID);
       dispatch(addChallenge(wrappedChallenge));
       const challengeUserData = await tcr.getUserChallengeData(challengeId, user);
-      console.log("got user challenge data: ", challengeUserData);
       dispatch(addUserChallengeData(challengeId.toString(), user, challengeUserData));
 
       // if the challenge ID corresponds to an appeal challenge, get any user data for it
       if (!pollID.equals(challengeId)) {
-        console.log("found one with diff");
         const appealChallengeUserData = await tcr.getUserChallengeData(pollID, user);
-        console.log("add user appeal challenge data for pollID: " + pollID);
-        console.log("and that data is: ", appealChallengeUserData);
         dispatch(addUserAppealChallengeData(pollID.toString(), user, appealChallengeUserData));
       }
     });

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -87,15 +87,21 @@ export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, 
     .getVoting()
     .votesCommitted(undefined, user)
     .subscribe(async (pollID: BigNumber) => {
+      console.log("vote committed pollID: " + pollID);
       const challengeId = await tcr.getChallengeIDForPollID(pollID);
       const wrappedChallenge = await tcr.getChallengeData(challengeId);
+      console.log("got challenge for pollID: " + pollID);
       dispatch(addChallenge(wrappedChallenge));
       const challengeUserData = await tcr.getUserChallengeData(challengeId, user);
+      console.log("got user challenge data: ", challengeUserData);
       dispatch(addUserChallengeData(challengeId.toString(), user, challengeUserData));
 
       // if the challenge ID corresponds to an appeal challenge, get any user data for it
       if (!pollID.equals(challengeId)) {
+        console.log("found one with diff");
         const appealChallengeUserData = await tcr.getUserChallengeData(pollID, user);
+        console.log("add user appeal challenge data for pollID: " + pollID);
+        console.log("and that data is: ", appealChallengeUserData);
         dispatch(addUserAppealChallengeData(pollID.toString(), user, appealChallengeUserData));
       }
     });

--- a/packages/dapp/src/redux/actionCreators/challenges.ts
+++ b/packages/dapp/src/redux/actionCreators/challenges.ts
@@ -16,6 +16,7 @@ export enum challengeActions {
   FETCH_GRANT_APPEAL_TX = "FETCH_GRANT_APPEAL_TX",
   FETCH_AND_ADD_CHALLENGE_DATA = "FETCH_AND_ADD_CHALLENGE_DATA",
   FETCH_AND_ADD_GRANT_APPEAL_TX = "FETCH_AND_ADD_GRANT_APPEAL_TX",
+  LINK_APPEAL_CHALLENGE_TO_CHALLENGE = "LINK_APPEAL_CHALLENGE_TO_CHALLENGE",
 }
 
 export const addGrantAppealTx = (listingAddress: EthAddress, txData: TxDataAll): AnyAction => {
@@ -90,6 +91,16 @@ export const fetchChallengeComplete = (challengeID: string): AnyAction => {
     data: {
       challengeID,
       isFetching: false,
+    },
+  };
+};
+
+export const linkAppealChallengeToChallenge = (appealChallengeID: string, challengeID: string): AnyAction => {
+  return {
+    type: challengeActions.LINK_APPEAL_CHALLENGE_TO_CHALLENGE,
+    data: {
+      appealChallengeID,
+      challengeID,
     },
   };
 };

--- a/packages/dapp/src/redux/reducers/challenges.ts
+++ b/packages/dapp/src/redux/reducers/challenges.ts
@@ -15,6 +15,18 @@ export function challenges(
   }
 }
 
+export function appealChallengeIDsToChallengeIDs(
+  state: Map<string, string> = Map<string, string>(),
+  action: AnyAction,
+): Map<string, string> {
+  switch (action.type) {
+    case challengeActions.LINK_APPEAL_CHALLENGE_TO_CHALLENGE:
+      return state.set(action.data.appealChallengeID.toString(), action.data.challengeID.toString());
+    default:
+      return state;
+  }
+}
+
 export function grantAppealTxs(
   state: Map<string, TxDataAll> = Map<string, TxDataAll>(),
   action: AnyAction,

--- a/packages/dapp/src/redux/reducers/index.ts
+++ b/packages/dapp/src/redux/reducers/index.ts
@@ -40,6 +40,7 @@ import {
   challengeUserData,
   grantAppealTxs,
   grantAppealTxsFetching,
+  appealChallengeIDsToChallengeIDs,
 } from "./challenges";
 import {
   government,
@@ -116,6 +117,7 @@ export interface NetworkDependentState {
   challengeUserData: Map<string, Map<string, UserChallengeData>>;
   grantAppealTxs: Map<string, TxDataAll>;
   grantAppealTxsFetching: Map<string, boolean>;
+  appealChallengeIDsToChallengeIDs: Map<string, string>;
   appealChallengeUserData: Map<string, Map<string, UserChallengeData>>;
   government: Map<string, string>;
   constitution: Map<string, string>;
@@ -164,6 +166,7 @@ const networkDependentReducers = combineReducers({
   challengeUserData,
   grantAppealTxs,
   grantAppealTxsFetching,
+  appealChallengeIDsToChallengeIDs,
   appealChallengeUserData,
   government,
   constitution,

--- a/packages/dapp/src/selectors/index.ts
+++ b/packages/dapp/src/selectors/index.ts
@@ -347,23 +347,38 @@ export const getUserChallengesWithRescueTokens = createSelector(
   },
 );
 
+export const getUserAppealChallengesWithUnrevealedVotes = createSelector(
+  [getAppealChallengeUserData, getUser],
+  (challengeUserData, user) => {
+    if (!challengeUserData || !user || !user.account) {
+      return;
+    }
+    return challengeUserData
+      .filter((challengeData, challengeID, iter): boolean => {
+        try {
+          const { didUserCommit, didUserReveal, canUserReveal } = challengeData!.get(user.account.account);
+          return !!didUserCommit && !didUserReveal && canUserReveal!;
+        } catch (ex) {
+          return false;
+        }
+      })
+      .keySeq()
+      .toSet() as Set<string>;
+  },
+);
+
 export const getUserAppealChallengesWithRescueTokens = createSelector(
   [getAppealChallengeUserData, getUser],
   (challengeUserData, user) => {
     if (!challengeUserData || !user || !user.account) {
       return;
     }
-    console.log("appealChallengeUserData: ", challengeUserData);
     return challengeUserData
       .filter((challengeData, challengeID, iter): boolean => {
         try {
           const { didUserCommit, didUserReveal, didUserRescue, canUserRescue } = challengeData!.get(
             user.account.account,
           );
-          console.log("didUserCommit: ", didUserCommit);
-          console.log("didUserReveal: ", didUserReveal);
-          console.log("didUserRescue: ", didUserRescue);
-          console.log("canUserRescue: ", canUserRescue);
           return !!didUserCommit && !didUserReveal && canUserRescue! && !didUserRescue;
         } catch (ex) {
           return false;

--- a/packages/dapp/src/selectors/index.ts
+++ b/packages/dapp/src/selectors/index.ts
@@ -254,6 +254,26 @@ export const getUserChallengesWithUnclaimedRewards = createSelector(
   },
 );
 
+export const getUserAppealChallengesWithUnclaimedRewards = createSelector(
+  [getAppealChallengeUserData, getUser],
+  (appealChallengeUserData, user) => {
+    if (!appealChallengeUserData || !user) {
+      return;
+    }
+    return appealChallengeUserData
+      .filter((challengeData, challengeID, iter): boolean => {
+        try {
+          const { didUserReveal, didUserCollect, isVoterWinner } = challengeData!.get(user.account.account);
+          return !!didUserReveal && !!isVoterWinner && !didUserCollect;
+        } catch (ex) {
+          return false;
+        }
+      })
+      .keySeq()
+      .toSet() as Set<string>;
+  },
+);
+
 export const makeGetUnclaimedRewardAmount = () => {
   return createSelector(
     [getChallengeUserDataMap, getChallenges, getUser, getChallengeID],
@@ -313,8 +333,38 @@ export const getUserChallengesWithRescueTokens = createSelector(
         try {
           const { didUserCommit, didUserReveal, didUserRescue } = challengeData!.get(user.account.account);
           const challenge = challenges.get(challengeID!);
-          const isResolved = challenge && challenge.challenge.resolved;
-          return !!didUserCommit && !didUserReveal && isResolved && !didUserRescue;
+          const canRescue =
+            challenge &&
+            !isChallengeInCommitStage(challenge.challenge) &&
+            !isChallengeInRevealStage(challenge.challenge);
+          return !!didUserCommit && !didUserReveal && canRescue && !didUserRescue;
+        } catch (ex) {
+          return false;
+        }
+      })
+      .keySeq()
+      .toSet() as Set<string>;
+  },
+);
+
+export const getUserAppealChallengesWithRescueTokens = createSelector(
+  [getAppealChallengeUserData, getUser],
+  (challengeUserData, user) => {
+    if (!challengeUserData || !user || !user.account) {
+      return;
+    }
+    console.log("appealChallengeUserData: ", challengeUserData);
+    return challengeUserData
+      .filter((challengeData, challengeID, iter): boolean => {
+        try {
+          const { didUserCommit, didUserReveal, didUserRescue, canUserRescue } = challengeData!.get(
+            user.account.account,
+          );
+          console.log("didUserCommit: ", didUserCommit);
+          console.log("didUserReveal: ", didUserReveal);
+          console.log("didUserRescue: ", didUserRescue);
+          console.log("canUserRescue: ", canUserRescue);
+          return !!didUserCommit && !didUserReveal && canUserRescue! && !didUserRescue;
         } catch (ex) {
           return false;
         }


### PR DESCRIPTION
- adds appeal challenges to rescue and claim rewards for to my activity
- these do not necessarily render properly, the whole my activity section will be overhauled this sprint, but it does unblock users who want to transfer tokens out of voting contract