### PR TITLE
Don't pop up ethereum enable during email auth

### DIFF
--- a/packages/dapp/src/components/SignUpNewsroom.tsx
+++ b/packages/dapp/src/components/SignUpNewsroom.tsx
@@ -1,16 +1,11 @@
 import { EthAddress } from "@joincivil/core";
 import { Newsroom } from "@joincivil/newsroom-signup";
-import { ethereumEnable } from "@joincivil/utils";
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
 import { getCivil } from "../helpers/civilInstance";
 import { PageView } from "./utility/ViewModules";
 import { State } from "../redux/reducers";
 
-export interface CreateNewsroomState {
-  error: string;
-  metamaskEnabled?: boolean;
-}
 export interface CreateNewsroomProps {
   match: any;
   history: any;
@@ -20,44 +15,21 @@ export interface CreateNewsroomReduxProps {
   userAccount: EthAddress;
 }
 
-class SignUpNewsroom extends React.Component<
-  CreateNewsroomProps & CreateNewsroomReduxProps & DispatchProp<any>,
-  CreateNewsroomState
-> {
-  constructor(props: CreateNewsroomProps & CreateNewsroomReduxProps) {
-    super(props);
-    this.state = {
-      error: "",
-    };
-  }
-
-  public async componentDidMount(): Promise<void> {
-    this.setState({ metamaskEnabled: !!(await ethereumEnable()) });
-  }
-
+class SignUpNewsroom extends React.Component<CreateNewsroomProps & CreateNewsroomReduxProps & DispatchProp<any>> {
   public render(): JSX.Element {
     const civil = getCivil();
     return (
       <PageView>
         <Newsroom
           civil={civil}
-          onNewsroomCreated={this.onCreated}
           account={this.props.userAccount}
           currentNetwork={this.props.networkName}
-          metamaskEnabled={this.state.metamaskEnabled}
           allSteps={true}
           initialStep={0}
-          enable={async () => {
-            this.setState({ metamaskEnabled: !!(await ethereumEnable()) });
-          }}
         />
       </PageView>
     );
   }
-
-  private onCreated = (address: EthAddress) => {
-    return;
-  };
 }
 
 const mapStateToProps = (

--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -63,10 +63,8 @@ export interface NewsroomExternalProps {
   helpUrlBase?: string;
   newsroomUrl?: string;
   logoUrl?: string;
-  metamaskEnabled?: boolean;
   allSteps?: boolean; // @TODO temporary while excluding it from IRL newsroom use but including for testing in dapp
   initialStep?: number;
-  enable(): void;
   renderUserSearch?(onSetAddress: any): JSX.Element;
   onNewsroomCreated?(address: EthAddress): void;
   onContractDeployStarted?(txHash: TxHash): void;

--- a/packages/newsroom-signup/src/NewsroomProfile/CharterQuestions.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/CharterQuestions.tsx
@@ -30,7 +30,7 @@ export class CharterQuestions extends React.Component<CharterQuestionsProps> {
         </OBSectionDescription>
         <LearnMoreButton />
         <StyledHr />
-        <StepSectionCounter>Step 2 of 4: Roster</StepSectionCounter>
+        <StepSectionCounter>Step 3 of 4: Charter</StepSectionCounter>
 
         <FormSection>
           <p>Suggested length for answers: 250 words or about 2 paragraphs.</p>

--- a/packages/newsroom-signup/src/NewsroomProfile/SignConstitution.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/SignConstitution.tsx
@@ -277,13 +277,13 @@ class SignConstitutionComponent extends React.Component<
             isWaitingSignatureOpen: false,
           });
         },
-        handleTransactionError: (err: Error) => {
+        handleTransactionError: (err?: Error) => {
           this.setState({ isWaitingSignatureOpen: false });
-          if (err.message.indexOf("Error: MetaMask Message Signature: User denied message signature.") !== -1) {
+          if (err && err.message.indexOf("Error: MetaMask Message Signature: User denied message signature.") !== -1) {
             this.setState({ metaMaskRejectionModal: true });
           } else {
             console.error("Transaction failed:", err);
-            alert("Transaction failed: " + err.message);
+            alert("Transaction failed. Error: " + (err && err.message));
           }
         },
       },


### PR DESCRIPTION
Also, unrelated, but `handleTransactionError` was being called with no error from sign constitution button, so this handles that case without breaking as much.