### PR TITLE
Fix default link colors for the Dapp

### DIFF
--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -6,6 +6,20 @@ import { ApolloProvider } from "react-apollo";
 import { getApolloClient } from "@joincivil/utils";
 import config from "./helpers/config";
 
+import { injectGlobal } from "styled-components";
+import { colors, fonts } from "@joincivil/components";
+
+// tslint:disable-next-line:no-unused-expression
+injectGlobal`
+  body {
+    font-family: ${fonts.SANS_SERIF};
+  }
+
+  a {
+    color: ${colors.accent.CIVIL_BLUE};
+  }
+`;
+
 console.log("using config:", config);
 
 const client = getApolloClient({});


### PR DESCRIPTION
This update injects global styles for Dapp that properly sets default colors for link elements as well as the correct default sans-serif font, per Design.