### PR TITLE
Granted Appeal URI

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/AppealAwaitingDecisionCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealAwaitingDecisionCard.tsx
@@ -19,11 +19,18 @@ import { ProgressBarCountdownTimer } from "../PhaseCountdown/";
 import { ChallengeResults, ChallengeResultsProps } from "../ChallengeResultsChart";
 import { ChallengePhaseDetail } from "./ChallengePhaseDetail";
 import { NeedHelp } from "./NeedHelp";
+import { TextInput } from "../input";
 
 export interface AppealProps {
   requester: string;
   appealFeePaid: string;
   txIdToConfirm?: number;
+  uriValue?: string;
+  onChange?(name: string, value: string): any;
+}
+
+export interface AppealAwaitingDecisionCardState {
+  grantURI: string;
 }
 
 export type AppealAwaitingDecisionCardProps = ListingDetailPhaseCardComponentProps &
@@ -38,13 +45,17 @@ const GrantAppealButton: React.StatelessComponent<AppealAwaitingDecisionCardProp
     text = "Confirm Appeal";
   }
   return (
-    <TransactionButtonNoModal
-      transactions={props.transactions!}
-      disabledOnMobile={true}
-      onMobileClick={props.onMobileTransactionClick}
-    >
-      {text}
-    </TransactionButtonNoModal>
+    <div>
+      {!props.txIdToConfirm && <TextInput name="uri" value={props.uriValue} onChange={props.onChange} />}
+
+      <TransactionButtonNoModal
+        transactions={props.transactions!}
+        disabledOnMobile={true}
+        onMobileClick={props.onMobileTransactionClick}
+      >
+        {text}
+      </TransactionButtonNoModal>
+    </div>
   );
 };
 

--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeCommitVoteCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeCommitVoteCard.tsx
@@ -104,7 +104,10 @@ export class AppealChallengeCommitVoteCard extends React.Component<
                 />
               </StyledListingDetailPhaseCardSection>
 
-              <AppealDecisionDetail appealGranted={this.props.appealGranted} />
+              <AppealDecisionDetail
+                appealGranted={this.props.appealGranted}
+                appealGrantedStatementUri={this.props.appealGrantedStatementURI}
+              />
 
               <StyledListingDetailPhaseCardSection bgAccentColor="COMMIT_VOTE">
                 {this.renderCommitVoteCallout()}

--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeResolveCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeResolveCard.tsx
@@ -68,7 +68,10 @@ export const AppealChallengeResolveCard: React.SFC<AppealChallengeResolveCardPro
         />
       </StyledListingDetailPhaseCardSection>
 
-      <AppealDecisionDetail appealGranted={props.appealGranted} />
+      <AppealDecisionDetail
+        appealGranted={props.appealGranted}
+        appealGrantedStatementUri={props.appealGrantedStatementURI}
+      />
 
       {showAppealChallenge && (
         <StyledListingDetailPhaseCardSection>

--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeRevealVoteCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeRevealVoteCard.tsx
@@ -97,7 +97,10 @@ export class AppealChallengeRevealVoteCard extends React.Component<
                 />
               </StyledListingDetailPhaseCardSection>
 
-              <AppealDecisionDetail appealGranted={this.props.appealGranted} />
+              <AppealDecisionDetail
+                appealGranted={this.props.appealGranted}
+                appealGrantedStatementUri={this.props.appealGrantedStatementURI}
+              />
 
               <StyledListingDetailPhaseCardSection bgAccentColor="REVEAL_VOTE">
                 {this.renderRevealVote()}

--- a/packages/components/src/ListingDetailPhaseCard/AppealDecisionCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealDecisionCard.tsx
@@ -87,7 +87,10 @@ export const AppealDecisionCard: React.SFC<
         />
       </StyledListingDetailPhaseCardSection>
 
-      <AppealDecisionDetail appealGranted={props.appealGranted} />
+      <AppealDecisionDetail
+        appealGranted={props.appealGranted}
+        appealGrantedStatementUri={props.appealGrantedStatementURI}
+      />
 
       <StyledListingDetailPhaseCardSection>
         <CTACopy>

--- a/packages/components/src/ListingDetailPhaseCard/AppealDecisionDetail.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealDecisionDetail.tsx
@@ -12,6 +12,7 @@ export interface AppealDecisionDetailProps {
   appealGranted?: boolean;
   collapsable?: boolean;
   open?: boolean;
+  appealGrantedStatementUri?: string;
 }
 
 const StyledInner = styled.div`
@@ -27,7 +28,11 @@ const AppealDecisionDetailInner: React.SFC<AppealDecisionDetailProps> = props =>
         {props.appealGranted && "Read more about their methodology and how they’ve come to this decision."}
       </FormCopy>
 
-      {props.appealGranted && <InvertedButton size={buttonSizes.MEDIUM_WIDE}>Read about this decision</InvertedButton>}
+      {props.appealGranted && (
+        <InvertedButton href={props.appealGrantedStatementUri} size={buttonSizes.MEDIUM_WIDE}>
+          Read about this decision
+        </InvertedButton>
+      )}
     </StyledInner>
   );
 };

--- a/packages/components/src/ListingDetailPhaseCard/AppealResolveCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealResolveCard.tsx
@@ -45,7 +45,10 @@ export const AppealResolveCard: React.StatelessComponent<
         />
       </StyledListingDetailPhaseCardSection>
 
-      <AppealDecisionDetail appealGranted={props.appealGranted} />
+      <AppealDecisionDetail
+        appealGranted={props.appealGranted}
+        appealGrantedStatementUri={props.appealGrantedStatementURI}
+      />
 
       <StyledListingDetailPhaseCardSection>
         <CTACopy>

--- a/packages/components/src/ListingDetailPhaseCard/types.ts
+++ b/packages/components/src/ListingDetailPhaseCard/types.ts
@@ -62,6 +62,7 @@ export interface RevealVoteProps extends VoteBaseProps {
 export interface AppealDecisionProps {
   appealRequested?: boolean;
   appealGranted?: boolean;
+  appealGrantedStatementURI?: string;
   submitAppealChallengeURI?: string;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -207,6 +207,7 @@ export interface AppealData {
   appealChallengeID: BigNumber;
   appealChallenge?: AppealChallengeData;
   appealStatementURI?: string;
+  appealGrantedStatementURI?: string;
 }
 
 /**

--- a/packages/dapp/src/apis/civilTCR.ts
+++ b/packages/dapp/src/apis/civilTCR.ts
@@ -221,11 +221,11 @@ export async function getRawGrantAppeal(address: EthAddress): Promise<string> {
   return tx.data!;
 }
 
-export async function grantAppeal(address: EthAddress): Promise<TwoStepEthTransaction> {
+export async function grantAppeal(address: EthAddress, uri: string): Promise<TwoStepEthTransaction> {
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();
   const council = await tcr.getCouncil();
-  return council.grantAppeal(address);
+  return council.grantAppeal(address, uri);
 }
 
 export async function confirmAppeal(id: number): Promise<TwoStepEthTransaction> {

--- a/packages/dapp/src/components/listing/AppealChallengeCommitVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeCommitVote.tsx
@@ -156,6 +156,7 @@ class AppealChallengeCommitVote extends React.Component<
       appealGranted: this.props.appeal.appealGranted,
       key: this.state.key,
       onMobileTransactionClick: this.props.onMobileTransactionClick,
+      appealGrantedStatementURI: this.props.appeal.appealGrantedStatementURI,
     };
 
     return (

--- a/packages/dapp/src/components/listing/AppealChallengeResolve.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeResolve.tsx
@@ -108,6 +108,7 @@ class AppealChallengeResolve extends React.Component<AppealChallengeDetailProps 
           appealChallengePercentAgainst={appealChallengePercentAgainst.toString()}
           didAppealChallengeSucceed={didAppealChallengeSucceed}
           onMobileTransactionClick={this.props.onMobileTransactionClick}
+          appealGrantedStatementURI={this.props.appeal.appealGrantedStatementURI}
         />
       </>
     );

--- a/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeRevealVote.tsx
@@ -122,6 +122,7 @@ class AppealChallengeRevealVote extends React.Component<
           appealChallengeID={this.props.appealChallengeID.toString()}
           appealGranted={this.props.appeal.appealGranted}
           onMobileTransactionClick={this.props.onMobileTransactionClick}
+          appealGrantedStatementURI={this.props.appeal.appealGrantedStatementURI}
           key={this.state.key}
         />
       </>

--- a/packages/dapp/src/components/listing/AppealResolve.tsx
+++ b/packages/dapp/src/components/listing/AppealResolve.tsx
@@ -77,6 +77,7 @@ class AppealResolve extends React.Component<AppealDetailProps & InjectedTransact
           percentFor={percentFor.toString()}
           percentAgainst={percentAgainst.toString()}
           appealGranted={appealGranted}
+          appealGrantedStatementURI={this.props.appeal.appealGrantedStatementURI}
           transactions={transactions}
           onMobileTransactionClick={this.props.onMobileTransactionClick}
         />

--- a/packages/dapp/src/components/listing/ListingPhaseActions.tsx
+++ b/packages/dapp/src/components/listing/ListingPhaseActions.tsx
@@ -136,6 +136,7 @@ class ListingPhaseActions extends React.Component<ListingPhaseActionsProps, List
         appealProps = {
           appealRequested: !data.prevChallenge!.appeal!.appealFeePaid!.isZero(),
           appealGranted: data.prevChallenge!.appeal!.appealGranted,
+          appealGrantedStatementURI: data.prevChallenge!.appeal!.appealGrantedStatementURI,
         };
       }
       let appealChallengePhaseProps: AppealChallengePhaseProps = {};


### PR DESCRIPTION
- allow council to input URL when granting appeal, put that URL in "read about decision" button
- not yet working when loading via graphql since query result doesn't contain data we need