### PR TITLE
reduce filtered log requests

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,22 +15,17 @@
     "examples:typed": "node build/doc/examples/low-level/typed_contracts.js",
     "examples:multisig": "node build/doc/examples/low-level/multisig.js",
     "generate": "run-p generate:*",
-    "generate:contracts":
-      "abi-gen --abis '../artifacts/v1/'\"${npm_package_config_contractsGlob}\"'.json' --template 'src/templates/contract/contract.handlebars' --partials 'src/templates/contract/partials/**/*.handlebars' --output 'src/contracts/generated/wrappers'",
-    "generate:artifacts":
-      "node ../dev-utils/build/scripts/generate-from-files/bin.js '../artifacts/v1/'\"${npm_package_config_contractsGlob}\"'.json' 'src/templates/artifacts.handlebars' 'src/contracts/generated/artifacts.ts'",
-    "generate:events":
-      "node ../dev-utils/build/scripts/generate-from-files/bin.js '../artifacts/v1/'\"${npm_package_config_contractsGlob}\"'.json' 'src/templates/events.handlebars' 'src/contracts/generated/events.ts'",
-    "generate:multisig":
-      "abi-gen --abis '../artifacts/v1/'\"${npm_package_config_multisigGlob}\"'.json' --template 'src/templates/contract/multisigproxy.handlebars' --partials 'src/templates/contract/partials/**/*.handlebars' --output 'src/contracts/generated/multisig'",
+    "generate:contracts": "abi-gen --abis '../artifacts/v1/'\"${npm_package_config_contractsGlob}\"'.json' --template 'src/templates/contract/contract.handlebars' --partials 'src/templates/contract/partials/**/*.handlebars' --output 'src/contracts/generated/wrappers'",
+    "generate:artifacts": "node ../dev-utils/build/scripts/generate-from-files/bin.js '../artifacts/v1/'\"${npm_package_config_contractsGlob}\"'.json' 'src/templates/artifacts.handlebars' 'src/contracts/generated/artifacts.ts'",
+    "generate:events": "node ../dev-utils/build/scripts/generate-from-files/bin.js '../artifacts/v1/'\"${npm_package_config_contractsGlob}\"'.json' 'src/templates/events.handlebars' 'src/contracts/generated/events.ts'",
+    "generate:multisig": "abi-gen --abis '../artifacts/v1/'\"${npm_package_config_multisigGlob}\"'.json' --template 'src/templates/contract/multisigproxy.handlebars' --partials 'src/templates/contract/partials/**/*.handlebars' --output 'src/contracts/generated/multisig'",
     "tsc": "tsc",
     "prepublishOnly": "run-s build lint",
     "clean": "rimraf build/ src/contracts/generated/*"
   },
   "config": {
     "multisigGlob": "@(Newsroom|CVLToken|CivilTCR)",
-    "contractsGlob":
-      "@(CivilTCR|CivilPLCRVoting|CivilParameterizer|CVLToken|EventStorage|Government|MultiSigWallet|Newsroom|NewsroomFactory|CivilTokenController|CreateNewsroomInGroup|NoOpTokenController)"
+    "contractsGlob": "@(CivilTCR|CivilPLCRVoting|CivilParameterizer|CVLToken|EventStorage|Government|MultiSigWallet|Newsroom|NewsroomFactory|CivilTokenController|CreateNewsroomInGroup|NoOpTokenController)"
   },
   "author": "The Civil Media Company",
   "bugs": {
@@ -46,6 +41,7 @@
     "@types/debug": "0.0.30",
     "@types/underscore": "^1.8.6",
     "copyfiles": "^2.1.0",
+    "ipfs-http-client": "^29.1.1",
     "npm-run-all": ">=4.1.5",
     "rimraf": "^2.6.2",
     "tslint": "^5.9.1",
@@ -59,7 +55,6 @@
     "debug": "^4.1.0",
     "ethereumjs-util": "^5.2.0",
     "events": "^3.0.0",
-    "ipfs-api": "^26.1.2",
     "rxjs": "^5.5.6",
     "web3": "^0.20.3"
   }

--- a/packages/core/src/content/ipfsprovider.ts
+++ b/packages/core/src/content/ipfsprovider.ts
@@ -1,7 +1,7 @@
 import { StorageHeader } from "../types";
 import { ContentProvider } from "./contentprovider";
 // tslint:disable-next-line
-import * as IPFS from "ipfs-api";
+import * as IPFS from "ipfs-http-client";
 import { hashContent, promisify } from "@joincivil/utils";
 
 const ipfs = new IPFS({ host: "ipfs.infura.io", port: 5001, protocol: "https" });

--- a/packages/core/src/contracts/tcr/parameterizer.ts
+++ b/packages/core/src/contracts/tcr/parameterizer.ts
@@ -12,6 +12,7 @@ import {
   PollID,
   ParamPropChallengeData,
   UserChallengeData,
+  WrappedPropID,
 } from "../../types";
 import { EthApi, requireAccount } from "@joincivil/ethapi";
 import { BaseWrapper } from "../basewrapper";
@@ -204,6 +205,15 @@ export class Parameterizer extends BaseWrapper<CivilParameterizerContract> {
       ._NewChallengeStream({}, { fromBlock })
       .concatFilter(async e => this.isChallengeResolved(e.args.challengeID))
       .map(e => e.args.propID);
+  }
+
+  public allProposalChallengeIDsEver(): Observable<WrappedPropID> {
+    return this.instance._NewChallengeStream({}, { fromBlock: getDefaultFromBlock(this.ethApi.network()) }).map(e => {
+      return {
+        propID: e.args.propID,
+        challengeID: e.args.challengeID,
+      };
+    });
   }
 
   /**

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -1,5 +1,5 @@
 declare module "bn.js";
-declare module "ipfs-api";
+declare module "ipfs-http-client";
 
 declare module "*.json" {
   const json: any;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -261,6 +261,31 @@ export interface ParamPropChallengeData {
   poll: PollData;
 }
 
+export interface PollIDWithBlockNum {
+  pollID: BigNumber;
+  blockNum: number;
+}
+
+export interface AppealChallengeChallengeID {
+  appealChallengeID: BigNumber;
+  challengeID: BigNumber;
+}
+
+export interface WrappedChallengeID {
+  listingAddress: EthAddress;
+  challengeID: BigNumber;
+}
+
+export interface WrappedAppealChallengeID {
+  listingAddress: EthAddress;
+  appealChallengeToChallengeID: AppealChallengeChallengeID;
+}
+
+export interface WrappedPropID {
+  propID: string;
+  challengeID: BigNumber;
+}
+
 // tslint:disable-next-line
 export interface TimestampedEvent<T extends DecodedLogEntryEvent> extends DecodedLogEntryEvent {
   timestamp(): Promise<number>;

--- a/packages/dapp/src/helpers/listingEvents.ts
+++ b/packages/dapp/src/helpers/listingEvents.ts
@@ -1,4 +1,12 @@
-import { EthAddress, getNextTimerExpiry, ListingWrapper, StorageHeader } from "@joincivil/core";
+import {
+  EthAddress,
+  getNextTimerExpiry,
+  ListingWrapper,
+  StorageHeader,
+  WrappedChallengeID,
+  WrappedAppealChallengeID,
+  WrappedPropID,
+} from "@joincivil/core";
 import { addNewsroom } from "@joincivil/newsroom-signup";
 import { getDefaultFromBlock } from "@joincivil/utils";
 import { BigNumber } from "bignumber.js";
@@ -71,6 +79,93 @@ export function clearListingSubscriptions(): any {
 let challengeSubscription: Subscription;
 let newChallengeActionsSubscription: Subscription;
 let challengeStartedSubscription: Subscription;
+let allChallengeIDs: Set<string> = new Set();
+let allAppealChallengeIDs: Set<string> = new Set();
+let appealChallengesToChallengeIDs: Map<string, string> = new Map();
+let allUserPollIDs: Set<string> = new Set();
+let challengeIdsToListingAddresses: Map<string, string> = new Map();
+let allPropChallengeIDs: Set<string> = new Set();
+let propChallengeIDsToPropIDs: Map<string, string> = new Map();
+
+async function checkChallengeForUserPoll(
+  challengeId: BigNumber,
+  dispatch: Dispatch<any>,
+  user: EthAddress,
+): Promise<void> {
+  if (allUserPollIDs.has(challengeId.toString())) {
+    await getChallenge(challengeId, dispatch, user);
+  }
+}
+
+async function checkAppealChallengeForUserPoll(
+  appealChallengeID: BigNumber,
+  dispatch: Dispatch<any>,
+  user: EthAddress,
+): Promise<void> {
+  if (allUserPollIDs.has(appealChallengeID.toString())) {
+    await getAppealChallenge(appealChallengeID, dispatch, user);
+  }
+}
+
+async function checkPropChallengeIDForUserPoll(
+  propChallengeID: BigNumber,
+  dispatch: Dispatch<any>,
+  user: EthAddress,
+): Promise<void> {
+  if (allUserPollIDs.has(propChallengeID.toString())) {
+    await getPropChallenge(propChallengeID, dispatch, user);
+  }
+}
+
+async function checkUserPollForChallengeType(
+  pollID: BigNumber,
+  dispatch: Dispatch<any>,
+  user: EthAddress,
+): Promise<void> {
+  if (allChallengeIDs.has(pollID.toString())) {
+    await getChallenge(pollID, dispatch, user);
+  } else if (allAppealChallengeIDs.has(pollID.toString())) {
+    await getAppealChallenge(pollID, dispatch, user);
+  } else if (allPropChallengeIDs.has(pollID.toString())) {
+    await getPropChallenge(pollID, dispatch, user);
+  }
+}
+
+async function getChallenge(challengeId: BigNumber, dispatch: Dispatch<any>, user: EthAddress): Promise<void> {
+  const tcr = await getTCR();
+  const listingAddress = challengeIdsToListingAddresses.get(challengeId.toString())!;
+  const wrappedChallenge = await tcr.getChallengeData(challengeId, listingAddress);
+  dispatch(addChallenge(wrappedChallenge));
+  const challengeUserData = await tcr.getUserChallengeData(challengeId, user);
+  dispatch(addUserChallengeData(challengeId.toString(), user, challengeUserData));
+}
+
+async function getAppealChallenge(
+  appealChallengeID: BigNumber,
+  dispatch: Dispatch<any>,
+  user: EthAddress,
+): Promise<void> {
+  const challengeId = new BigNumber(appealChallengesToChallengeIDs.get(appealChallengeID.toString())!);
+  const listingAddress = challengeIdsToListingAddresses.get(challengeId.toString())!;
+  const tcr = await getTCR();
+  const wrappedChallenge = await tcr.getChallengeData(challengeId, listingAddress);
+  dispatch(addChallenge(wrappedChallenge));
+  const challengeUserData = await tcr.getUserAppealChallengeData(appealChallengeID, user);
+  dispatch(addUserAppealChallengeData(appealChallengeID.toString(), user, challengeUserData));
+  dispatch(linkAppealChallengeToChallenge(appealChallengeID.toString(), challengeId.toString()));
+}
+
+async function getPropChallenge(
+  proposalChallengeID: BigNumber,
+  dispatch: Dispatch<any>,
+  user: EthAddress,
+): Promise<void> {
+  const tcr = await getTCR();
+  const parameterizer = await tcr.getParameterizer();
+  const propChallengeUserData = await parameterizer.getUserProposalChallengeData(proposalChallengeID, user);
+  dispatch(addUserProposalChallengeData(proposalChallengeID.toString(), user, propChallengeUserData));
+}
+
 export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, user: EthAddress): Promise<void> {
   if (challengeSubscription) {
     challengeSubscription.unsubscribe();
@@ -82,32 +177,50 @@ export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, 
     challengeStartedSubscription.unsubscribe();
   }
 
+  allChallengeIDs = new Set();
+  allAppealChallengeIDs = new Set();
+  appealChallengesToChallengeIDs = new Map();
+  allUserPollIDs = new Set();
+  challengeIdsToListingAddresses = new Map();
+  allPropChallengeIDs = new Set();
+  propChallengeIDsToPropIDs = new Map();
+
   const tcr = await getTCR();
   const civil = getCivil();
   const current = await civil.currentBlock();
+  const parameterizer = await tcr.getParameterizer();
+
+  tcr.allChallengeIDsEver().subscribe(async (wrappedChallengeID: WrappedChallengeID) => {
+    allChallengeIDs.add(wrappedChallengeID.challengeID.toString());
+    challengeIdsToListingAddresses.set(wrappedChallengeID.challengeID.toString(), wrappedChallengeID.listingAddress);
+    await checkChallengeForUserPoll(wrappedChallengeID.challengeID, dispatch, user);
+  });
+  tcr.allAppealChallengeIDsEver().subscribe(async (wrappedAppealChallengeID: WrappedAppealChallengeID) => {
+    allAppealChallengeIDs.add(wrappedAppealChallengeID.appealChallengeToChallengeID.appealChallengeID.toString());
+    appealChallengesToChallengeIDs.set(
+      wrappedAppealChallengeID.appealChallengeToChallengeID.appealChallengeID.toString(),
+      wrappedAppealChallengeID.appealChallengeToChallengeID.challengeID.toString(),
+    );
+    await checkAppealChallengeForUserPoll(
+      wrappedAppealChallengeID.appealChallengeToChallengeID.appealChallengeID,
+      dispatch,
+      user,
+    );
+  });
+  parameterizer.allProposalChallengeIDsEver().subscribe(async (wrappedPropID: WrappedPropID) => {
+    allPropChallengeIDs.add(wrappedPropID.challengeID.toString());
+    propChallengeIDsToPropIDs.set(wrappedPropID.challengeID.toString(), wrappedPropID.propID);
+    await checkPropChallengeIDForUserPoll(wrappedPropID.challengeID, dispatch, user);
+  });
+
+  // TODO: also add support for govt proposals
+
   challengeSubscription = tcr
     .getVoting()
     .votesCommitted(undefined, user)
     .subscribe(async (pollID: BigNumber) => {
-      const challengeId = await tcr.getChallengeIDForPollID(pollID);
-      if (!challengeId.isZero()) {
-        const wrappedChallenge = await tcr.getChallengeData(challengeId);
-        dispatch(addChallenge(wrappedChallenge));
-        const challengeUserData = await tcr.getUserChallengeData(challengeId, user);
-        dispatch(addUserChallengeData(challengeId.toString(), user, challengeUserData));
-
-        // if the challenge ID corresponds to an appeal challenge, get any user data for it
-        if (!pollID.equals(challengeId)) {
-          const appealChallengeUserData = await tcr.getUserAppealChallengeData(pollID, user);
-          dispatch(addUserAppealChallengeData(pollID.toString(), user, appealChallengeUserData));
-          dispatch(linkAppealChallengeToChallenge(pollID.toString(), challengeId.toString()));
-        }
-      } else {
-        const parameterizer = await tcr.getParameterizer();
-        const propChallengeUserData = await parameterizer.getUserProposalChallengeData(pollID, user);
-        dispatch(addUserProposalChallengeData(pollID.toString(), user, propChallengeUserData));
-      }
-      // TODO: also add support for govt proposals
+      allUserPollIDs.add(pollID.toString());
+      await checkUserPollForChallengeType(pollID, dispatch, user);
     });
 
   newChallengeActionsSubscription = Observable.merge(
@@ -127,7 +240,6 @@ export async function initializeChallengeSubscriptions(dispatch: Dispatch<any>, 
         dispatch(linkAppealChallengeToChallenge(pollID.toString(), challengeId.toString()));
       }
     } else {
-      const parameterizer = await tcr.getParameterizer();
       const propChallengeUserData = await parameterizer.getUserProposalChallengeData(pollID, user);
       dispatch(addUserProposalChallengeData(pollID.toString(), user, propChallengeUserData));
     }

--- a/packages/utils/src/civilHelpers.ts
+++ b/packages/utils/src/civilHelpers.ts
@@ -48,7 +48,7 @@ export function getDefaultFromBlock(network: number): number {
   // first Newsroom contract on that network
   const defaultFromBlocks: { [index: string]: number } = {
     1: 6904575,
-    4: 2848355,
+    4: 3689706,
     50: 0,
   };
   return defaultFromBlocks[network.toString()] || 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,6 +3189,11 @@ bignumber.js@^5.0.0, bignumber.js@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-5.0.0.tgz#fbce63f09776b3000a83185badcde525daf34833"
 
+bignumber.js@^8.0.2:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
+  integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+
 "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
@@ -4225,6 +4230,16 @@ concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.5.1, concat-stream@^
     buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
 config-chain@^1.1.11:
@@ -5416,7 +5431,7 @@ eol@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
 
-err-code@^1.0.0:
+err-code@^1.0.0, err-code@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
 
@@ -7709,6 +7724,11 @@ ip-address@^5.8.9:
     lodash.repeat "^4.1.0"
     sprintf-js "1.1.0"
 
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
@@ -7769,6 +7789,53 @@ ipfs-block@~0.8.0:
     cids "~0.5.5"
     class-is "^1.1.0"
 
+ipfs-http-client@^29.1.1:
+  version "29.1.1"
+  resolved "https://registry.yarnpkg.com/ipfs-http-client/-/ipfs-http-client-29.1.1.tgz#dae3319621869a5ae76c3ce16ef97658b15ba3e2"
+  integrity sha512-aAjqZ9RwnpQECkMO058YjWG79U4w4wEKvHfVdXMhgkXDFkErxRpSqoCvwIVozbTU34NwEjWsZ9WoG0lr2FtgvA==
+  dependencies:
+    async "^2.6.1"
+    bignumber.js "^8.0.2"
+    bl "^2.1.2"
+    bs58 "^4.0.1"
+    cids "~0.5.5"
+    concat-stream "^2.0.0"
+    debug "^4.1.0"
+    detect-node "^2.0.4"
+    end-of-stream "^1.4.1"
+    err-code "^1.1.2"
+    flatmap "0.0.3"
+    glob "^7.1.3"
+    ipfs-block "~0.8.0"
+    ipfs-unixfs "~0.1.16"
+    ipld-dag-cbor "~0.13.0"
+    ipld-dag-pb "~0.15.0"
+    is-ipfs "~0.4.7"
+    is-pull-stream "0.0.0"
+    is-stream "^1.1.0"
+    libp2p-crypto "~0.16.0"
+    lodash "^4.17.11"
+    lru-cache "^5.1.1"
+    multiaddr "^6.0.0"
+    multibase "~0.6.0"
+    multihashes "~0.4.14"
+    ndjson "^1.5.0"
+    once "^1.4.0"
+    peer-id "~0.12.1"
+    peer-info "~0.15.0"
+    promisify-es6 "^1.0.3"
+    pull-defer "~0.2.3"
+    pull-pushable "^2.2.0"
+    pull-stream-to-stream "^1.3.4"
+    pump "^3.0.0"
+    qs "^6.5.2"
+    readable-stream "^3.0.6"
+    stream-http "^3.0.0"
+    stream-to-pull-stream "^1.7.2"
+    streamifier "~0.1.1"
+    tar-stream "^1.6.2"
+    through2 "^3.0.0"
+
 ipfs-unixfs@~0.1.16:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-0.1.16.tgz#41140f4359f1b8fe7a970052663331091c5f54c4"
@@ -7791,6 +7858,22 @@ ipld-dag-cbor@~0.13.0:
 ipld-dag-pb@~0.14.11:
   version "0.14.11"
   resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.14.11.tgz#df235a301fec8443cf933387cebb38e42c22c2a8"
+  dependencies:
+    async "^2.6.1"
+    bs58 "^4.0.1"
+    cids "~0.5.4"
+    class-is "^1.1.0"
+    is-ipfs "~0.4.2"
+    multihashing-async "~0.5.1"
+    protons "^1.0.1"
+    pull-stream "^3.6.9"
+    pull-traverse "^1.0.3"
+    stable "~0.1.8"
+
+ipld-dag-pb@~0.15.0:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/ipld-dag-pb/-/ipld-dag-pb-0.15.2.tgz#33156e2891bacdf538dd0193ba44661b37c8e705"
+  integrity sha512-9mzeYW4FneGROH+/PXMbXsfy3cUsMYHaI6vUu8nNpSTyQdGF+fa1ViA+jvqWzM8zXYwG4OOSCAAADssJeELAvw==
   dependencies:
     async "^2.6.1"
     bs58 "^4.0.1"
@@ -8008,6 +8091,13 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
+  dependencies:
+    ip-regex "^2.0.0"
+
 is-ipfs@~0.4.2, is-ipfs@~0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.4.7.tgz#748616ccfccc96601d4fb87aae1830cf8c5b9d62"
@@ -8202,6 +8292,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
+iso-random-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-1.1.0.tgz#c1dc1bb43dd8da6524df9cbc6253b010806585c8"
+  integrity sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ==
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -9330,6 +9425,17 @@ libp2p-crypto-secp256k1@~0.2.2:
     safe-buffer "^5.1.1"
     secp256k1 "^3.3.0"
 
+libp2p-crypto-secp256k1@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.3.tgz#212fc171d39dae7be3eaf4d9d311e0a8e9619c78"
+  integrity sha512-DFrK89VdboacqM3vqWV8yt8FH9Ni181JJAOU2tRkJfUN9tNEV7VfZEg390NJxEQQbLsyH4HZ7on3QTpPHMHQZQ==
+  dependencies:
+    async "^2.6.1"
+    multihashing-async "~0.5.1"
+    nodeify "^1.0.1"
+    safe-buffer "^5.1.2"
+    secp256k1 "^3.6.1"
+
 libp2p-crypto@~0.12.1:
   version "0.12.1"
   resolved "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz#4a870d269ba3150dfe014e4f9aea1e55076015c8"
@@ -9384,6 +9490,26 @@ libp2p-crypto@~0.14.0:
     tweetnacl "^1.0.0"
     ursa-optional "~0.9.9"
     webcrypto-shim "github:dignifiedquire/webcrypto-shim#master"
+
+libp2p-crypto@~0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.16.0.tgz#717d7cfa1b48cf8f01ede9f8dede6fe798ab8ece"
+  integrity sha512-Msu7PIumcVRO8LajSGs6uVZpC7bOiJVWu0a8iFMZ6mdbasI+A6accAmP/NjJ5WBcEdxzwjzQGNP23bQQzPoqqg==
+  dependencies:
+    asn1.js "^5.0.1"
+    async "^2.6.1"
+    browserify-aes "^1.2.0"
+    bs58 "^4.0.1"
+    iso-random-stream "^1.1.0"
+    keypair "^1.0.1"
+    libp2p-crypto-secp256k1 "~0.2.3"
+    multihashing-async "~0.5.1"
+    node-forge "~0.7.6"
+    pem-jwk "^2.0.0"
+    protons "^1.0.1"
+    rsa-pem-to-jwk "^1.1.3"
+    tweetnacl "^1.0.0"
+    ursa-optional "~0.9.10"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -9691,6 +9817,13 @@ lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 ltgt@^2.1.2, ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -9704,6 +9837,13 @@ mafmt@^6.0.0:
   resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-6.0.2.tgz#236f08e35d37c4efd96f869ade919b71f5972992"
   dependencies:
     multiaddr "^5.0.0"
+
+mafmt@^6.0.2:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-6.0.6.tgz#d94f491541264c51a810bea03c6866981e3c07fe"
+  integrity sha512-tbLpK8eZsGmjxo6HjSNQOrOiClXprErbdnmO/5VY3R4g0zWUELgvMjJQr3WTlh6MXMZqJqwmz6FsEyJEcU2Xnw==
+  dependencies:
+    multiaddr "^6.0.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -10178,6 +10318,17 @@ multiaddr@^5.0.0:
     varint "^5.0.0"
     xtend "^4.0.1"
 
+multiaddr@^6.0.0, multiaddr@^6.0.3, multiaddr@^6.0.4:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-6.0.5.tgz#7b5a4f2267a575af6da544ca3f1a16eb755dfe53"
+  integrity sha512-sS0lFPImtycB7w14TGPYtzbT/xgu6ByGIIu+26bkmavgYwXLud5OxU7ytlbdHmTTAgtOEL9k8yjZ+xMrCO2jeQ==
+  dependencies:
+    bs58 "^4.0.1"
+    class-is "^1.1.0"
+    ip "^1.1.5"
+    is-ip "^2.0.0"
+    varint "^5.0.0"
+
 multibase@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.4.0.tgz#1bdb62c82de0114f822a1d8751bcbee91cd2efba"
@@ -10187,6 +10338,13 @@ multibase@~0.4.0:
 multibase@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.5.0.tgz#45668ad138963d778bdf1f79da64f21caa7bb6eb"
+  dependencies:
+    base-x "3.0.4"
+
+multibase@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.6.0.tgz#0216e350614c7456da5e8e5b20d3fcd4c9104f56"
+  integrity sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==
   dependencies:
     base-x "3.0.4"
 
@@ -11192,6 +11350,16 @@ peer-id@~0.12.0:
     lodash "^4.17.10"
     multihashes "~0.4.13"
 
+peer-id@~0.12.1, peer-id@~0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.12.2.tgz#0d1b876ebf21a528be9948c9cb7d30266342b2fd"
+  integrity sha512-pked3yPLcOcprH21OnYbJAzk9OgI/TDEqjJ0IfRJSVB/61ZyqU5VKO7cw7hul+YD8nTD79wM79xFRWN3f6otNg==
+  dependencies:
+    async "^2.6.1"
+    class-is "^1.1.0"
+    libp2p-crypto "~0.16.0"
+    multihashes "~0.4.13"
+
 peer-info@~0.14.1:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/peer-info/-/peer-info-0.14.1.tgz#ac5aec421e9965f7b0e7576d717941bb25676134"
@@ -11200,6 +11368,16 @@ peer-info@~0.14.1:
     mafmt "^6.0.0"
     multiaddr "^4.0.0"
     peer-id "~0.10.7"
+
+peer-info@~0.15.0:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/peer-info/-/peer-info-0.15.1.tgz#21254a7c516d0dd046b150120b9aaf1b9ad02146"
+  integrity sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==
+  dependencies:
+    mafmt "^6.0.2"
+    multiaddr "^6.0.3"
+    peer-id "~0.12.2"
+    unique-by "^1.0.0"
 
 pegjs@^0.10.0:
   version "0.10.0"
@@ -11210,6 +11388,13 @@ pem-jwk@^1.5.1:
   resolved "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-1.5.1.tgz#7a8637fd2f67a827e57c0c42e1c23c3fd52cfb01"
   dependencies:
     asn1.js "1.0.3"
+
+pem-jwk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-2.0.0.tgz#1c5bb264612fc391340907f5c1de60c06d22f085"
+  integrity sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==
+  dependencies:
+    asn1.js "^5.0.1"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -12469,6 +12654,15 @@ readable-stream@1.0, readable-stream@~1.0.15, readable-stream@~1.0.26, readable-
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+"readable-stream@2 || 3", readable-stream@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
+  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@^1.0.33:
   version "1.1.14"
   resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -13101,6 +13295,20 @@ scryptsy@^1.2.1:
 secp256k1@^3.0.1, secp256k1@^3.3.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.5.2.tgz#f95f952057310722184fe9c914e6b71281f2f2ae"
+  dependencies:
+    bindings "^1.2.1"
+    bip66 "^1.1.3"
+    bn.js "^4.11.3"
+    create-hash "^1.1.2"
+    drbg.js "^1.0.1"
+    elliptic "^6.2.3"
+    nan "^2.2.1"
+    safe-buffer "^5.1.0"
+
+secp256k1@^3.6.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.6.2.tgz#da835061c833c74a12f75c73d2ec2e980f00dc1f"
+  integrity sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==
   dependencies:
     bindings "^1.2.1"
     bip66 "^1.1.3"
@@ -14247,6 +14455,14 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.2, through2@^2.0.3, through2@~2.
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
+through2@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.0.tgz#468b461df9cd9fcc170f22ebf6852e467e578ff2"
+  integrity sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==
+  dependencies:
+    readable-stream "2 || 3"
+    xtend "~4.0.1"
+
 through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.6, through@~2.3.8:
   version "2.3.8"
   resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -14726,6 +14942,11 @@ uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
 
+unique-by@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-by/-/unique-by-1.0.0.tgz#5220c86ba7bc572fb713ad74651470cb644212bd"
+  integrity sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0=
+
 unique-filename@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
@@ -14877,7 +15098,7 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-ursa-optional@~0.9.9:
+ursa-optional@~0.9.10, ursa-optional@~0.9.9:
   version "0.9.10"
   resolved "https://registry.yarnpkg.com/ursa-optional/-/ursa-optional-0.9.10.tgz#f2eabfe0b6001dbf07a78740cd0a6e5ba6eb2554"
   dependencies:


### PR DESCRIPTION
- still room for improvement in getting user challenge data, specifically getting rid of the `getRevealEvent` call and `getRewardClaimed` call. Would need to split up getting user challenge data though and update it in steps 
- update genesis block for rinkeby
- ignore first commit, part of another PR... sorry...