### PR TITLE
Newsroom Listing Logo Fixes

### DIFF
--- a/packages/components/src/ListingDetailHeader/ListingDetailHeaderStyledComponents.tsx
+++ b/packages/components/src/ListingDetailHeader/ListingDetailHeaderStyledComponents.tsx
@@ -48,8 +48,9 @@ export const StyledNewsroomLogo = styled.img`
   height: 130px;
   min-width: 130px;
   min-height: 130px;
-  object-fit: cover;
+  object-fit: contain;
   width: 130px;
+  background: ${colors.basic.WHITE};
 `;
 
 export const StyledEthereumInfoToggle = styled.div`

--- a/packages/components/src/ListingSummary/styledComponents.tsx
+++ b/packages/components/src/ListingSummary/styledComponents.tsx
@@ -164,7 +164,8 @@ export const NewsroomLogo = styled.img`
   height: 80px;
   min-width: 80px;
   min-height: 80px;
-  object-fit: cover;
+  object-fit: contain;
+  background: ${colors.basic.WHITE};
 `;
 
 export const SmallNewsroomLogo = styled.img`
@@ -172,7 +173,8 @@ export const SmallNewsroomLogo = styled.img`
   height: 52px;
   min-width: 52px;
   min-height: 52px;
-  object-fit: cover;
+  object-fit: contain;
+  background: ${colors.basic.WHITE};
 `;
 
 export const MetaRow = styled.div`


### PR DESCRIPTION
- use contain instead of cover for newsroom logo object-git
- set background to white