### PR TITLE
Clean up routing for Dapp + GA, plus additional bug fixes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,7 @@
     "react-add-to-calendar": "^0.1.5",
     "react-apollo": "^2.3.3",
     "react-async-script": "^1.0.0",
-    "react-router-dom": "^4.2.2",
+    "react-router-dom": "^4.3.1",
     "react-rte": "^0.16.1",
     "rxjs": "^5.5.6",
     "styled-components": "^3.2.3"

--- a/packages/dapp/src/components/ContractAddresses.tsx
+++ b/packages/dapp/src/components/ContractAddresses.tsx
@@ -90,9 +90,7 @@ const ContractAddresses: React.SFC<ContractAddressesReduxProps> = props => {
 
   return (
     <StyledMainContainer>
-      <Helmet>
-        <title>Contract Addresses - The Civil Registry</title>
-      </Helmet>
+      <Helmet title="Contract Addresses - The Civil Registry" />
       <StyledContent>
         <StyledHeader>
           <StyledNetwork>{formattedNetworkNames[props.network]}</StyledNetwork>

--- a/packages/dapp/src/components/Dashboard/Dashboard.tsx
+++ b/packages/dapp/src/components/Dashboard/Dashboard.tsx
@@ -24,9 +24,7 @@ export interface DashboardProps {
 export const Dashboard: React.SFC<DashboardProps> = props => {
   return (
     <>
-      <Helmet>
-        <title>My Dashboard - The Civil Registry</title>
-      </Helmet>
+      <Helmet title="My Dashboard - The Civil Registry" />
       <ScrollToTopOnMount />
       <UserDashboardHeader>
         <UserInfoSummary />

--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -4,7 +4,7 @@ import { StyledMainContainer } from "@joincivil/components";
 import BigNumber from "bignumber.js";
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-import { Route, RouteComponentProps, Switch, withRouter } from "react-router-dom";
+import { Redirect, Route, RouteComponentProps, Switch, withRouter } from "react-router-dom";
 import { setNetwork, setNetworkName } from "../redux/actionCreators/network";
 import { addUser } from "../redux/actionCreators/userAccount";
 import { getCivil, isGraphQLSupportedOnNetwork } from "../helpers/civilInstance";
@@ -124,10 +124,11 @@ class Main extends React.Component<MainReduxProps & DispatchProp<any> & RouteCom
       <StyledMainContainer>
         {isNetworkSupported && (
           <Switch>
-            <Route exact path="/" component={Listings} />
+            <Redirect exact path="/" to="/registry/approved" />
+            <Redirect exact path="/registry" to="/registry/approved" />
+            <Redirect exact path="/registry/in-progress" to="/registry/in-progress/new-applications" />
             <Route path="/registry/:listingType/:subListingType" component={Listings} />
             <Route path="/registry/:listingType" component={Listings} />
-            <Route path="/registry" component={Listings} />
             <Route path="/contract-addresses" component={ContractAddresses} />
             <Route path="/listing/:listing/challenge/:challengeID" component={ChallengePage} />
             <Route path="/listing/:listing/submit-challenge" component={SubmitChallengePage} />
@@ -140,8 +141,8 @@ class Main extends React.Component<MainReduxProps & DispatchProp<any> & RouteCom
             <Route path="/create-newsroom" component={CreateNewsroom} />
             <Route path="/apply-to-registry/:action?/:token?" component={SignUpNewsroom} />
             <Route path="/government" component={Government} />
+            <Redirect exact path="/dashboard" to="/dashboard/tasks/all" />
             <Route path="/dashboard/:activeDashboardTab/:activeDashboardSubTab" component={Dashboard} />
-            <Route path="/dashboard" component={Dashboard} />
             <Route path="/auth" component={AuthRouter} />>
             <Route path="/tokens" component={Tokens} />
             {/* TODO(jorgelo): Better 404 */}

--- a/packages/dapp/src/components/Parameterizer/index.tsx
+++ b/packages/dapp/src/components/Parameterizer/index.tsx
@@ -209,9 +209,7 @@ class Parameterizer extends React.Component<ParameterizerPageProps & DispatchPro
     return (
       <>
         <ScrollToTopOnMount />
-        <Helmet>
-          <title>Registry Parameters - The Civil Registry</title>
-        </Helmet>
+        <Helmet title="Registry Parameters - The Civil Registry" />
         <GridRow>
           <StyledTitle>Civil Registry Parameters</StyledTitle>
           <StyledDescriptionP>

--- a/packages/dapp/src/components/Tokens/Tokens.tsx
+++ b/packages/dapp/src/components/Tokens/Tokens.tsx
@@ -19,9 +19,7 @@ export const TokensComponent: React.SFC<TokensProps> = ({ network }) => {
 
   return (
     <>
-      <Helmet>
-        <title>Token Account - The Civil Registry</title>
-      </Helmet>
+      <Helmet title="Token Account - The Civil Registry" />
       <ScrollToTopOnMount />
       <LoadUser>
         {({ loading, user }) => {

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -103,9 +103,7 @@ class ListingPageComponent extends React.Component<
 
     return (
       <>
-        <Helmet>
-          <title>{newsroom!.data.name} - The Civil Registry</title>
-        </Helmet>
+        <Helmet title="{newsroom!.data.name} - The Civil Registry" />
 
         <ListingHeader
           userAccount={this.props.userAccount}

--- a/packages/dapp/src/components/listinglist/Listings.tsx
+++ b/packages/dapp/src/components/listinglist/Listings.tsx
@@ -65,9 +65,7 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
           >
             <Tab title={<ApprovedNewsroomsTabText />}>
               <StyledPageContent>
-                <Helmet>
-                  <title>The Civil Registry - A community-driven space for curating quality journalism</title>
-                </Helmet>
+                <Helmet title="The Civil Registry - A community-driven space for curating quality journalism" />
                 <WhitelistedListingListContainer />
               </StyledPageContent>
             </Tab>
@@ -82,9 +80,7 @@ class Listings extends React.Component<ListingProps & ListingReduxProps> {
             </Tab>
             <Tab title={<RejectedNewsroomsTabText />}>
               <StyledPageContent>
-                <Helmet>
-                  <title>Rejected Newsrooms - The Civil Registry</title>
-                </Helmet>
+                <Helmet title="Rejected Newsrooms - The Civil Registry" />
                 <RejectedListingListContainer />
               </StyledPageContent>
             </Tab>

--- a/packages/dapp/src/components/listinglist/ListingsInProgress.tsx
+++ b/packages/dapp/src/components/listinglist/ListingsInProgress.tsx
@@ -42,13 +42,7 @@ export interface ListingsInProgressProps {
   govtParameters: any;
 }
 
-const TABS: string[] = [
-  "in-application",
-  "under-challenge",
-  "under-appeal",
-  "under-appeal-challenge",
-  "ready-to-update",
-];
+const TABS: string[] = ["new-applications", "under-challenge", "under-appeal", "decisio-challenged", "ready-to-update"];
 
 class ListingsInProgress extends React.Component<ListingProps & ListingsInProgressProps> {
   public render(): JSX.Element {
@@ -86,41 +80,31 @@ class ListingsInProgress extends React.Component<ListingProps & ListingsInProgre
       >
         <Tab title={newApplicationsTab}>
           <>
-            <Helmet>
-              <title>New Applications - The Civil Registry</title>
-            </Helmet>
+            <Helmet title="New Applications - The Civil Registry" />
             {this.renderApplications()}
           </>
         </Tab>
         <Tab title={underChallengeTab}>
           <>
-            <Helmet>
-              <title>Newsrooms Under Challenge - The Civil Registry</title>
-            </Helmet>
+            <Helmet title="Newsrooms Under Challenge - The Civil Registry" />
             {this.renderUnderChallenge()}
           </>
         </Tab>
         <Tab title={appealToCouncilTab}>
           <>
-            <Helmet>
-              <title>Newsrooms Under Appeal - The Civil Registry</title>
-            </Helmet>
+            <Helmet title="Newsrooms Under Appeal - The Civil Registry" />
             {this.renderUnderAppeal()}
           </>
         </Tab>
         <Tab title={challengeCouncilAppealTab}>
           <>
-            <Helmet>
-              <title>Newsrooms Decision Challenged- The Civil Registry</title>
-            </Helmet>
+            <Helmet title="Newsrooms Decision Challenged- The Civil Registry" />
             {this.renderUnderAppealChallenge()}
           </>
         </Tab>
         <Tab title={readyToUpdateTab}>
           <>
-            <Helmet>
-              <title>Newsrooms Ready To Update - The Civil Registry</title>
-            </Helmet>
+            <Helmet title="Newsrooms Ready To Update - The Civil Registry" />
             {this.renderReadyToUpdate()}
           </>
         </Tab>


### PR DESCRIPTION
This PR includes:

- Updates `react-router-dom` version for `@joincivil/components` to match the version used in the dapp
- Adds router redirects for various URLs so that the URL matches the default renders for those views
- Uses `title` prop for `Helmet` component, instead of putting a the `<title>`
element inside the component, which can cause a `RangeError` related to Helmet's user of `deep-equal`. More details about this bug can be found here: https://github.com/nfl/react-helmet/issues/373