### PR TITLE
Fix History Event Alignment

### DIFF
--- a/packages/components/src/ListingHistoryEvent/EventDate.tsx
+++ b/packages/components/src/ListingHistoryEvent/EventDate.tsx
@@ -11,6 +11,8 @@ const StyledEventDate = styled.div`
   line-height: 16px;
   padding: 5px 0 0;
   width: 148px;
+  min-width: 148px;
+  max-width: 148px;
 `;
 
 const EventDate: React.StatelessComponent<ListingHistoryEventTimestampProps> = props => {


### PR DESCRIPTION
- make sure event date is always 148px wide so it doesn't get squished when rest of history event is bigger
- if there's a better way to do this, let me know