### PR TITLE
Fix behavior of "toggle" element for user drawer

### DIFF
--- a/packages/components/src/NavBar/NavBar.tsx
+++ b/packages/components/src/NavBar/NavBar.tsx
@@ -58,24 +58,24 @@ export class NavBar extends React.Component<NavProps, NavState> {
               applyURL={applyURL}
               enableEthereum={enableEthereum}
               toggleDrawer={this.toggleDrawer}
-            />
+            >
+              {isUserDrawerOpen && (
+                <NavDrawer
+                  balance={balance}
+                  votingBalance={votingBalance}
+                  userEthAddress={userEthAddress}
+                  userRevealVotesCount={userRevealVotesCount}
+                  userClaimRewardsCount={userClaimRewardsCount}
+                  userChallengesStartedCount={userChallengesStartedCount}
+                  userChallengesVotedOnCount={userChallengesVotedOnCount}
+                  buyCvlUrl={buyCvlUrl}
+                  useGraphQL={useGraphQL}
+                  onLoadingPrefToggled={onLoadingPrefToggled}
+                  handleOutsideClick={this.hideUserDrawer}
+                />
+              )}
+            </UserAccount>
           </NavInnerRight>
-
-          {isUserDrawerOpen && (
-            <NavDrawer
-              balance={balance}
-              votingBalance={votingBalance}
-              userEthAddress={userEthAddress}
-              userRevealVotesCount={userRevealVotesCount}
-              userClaimRewardsCount={userClaimRewardsCount}
-              userChallengesStartedCount={userChallengesStartedCount}
-              userChallengesVotedOnCount={userChallengesVotedOnCount}
-              buyCvlUrl={buyCvlUrl}
-              useGraphQL={useGraphQL}
-              onLoadingPrefToggled={onLoadingPrefToggled}
-              handleOutsideClick={this.hideUserDrawer}
-            />
-          )}
         </NavOuter>
       </NavContainer>
     );

--- a/packages/components/src/NavBar/NavDrawer.tsx
+++ b/packages/components/src/NavBar/NavDrawer.tsx
@@ -37,6 +37,7 @@ import { LoadingPrefToggle } from "./LoadingPrefToggle";
 import { NavUserAccountProps, NavDrawerProps as NavDrawerBaseProps } from "./NavBarTypes";
 
 export interface NavDrawerProps extends NavDrawerBaseProps, NavUserAccountProps {
+  userAccountElRef?: any;
   handleOutsideClick(): void;
 }
 
@@ -168,7 +169,11 @@ class NavDrawerBucketComponent extends React.Component<NavDrawerProps> {
   }
 
   private handleClick = (event: any) => {
-    if (this.bucket.contains(event.target)) {
+    const toggleEl = this.props.userAccountElRef && this.props.userAccountElRef.current;
+    if (
+      this.bucket.contains(event.target) ||
+      ((toggleEl && toggleEl.contains(event.target)) || event.target === toggleEl)
+    ) {
       return;
     }
 

--- a/packages/components/src/NavBar/UserAccount.tsx
+++ b/packages/components/src/NavBar/UserAccount.tsx
@@ -37,6 +37,15 @@ const UserAccount: React.SFC<NavUserAccountProps> = props => {
         }
 
         if (civilUser && userEthAddress) {
+          const userAccountElRef = React.createRef<HTMLDivElement>();
+          let child;
+
+          if (props.children) {
+            child = React.cloneElement(props.children as React.ReactElement<any>, {
+              userAccountElRef,
+            });
+          }
+
           return (
             <>
               <StyledVisibleIfLoggedInLink>
@@ -44,19 +53,23 @@ const UserAccount: React.SFC<NavUserAccountProps> = props => {
                   <NavLinkDashboardText />
                 </NavLink>
               </StyledVisibleIfLoggedInLink>
-              <NavUser onClick={ev => props.toggleDrawer()}>
-                <CvlContainer>
-                  <CvlToken />
-                  <BalancesContainer>
-                    <UserCvlBalance>{balance}</UserCvlBalance>
-                    <UserCvlVotingBalance>{votingBalance}</UserCvlVotingBalance>
-                  </BalancesContainer>
-                  <AvatarContainer>
-                    <UserAvatar />
-                    <Arrow isOpen={props.isUserDrawerOpen} />
-                  </AvatarContainer>
-                </CvlContainer>
-              </NavUser>
+              <div ref={userAccountElRef}>
+                <NavUser onClick={ev => props.toggleDrawer()}>
+                  <CvlContainer>
+                    <CvlToken />
+                    <BalancesContainer>
+                      <UserCvlBalance>{balance}</UserCvlBalance>
+                      <UserCvlVotingBalance>{votingBalance}</UserCvlVotingBalance>
+                    </BalancesContainer>
+                    <AvatarContainer>
+                      <UserAvatar />
+                      <Arrow isOpen={props.isUserDrawerOpen} />
+                    </AvatarContainer>
+                  </CvlContainer>
+                </NavUser>
+              </div>
+
+              {child}
             </>
           );
         } else if (civilUser && enableEthereum && !userEthAddress) {


### PR DESCRIPTION
This PR fixes the issue where the drawer could not be closed via the "toggle" control, once it was opened. 

Issue #1071 

To fix this issue, this update refactors the `NavDrawer` and `UserAccount` components so the drawer lives inside the User Account component (which toggles the display of the drawer).  The User Account component now passes its `ref` to the child drawer. Finally, the drawer checks if the `event.target` for the "close the drawer on outside click" handler is either the toggle element or the drawer before triggering the "outside click" handler.