### PR TITLE
Fix key for grant request graphql query

### DIFF
--- a/packages/newsroom-signup/src/NewsroomProfile/GrantApplication.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/GrantApplication.tsx
@@ -171,7 +171,7 @@ class GrantApplicationComponent extends React.Component<GrantApplicationProps & 
           update={cache => {
             cache.writeQuery({
               query: grantQuery,
-              data: { nrsignupRequestGrant: { grantRequested: true } },
+              data: { nrsignupNewsroom: { grantRequested: true, __typename: "NrsignupNewsroom" } },
             });
           }}
           mutation={requestGrantMutation}
@@ -228,7 +228,7 @@ class GrantApplicationComponent extends React.Component<GrantApplicationProps & 
           update={cache => {
             cache.writeQuery({
               query: grantQuery,
-              data: { nrsignupRequestGrant: { grantRequested: false } },
+              data: { nrsignupNewsroom: { grantRequested: false, __typename: "NrsignupNewsroom" } },
             });
           }}
         >


### PR DESCRIPTION
I continued to get an error with the new key name from your PR, and no re-render:

```
writeToStore.js:107 Missing field nrsignupNewsroom in {
  "nrsignupRequestGrant": {
    "grantRequested": false
  }
}
```

Looks like `nrsignupNewsroom` is the right key.

Also I was getting this warning:

```
Missing field __typename in {
  "grantRequested": true
}
```

Not sure why your `createOmitTypenameLink` isn't working here but didn't have time to dig in, adding it manually works here.

Feel free to make any changes to this.