### PR TITLE
remove nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,20 +159,20 @@ jobs:
 
 workflows:
     version: 2
-    nightly:
-        triggers:
-            - schedule:
-                cron: "0 0 * * *" # Midnight UTC
-                filters:
-                    branches:
-                        only:
-                            - master
-                            - production
-        jobs:
-            - build
-            - coverage:
-                requires:
-                    - build
+    # nightly:
+    #     triggers:
+    #         - schedule:
+    #             cron: "0 0 * * *" # Midnight UTC
+    #             filters:
+    #                 branches:
+    #                     only:
+    #                         - master
+    #                         - production
+    #     jobs:
+    #         - build
+    #         - coverage:
+    #             requires:
+    #                 - build
     pull-request:
         jobs:
             - build:


### PR DESCRIPTION
code coverage appears to have been broken for quite some time. this disables the nightly build, and will be enabled once coverage is fixed