### PR TITLE
Add Production Push to CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,18 @@ jobs:
                 command: |
                     kubectl set image deployment/dapp dapp=gcr.io/$GOOGLE_PROJECT_ID/dapp:master-$CIRCLE_SHA1 --namespace staging
 
+    deploy-production:
+        <<: *defaults
+        docker:
+            - image: civilmedia/gcloud-node:latest
+        steps:
+            - attach_workspace:
+                at: /root
+            - deploy:
+                name: Update Kubernetes Deployment on PRODUCTION
+                command: |
+                    kubectl set image deployment/dapp dapp=gcr.io/$GOOGLE_PROJECT_ID/dapp:master-$CIRCLE_SHA1 --namespace production
+
 workflows:
     version: 2
     nightly:
@@ -186,6 +198,14 @@ workflows:
                         only:
                             - master
             - deploy-staging:
+                context: gcp-common
+                requires:
+                    - push-containers
+                filters:
+                    branches:
+                        only:
+                            - master
+            - deploy-production:
                 context: gcp-common
                 requires:
                     - push-containers


### PR DESCRIPTION
- When code is pushed to `master`, deploys new container with the dapp code to production namespace in GCP.  
- Keying off the `master` branch for now, but there was some discussion on continuous delivery instead of continuous deployment and keying off a `production` branch. We can debate that offline and make changes later, just want to get the production deployment ready.

CIVIL-185