### PR TITLE
Fixes for Dashboard page

### DIFF
--- a/packages/components/src/PhaseCountdown/constants.ts
+++ b/packages/components/src/PhaseCountdown/constants.ts
@@ -4,10 +4,14 @@ import {
   ChallengeCommitVotePhaseLabelText,
   ChallengeRevealVotePhaseLabelText,
   ChallengeAwaitingAppealRequestPhaseLabelText,
+  ChallengeAwaitingAppealJudgementPhaseLabelText,
   InApplicationFlavorText,
   ChallengeCommitVoteFlavorText,
   ChallengeRevealVoteFlavorText,
   ChallengeAwaitingAppealRequestFlavorText,
+  ChallengeAwaitingAppealJudgementFlavorText,
+  ChallengeAwaitingAppealChallengePhaseLabelText,
+  ChallengeAwaitingAppealChallengeFlavorText,
 } from "./textComponents";
 
 export enum PHASE_TYPE_NAMES {
@@ -15,6 +19,10 @@ export enum PHASE_TYPE_NAMES {
   CHALLENGE_COMMIT_VOTE = "CHALLENGE_COMMIT_VOTE",
   CHALLENGE_REVEAL_VOTE = "CHALLENGE_REVEAL_VOTE",
   CHALLENGE_AWAITING_APPEAL_REQUEST = "CHALLENGE_AWAITING_APPEAL_REQUEST",
+  CHALLENGE_AWAITING_APPEAL_JUDGEMENT = "CHALLENGE_AWAITING_APPEAL_JUDGEMENT",
+  CHALLENGE_AWAITING_APPEAL_CHALLENGE = "CHALLENGE_AWAITING_APPEAL_CHALLENGE",
+  APPEAL_CHALLENGE_COMMIT_VOTE = "APPEAL_CHALLENGE_COMMIT_VOTE",
+  APPEAL_CHALLENGE_REVEAL_VOTE = "APPEAL_CHALLENGE_REVEAL_VOTE",
 }
 
 export const PHASE_TYPE_LABEL: { [index: string]: React.SFC } = {
@@ -22,6 +30,10 @@ export const PHASE_TYPE_LABEL: { [index: string]: React.SFC } = {
   CHALLENGE_COMMIT_VOTE: ChallengeCommitVotePhaseLabelText,
   CHALLENGE_REVEAL_VOTE: ChallengeRevealVotePhaseLabelText,
   CHALLENGE_AWAITING_APPEAL_REQUEST: ChallengeAwaitingAppealRequestPhaseLabelText,
+  CHALLENGE_AWAITING_APPEAL_JUDGEMENT: ChallengeAwaitingAppealJudgementPhaseLabelText,
+  CHALLENGE_AWAITING_APPEAL_CHALLENGE: ChallengeAwaitingAppealChallengePhaseLabelText,
+  APPEAL_CHALLENGE_COMMIT_VOTE: ChallengeCommitVotePhaseLabelText,
+  APPEAL_CHALLENGE_REVEAL_VOTE: ChallengeRevealVotePhaseLabelText,
 };
 
 export const PHASE_TYPE_FLAVOR_TEXT: { [index: string]: React.SFC } = {
@@ -29,4 +41,8 @@ export const PHASE_TYPE_FLAVOR_TEXT: { [index: string]: React.SFC } = {
   CHALLENGE_COMMIT_VOTE: ChallengeCommitVoteFlavorText,
   CHALLENGE_REVEAL_VOTE: ChallengeRevealVoteFlavorText,
   CHALLENGE_AWAITING_APPEAL_REQUEST: ChallengeAwaitingAppealRequestFlavorText,
+  CHALLENGE_AWAITING_APPEAL_JUDGEMENT: ChallengeAwaitingAppealJudgementFlavorText,
+  CHALLENGE_AWAITING_APPEAL_CHALLENGE: ChallengeAwaitingAppealChallengeFlavorText,
+  APPEAL_CHALLENGE_COMMIT_VOTE: ChallengeCommitVoteFlavorText,
+  APPEAL_CHALLENGE_REVEAL_VOTE: ChallengeRevealVoteFlavorText,
 };

--- a/packages/components/src/PhaseCountdown/textComponents.tsx
+++ b/packages/components/src/PhaseCountdown/textComponents.tsx
@@ -4,7 +4,7 @@ export const InApplicationPhaseLabelText: React.SFC = props => <>Awaiting Approv
 
 export const ChallengeCommitVotePhaseLabelText: React.SFC = props => <>Commit Vote</>;
 
-export const ChallengeRevealVotePhaseLabelText: React.SFC = props => <>Confirm Vote</>;
+export const ChallengeRevealVotePhaseLabelText: React.SFC = props => <>Reveal Vote</>;
 
 export const ChallengeAwaitingAppealRequestPhaseLabelText: React.SFC = props => <>Awaiting Appeal Request</>;
 
@@ -16,7 +16,7 @@ export const InApplicationFlavorText: React.SFC = props => <>until approval</>;
 
 export const ChallengeCommitVoteFlavorText: React.SFC = props => <>to commit votes</>;
 
-export const ChallengeRevealVoteFlavorText: React.SFC = props => <>to confirm votes</>;
+export const ChallengeRevealVoteFlavorText: React.SFC = props => <>to reveal votes</>;
 
 export const ChallengeAwaitingAppealRequestFlavorText: React.SFC = props => <>to request an appeal</>;
 

--- a/packages/components/src/PhaseCountdown/textComponents.tsx
+++ b/packages/components/src/PhaseCountdown/textComponents.tsx
@@ -2,18 +2,24 @@ import * as React from "react";
 
 export const InApplicationPhaseLabelText: React.SFC = props => <>Awaiting Approval</>;
 
-export const ChallengeCommitVotePhaseLabelText: React.SFC = props => <>Under Challenge &gt; Commiting Votes</>;
+export const ChallengeCommitVotePhaseLabelText: React.SFC = props => <>Commit Vote</>;
 
-export const ChallengeRevealVotePhaseLabelText: React.SFC = props => <>Under Challenge &gt; Revealing Votes</>;
+export const ChallengeRevealVotePhaseLabelText: React.SFC = props => <>Confirm Vote</>;
 
-export const ChallengeAwaitingAppealRequestPhaseLabelText: React.SFC = props => (
-  <>Under Challenge &gt; Awaiting Appeal Request</>
-);
+export const ChallengeAwaitingAppealRequestPhaseLabelText: React.SFC = props => <>Awaiting Appeal Request</>;
+
+export const ChallengeAwaitingAppealJudgementPhaseLabelText: React.SFC = props => <>Awaiting Appeal Decision</>;
+
+export const ChallengeAwaitingAppealChallengePhaseLabelText: React.SFC = props => <>Awaiting Appeal Challenge</>;
 
 export const InApplicationFlavorText: React.SFC = props => <>until approval</>;
 
-export const ChallengeCommitVoteFlavorText: React.SFC = props => <>to submit votes</>;
+export const ChallengeCommitVoteFlavorText: React.SFC = props => <>to commit votes</>;
 
-export const ChallengeRevealVoteFlavorText: React.SFC = props => <>to reveal votes</>;
+export const ChallengeRevealVoteFlavorText: React.SFC = props => <>to confirm votes</>;
 
 export const ChallengeAwaitingAppealRequestFlavorText: React.SFC = props => <>to request an appeal</>;
+
+export const ChallengeAwaitingAppealJudgementFlavorText: React.SFC = props => <>until Council's decision</>;
+
+export const ChallengeAwaitingAppealChallengeFlavorText: React.SFC = props => <>to challenge the granted appeal</>;

--- a/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListAppealChallengeItem.tsx
@@ -85,9 +85,8 @@ class ActivityListAppealChallengeItemComponent extends React.Component<
         listingDetailURL = `/listing/${address}/challenge/${this.props.challenge.challengeID}`;
       }
       const buttonTextTuple = this.getButtonText();
-      console.log("challengeID: ", this.props.challengeID);
       const props = {
-        newsroomName: newsroomData.name,
+        newsroomName: `${newsroomData.name} Appeal Challenge #${this.props.challengeID}`,
         charter,
         listingDetailURL,
         buttonText: buttonTextTuple[0],

--- a/packages/dapp/src/components/listing/AppealChallengeResolve.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeResolve.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { compose } from "redux";
-import { EthAddress, TwoStepEthTransaction, TxHash } from "@joincivil/core";
+import {
+  EthAddress,
+  TwoStepEthTransaction,
+  TxHash,
+  didAppealChallengeSucceed as getDidAppealChallengeSucceed,
+} from "@joincivil/core";
 import {
   AppealChallengeResolveCard as AppealChallengeResolveCardComponent,
   AppealChallengeResolveCardProps,
@@ -85,9 +90,7 @@ class AppealChallengeResolve extends React.Component<AppealChallengeDetailProps 
       .mul(100)
       .toFixed(0);
 
-    const didAppealChallengeSucceed = this.props.appealChallenge.poll.votesAgainst.greaterThan(
-      this.props.appealChallenge.poll.votesFor,
-    );
+    const didAppealChallengeSucceed = getDidAppealChallengeSucceed(this.props.appealChallenge);
 
     const transactions = this.getTransactions();
 


### PR DESCRIPTION
This updates includes:

- Fix for wrong challenge results displayed in Dashboard Activity Items. The Challenge Results component for these pages now uses the appropriate helper method from `@joincivil/core` to determine if a challenge succeeded
- Enables proper phase countdown rendering for Dashboard Activity Items that are in the various appeal phases with expiries
