### PR TITLE
Tiny Listing Card Fix

### DIFF
--- a/packages/components/src/ListingSummary/ChallengeResults.tsx
+++ b/packages/components/src/ListingSummary/ChallengeResults.tsx
@@ -50,7 +50,8 @@ const ChallengeResults: React.SFC<ListingSummaryChallengeResultsProps> = props =
       isInAppealChallengeRevealPhase ||
       canListingAppealChallengeBeResolved ||
       (isRejected && !isUnderChallenge)
-    )
+    ) ||
+    (canBeWhitelisted && !isUnderChallenge)
   ) {
     return null;
   }


### PR DESCRIPTION
- don't show challenge results on ready-to-update newsroom if there is no challenge