### PR TITLE
Refactor step storage/navigation + grant approval/rejection [CIVIL-408] [CIVIL-486]

### DIFF
--- a/packages/dapp/src/components/SignUpNewsroom.tsx
+++ b/packages/dapp/src/components/SignUpNewsroom.tsx
@@ -20,13 +20,7 @@ class SignUpNewsroom extends React.Component<CreateNewsroomProps & CreateNewsroo
     const civil = getCivil();
     return (
       <PageView>
-        <Newsroom
-          civil={civil}
-          account={this.props.userAccount}
-          currentNetwork={this.props.networkName}
-          allSteps={true}
-          initialStep={0}
-        />
+        <Newsroom civil={civil} account={this.props.userAccount} currentNetwork={this.props.networkName} />
       </PageView>
     );
   }

--- a/packages/newsroom-signup/src/DataWrapper.tsx
+++ b/packages/newsroom-signup/src/DataWrapper.tsx
@@ -81,7 +81,11 @@ export class DataWrapper extends React.Component<DataWrapperProps> {
             return "Loading...";
           }
           if (error) {
-            return `Error! ${JSON.stringify(error)}`;
+            return (
+              <>
+                Sorry, there was an error! <code>{JSON.stringify(error)}</code>
+              </>
+            );
           }
 
           return (
@@ -91,10 +95,14 @@ export class DataWrapper extends React.Component<DataWrapperProps> {
                   return "Loading...";
                 }
                 if (charterError) {
-                  if (charterError.graphQLErrors && charterError.graphQLErrors[0].message === "No jsonb found") {
+                  if (charterError.graphQLErrors[0] && charterError.graphQLErrors[0].message === "No jsonb found") {
                     // ok, they haven't saved a charter yet
                   } else {
-                    return `Error! ${JSON.stringify(charterError)}`;
+                    return (
+                      <>
+                        Sorry, there was an error! <code>{JSON.stringify(charterError)}</code>
+                      </>
+                    );
                   }
                 }
 

--- a/packages/newsroom-signup/src/DataWrapper.tsx
+++ b/packages/newsroom-signup/src/DataWrapper.tsx
@@ -15,6 +15,7 @@ const getCharterQuery = gql`
   query {
     nrsignupNewsroom {
       grantRequested
+      grantApproved
       charter {
         name
         tagline
@@ -59,10 +60,9 @@ const saveCharterMutation = gql`
   }
 `;
 
-// const askForGrant
-
 export interface DataWrapperChildrenProps {
   grantRequested?: boolean;
+  grantApproved?: boolean;
   profileWalletAddress: EthAddress;
   persistedCharter: Partial<CharterData>;
   persistCharter(charter: Partial<CharterData>): Promise<void | FetchResult>;
@@ -108,11 +108,13 @@ export class DataWrapper extends React.Component<DataWrapperProps> {
 
                 let persistedCharter: Partial<CharterData>;
                 let grantRequested: boolean;
+                let grantApproved: boolean;
                 if (charterData && charterData.nrsignupNewsroom) {
                   if (charterData.nrsignupNewsroom.charter) {
                     persistedCharter = charterData.nrsignupNewsroom.charter;
                   }
                   grantRequested = charterData.nrsignupNewsroom.grantRequested;
+                  grantApproved = charterData.nrsignupNewsroom.grantApproved;
                 }
 
                 return (
@@ -120,6 +122,7 @@ export class DataWrapper extends React.Component<DataWrapperProps> {
                     {(saveCharter: MutationFunc) => {
                       return this.props.children({
                         grantRequested,
+                        grantApproved,
                         profileWalletAddress: data.currentUser.ethAddress,
                         persistedCharter,
                         persistCharter: this.saveCharterFuncFromMutation(saveCharter),

--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -254,12 +254,12 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
     }
   }
 
-  public async componentWillReceiveProps(newProps: NewsroomProps & DispatchProp<any>): Promise<void> {
-    if (newProps.address && !this.props.address) {
-      await this.hydrateNewsroom(newProps.address);
+  public async componentDidUpdate(prevProps: NewsroomProps & DispatchProp<any>): Promise<void> {
+    if (this.props.address && !prevProps.address) {
+      await this.hydrateNewsroom(this.props.address);
     }
-    if (this.props.newsroom && newProps.account !== this.props.account) {
-      this.setRoles(newProps.address || this.props.address!);
+    if (prevProps.newsroom && this.props.account !== prevProps.account) {
+      this.setRoles(this.props.address || prevProps.address!);
     }
   }
 

--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -36,8 +36,53 @@ import { CivilContext } from "./CivilContext";
 import { StateWithNewsroom } from "./reducers";
 import { CmsUserData } from "./types";
 
+enum SECTION {
+  PROFILE,
+  CONTRACT,
+  TUTORIAL,
+  TOKENS,
+  APPLY,
+}
+export enum STEP {
+  PROFILE_BIO,
+  PROFILE_ROSTER,
+  PROFILE_CHARTER,
+  PROFILE_SIGN,
+  PROFILE_SO_FAR,
+  PROFILE_GRANT,
+  CONTRACT_GET_STARTED,
+  CONTRACT_UNDERSTANDING_ETH,
+  CONTRACT_CREATE,
+  CONTRACT_ASSIGN,
+  TUTORIAL,
+  TOKENS,
+  APPLY,
+}
+const STEP_TO_SECTION = {
+  [STEP.PROFILE_BIO]: SECTION.PROFILE,
+  [STEP.PROFILE_ROSTER]: SECTION.PROFILE,
+  [STEP.PROFILE_CHARTER]: SECTION.PROFILE,
+  [STEP.PROFILE_SIGN]: SECTION.PROFILE,
+  [STEP.PROFILE_SO_FAR]: SECTION.PROFILE,
+  [STEP.PROFILE_GRANT]: SECTION.PROFILE,
+  [STEP.CONTRACT_GET_STARTED]: SECTION.CONTRACT,
+  [STEP.CONTRACT_UNDERSTANDING_ETH]: SECTION.CONTRACT,
+  [STEP.CONTRACT_CREATE]: SECTION.CONTRACT,
+  [STEP.CONTRACT_ASSIGN]: SECTION.CONTRACT,
+  [STEP.TUTORIAL]: SECTION.TUTORIAL,
+  [STEP.TOKENS]: SECTION.TOKENS,
+  [STEP.APPLY]: SECTION.APPLY,
+};
+const SECTION_STARTS = {
+  [SECTION.PROFILE]: 0,
+  [SECTION.CONTRACT]: 6,
+  [SECTION.TUTORIAL]: 10,
+  [SECTION.TOKENS]: 11,
+  [SECTION.APPLY]: 12,
+};
+
 export interface NewsroomComponentState {
-  currentStep: number;
+  currentStep: STEP;
   subscription?: any;
   charterPartOneComplete?: boolean;
   charterPartTwoComplete?: boolean;
@@ -64,8 +109,7 @@ export interface NewsroomExternalProps {
   helpUrlBase?: string;
   newsroomUrl?: string;
   logoUrl?: string;
-  allSteps?: boolean; // @TODO temporary while excluding it from IRL newsroom use but including for testing in dapp
-  initialStep?: number;
+  forceInitialStep?: STEP;
   renderUserSearch?(onSetAddress: any): JSX.Element;
   onNewsroomCreated?(address: EthAddress): void;
   onContractDeployStarted?(txHash: TxHash): void;
@@ -153,18 +197,13 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
 
   constructor(props: NewsroomProps) {
     super(props);
-    let currentStep = props.address ? 1 : 0;
-    if (typeof props.initialStep !== "undefined") {
-      currentStep = props.initialStep;
+    let currentStep = props.address ? SECTION_STARTS[SECTION.CONTRACT] : 0;
+    if (typeof props.forceInitialStep !== "undefined") {
+      currentStep = props.forceInitialStep;
     } else {
       try {
         if (localStorage.newsroomOnBoardingLastSeen) {
           currentStep = Number(localStorage.newsroomOnBoardingLastSeen);
-
-          // @TODO Temporary cause of infinite loop in sign constitution step
-          if (this.props.allSteps && currentStep === 4) {
-            currentStep--;
-          }
         }
       } catch (e) {
         console.error("Failed to load step index", e);
@@ -226,15 +265,8 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
           }}
         >
           <StepProcessTopNavNoButtons
-            activeIndex={this.state.currentStep}
-            onActiveTabChange={(newIndex: number) => {
-              try {
-                localStorage.newsroomOnBoardingLastSeen = JSON.stringify(newIndex);
-              } catch (e) {
-                console.error("Failed to save step index", e);
-              }
-              this.setState({ currentStep: newIndex });
-            }}
+            activeIndex={STEP_TO_SECTION[this.state.currentStep]}
+            onActiveTabChange={this.navigateToSection}
           >
             {this.renderSteps()}
           </StepProcessTopNavNoButtons>
@@ -245,20 +277,22 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
 
   public renderSteps(): JSX.Element[] {
     return [
-      <StepNoButtons
-        title={"Registry Profile"}
-        disabled={!this.props.userIsOwner}
-        complete={this.state.charterPartOneComplete}
-        key="createCharterPartOne"
-      >
+      <StepNoButtons title={"Registry Profile"} complete={this.state.charterPartOneComplete} key="createCharterPartOne">
         <NewsroomProfile
+          currentStep={this.state.currentStep - SECTION_STARTS[SECTION.PROFILE]}
+          navigate={this.navigate}
           grantRequested={this.props.grantRequested}
           charter={this.props.charter}
           updateCharter={this.updateCharter}
         />
       </StepNoButtons>,
-      <StepNoButtons title={"Smart Contract"} disabled={true} key="smartcontract">
-        <SmartContract profileWalletAddress={this.props.profileWalletAddress} charter={this.props.charter} />
+      <StepNoButtons title={"Smart Contract"} key="smartcontract">
+        <SmartContract
+          currentStep={this.state.currentStep - SECTION_STARTS[SECTION.CONTRACT]}
+          navigate={this.navigate}
+          profileWalletAddress={this.props.profileWalletAddress}
+          charter={this.props.charter}
+        />
       </StepNoButtons>,
       <StepNoButtons title={"Tutorial"} disabled={true} key="tutorial">
         <div />
@@ -302,6 +336,32 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
       this.props.onNewsroomCreated(result.address);
     }
   };
+
+  private navigateToSection = (newSection: SECTION): void => {
+    if (newSection === STEP_TO_SECTION[this.state.currentStep]) {
+      // Already on this section
+      return;
+    }
+
+    let newStep = SECTION_STARTS[newSection]; // Go to first step in that section
+    if (newSection === SECTION.PROFILE) {
+      newStep = STEP.PROFILE_SO_FAR; // For this section, makes more sense to go to "your profile so far" step
+    }
+
+    this.saveStep(newStep);
+    this.setState({ currentStep: newStep });
+  };
+  private navigate = (go: 1 | -1): void => {
+    this.saveStep(this.state.currentStep + go);
+    this.setState({ currentStep: this.state.currentStep + go });
+  };
+  private saveStep(step: STEP): void {
+    try {
+      localStorage.newsroomOnBoardingLastSeen = JSON.stringify(step);
+    } catch (e) {
+      console.error("Failed to save step index", e);
+    }
+  }
 
   private initCharter(): void {
     this.updateCharter(this.defaultCharterValues(this.props.persistedCharter || {}));

--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -109,7 +109,6 @@ export interface NewsroomExternalProps {
   helpUrlBase?: string;
   newsroomUrl?: string;
   logoUrl?: string;
-  forceInitialStep?: STEP;
   renderUserSearch?(onSetAddress: any): JSX.Element;
   onNewsroomCreated?(address: EthAddress): void;
   onContractDeployStarted?(txHash: TxHash): void;
@@ -213,17 +212,13 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
 
   constructor(props: NewsroomProps) {
     super(props);
-    let currentStep = props.address ? SECTION_STARTS[SECTION.CONTRACT] : 0;
-    if (typeof props.forceInitialStep !== "undefined") {
-      currentStep = props.forceInitialStep;
-    } else {
-      try {
-        if (localStorage.newsroomOnBoardingLastSeen) {
-          currentStep = Number(localStorage.newsroomOnBoardingLastSeen);
-        }
-      } catch (e) {
-        console.error("Failed to load step index", e);
+    let currentStep = props.address ? SECTION_STARTS[SECTION.CONTRACT] : STEP.PROFILE_SO_FAR;
+    try {
+      if (localStorage.newsroomOnBoardingLastSeen) {
+        currentStep = Number(localStorage.newsroomOnBoardingLastSeen);
       }
+    } catch (e) {
+      console.error("Failed to load step index", e);
     }
 
     this.state = {

--- a/packages/newsroom-signup/src/NewsroomProfile/ApplicationSoFarPage.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/ApplicationSoFarPage.tsx
@@ -1,6 +1,13 @@
 import * as React from "react";
 import styled from "styled-components";
-import { fonts, colors, OBCollapsable } from "@joincivil/components";
+import {
+  fonts,
+  colors,
+  OBCollapsable,
+  OBSectionHeader,
+  OBSectionDescription,
+  HollowGreenCheck,
+} from "@joincivil/components";
 import { AvatarWrap, AvatarImg, noAvatar } from "../styledComponents";
 import { CharterData, RosterMember } from "@joincivil/core";
 import { charterQuestions, questionsCopy } from "../constants";
@@ -11,17 +18,25 @@ export interface ApplicationSoFarPageProps {
 }
 
 const Collapsable = styled(OBCollapsable)`
-  margin-bottom: 0;
-  margin-top: 0;
-  border-bottom: none;
+  &:last-child {
+    margin-bottom: 64px;
+  }
 `;
 
 const SectionHeaders = styled.h4`
+  padding-left: 36px;
   margin-bottom: 0;
   font-size: 16px;
   font-weight: bold;
   line-height: 32px;
   font-family: ${fonts.SANS_SERIF};
+`;
+const SectionHeaderCheck = styled(HollowGreenCheck)`
+  position: absolute;
+  left: 0;
+  top: 3px;
+  width: 24px;
+  height: 24px;
 `;
 
 const Label = styled.div`
@@ -40,7 +55,7 @@ const Value = styled.div`
 `;
 
 const CollapsableInner = styled.div`
-  padding: 10px 20px;
+  padding: 10px 20px 10px 36px;
 `;
 
 const GridWrapper = styled.div`
@@ -70,7 +85,19 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
   public render(): JSX.Element {
     return (
       <div>
-        <Collapsable open={true} header={<SectionHeaders>Newsroom Details</SectionHeaders>}>
+        <OBSectionHeader>Here’s your Registry Profile so far</OBSectionHeader>
+        <OBSectionDescription>
+          Please review your newsroom Registry Profile. Keep in mind that this is a public document.
+        </OBSectionDescription>
+        <Collapsable
+          open={true}
+          header={
+            <SectionHeaders>
+              <SectionHeaderCheck />
+              Newsroom Details
+            </SectionHeaders>
+          }
+        >
           <CollapsableInner>
             <GridWrapper>
               <div>
@@ -100,14 +127,28 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
             </GridWrapper>
           </CollapsableInner>
         </Collapsable>
-        <Collapsable open={false} header={<SectionHeaders>Roster</SectionHeaders>}>
+        <Collapsable
+          open={false}
+          header={
+            <SectionHeaders>
+              <SectionHeaderCheck />Roster
+            </SectionHeaders>
+          }
+        >
           <CollapsableInner>
             {this.props.charter.roster!.map((member: RosterMember) => {
               return <RosterMemberListItem member={member} />;
             })}
           </CollapsableInner>
         </Collapsable>
-        <Collapsable open={false} header={<SectionHeaders>Charter</SectionHeaders>}>
+        <Collapsable
+          open={false}
+          header={
+            <SectionHeaders>
+              <SectionHeaderCheck />Charter
+            </SectionHeaders>
+          }
+        >
           <CollapsableInner>
             <QuestionContainer>
               <Label>{questionsCopy[charterQuestions.PURPOSE]}</Label>
@@ -131,7 +172,14 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
             </QuestionContainer>
           </CollapsableInner>
         </Collapsable>
-        <Collapsable open={false} header={<SectionHeaders>Civil Constitution</SectionHeaders>}>
+        <Collapsable
+          open={false}
+          header={
+            <SectionHeaders>
+              <SectionHeaderCheck />Civil Constitution
+            </SectionHeaders>
+          }
+        >
           <CollapsableInner>
             I agree to abide by the Civil Community's ethical principles as described in the Civil Constitution.
           </CollapsableInner>

--- a/packages/newsroom-signup/src/NewsroomProfile/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/index.tsx
@@ -12,15 +12,15 @@ import { GrantApplication } from "./GrantApplication";
 const NUM_STEPS = 5;
 
 export interface NewsroomProfileState {
-  currentStep: number;
   showButtons: boolean;
 }
 
 export interface NewsroomProfileProps {
+  currentStep: number;
   charter: Partial<CharterData>;
   grantRequested?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
-  goNext?(): void;
+  navigate(go: 1 | -1): void;
 }
 
 const ButtonContainer = styled.div`
@@ -33,16 +33,7 @@ const ButtonContainer = styled.div`
 export class NewsroomProfile extends React.Component<NewsroomProfileProps, NewsroomProfileState> {
   constructor(props: NewsroomProfileProps) {
     super(props);
-    let currentStep = 0;
-    try {
-      if (localStorage.newsroomOnBoardingNewsroomProfileStep) {
-        currentStep = Number(localStorage.newsroomOnBoardingNewsroomProfileStep);
-      }
-    } catch (e) {
-      console.error("Failed to load step index");
-    }
     this.state = {
-      currentStep,
       showButtons: true,
     };
   }
@@ -78,7 +69,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
         return false;
       },
       () => {
-        return true;
+        return !!this.props.grantRequested;
       },
     ];
     return functions[index];
@@ -96,7 +87,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
       <ApplicationSoFarPage charter={this.props.charter} />,
       <GrantApplication />,
     ];
-    return steps[this.state.currentStep];
+    return steps[this.props.currentStep];
   }
   public renderButtons(): JSX.Element | null {
     if (!this.state.showButtons || this.props.grantRequested) {
@@ -104,45 +95,26 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
     }
     return (
       <ButtonContainer>
-        {this.state.currentStep > 0 ? (
-          <BorderlessButton size={buttonSizes.MEDIUM} onClick={() => this.goBack()}>
+        {this.props.currentStep > 0 ? (
+          <BorderlessButton size={buttonSizes.MEDIUM} onClick={() => this.props.navigate(-1)}>
             Back
           </BorderlessButton>
         ) : (
           <div />
         )}
-        {this.state.currentStep < NUM_STEPS ? (
-          <Button
-            disabled={this.getDisabled(this.state.currentStep)()}
-            textTransform="none"
-            width={220}
-            size={buttonSizes.MEDIUM}
-            onClick={() => this.goNext()}
-          >
-            Next
-          </Button>
-        ) : (
-          <div />
-        )}
+        <Button
+          disabled={this.getDisabled(this.props.currentStep)()}
+          textTransform="none"
+          width={220}
+          size={buttonSizes.MEDIUM}
+          onClick={() => this.props.navigate(+1)}
+        >
+          Next
+        </Button>
       </ButtonContainer>
     );
   }
-  public goNext(): void {
-    try {
-      localStorage.newsroomOnBoardingNewsroomProfileStep = JSON.stringify(this.state.currentStep + 1);
-    } catch (e) {
-      console.error("Failed to save step index", e);
-    }
-    this.setState({ currentStep: this.state.currentStep + 1 });
-  }
-  public goBack(): void {
-    try {
-      localStorage.newsroomOnBoardingNewsroomProfileStep = JSON.stringify(this.state.currentStep - 1);
-    } catch (e) {
-      console.error("Failed to save step index", e);
-    }
-    this.setState({ currentStep: this.state.currentStep - 1 });
-  }
+
   public render(): JSX.Element {
     return (
       <>

--- a/packages/newsroom-signup/src/NewsroomProfile/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/index.tsx
@@ -117,7 +117,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
           textTransform="none"
           width={220}
           size={buttonSizes.MEDIUM}
-          onClick={() => this.props.navigate(+1)}
+          onClick={() => this.props.navigate(1)}
         >
           Next
         </Button>

--- a/packages/newsroom-signup/src/NewsroomProfile/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/index.tsx
@@ -9,8 +9,6 @@ import { SignConstitution } from "./SignConstitution";
 import { ApplicationSoFarPage } from "./ApplicationSoFarPage";
 import { GrantApplication } from "./GrantApplication";
 
-const NUM_STEPS = 5;
-
 export interface NewsroomProfileState {
   showButtons: boolean;
 }
@@ -19,6 +17,7 @@ export interface NewsroomProfileProps {
   currentStep: number;
   charter: Partial<CharterData>;
   grantRequested?: boolean;
+  grantApproved?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
   navigate(go: 1 | -1): void;
 }
@@ -72,6 +71,14 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
         return !!this.props.grantRequested;
       },
     ];
+
+    if (index >= functions.length) {
+      // Dumb edge case because of how auto-skipping from grant step interacts with our nested step processes, we can briefly have too-high a step
+      return () => {
+        return false;
+      };
+    }
+
     return functions[index];
   }
   public renderCurrentStep(): JSX.Element {
@@ -89,8 +96,11 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
     ];
     return steps[this.props.currentStep];
   }
+
   public renderButtons(): JSX.Element | null {
-    if (!this.state.showButtons || this.props.grantRequested) {
+    // @TODO/toby Confirm that when grant is rejected, it comes through as explicit `false` and not null or undefined
+    const waitingOnGrant = this.props.grantRequested && typeof this.props.grantApproved !== "boolean";
+    if (!this.state.showButtons || waitingOnGrant) {
       return null;
     }
     return (
@@ -123,6 +133,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
       </>
     );
   }
+
   private setButtonVisibility = (visible: boolean) => {
     this.setState({ showButtons: visible });
   };

--- a/packages/newsroom-signup/src/SmartContract/UnderstandingEth.tsx
+++ b/packages/newsroom-signup/src/SmartContract/UnderstandingEth.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { OBSectionHeader, OBSectionDescription } from "@joincivil/components";
+
+export class UnderstandingEth extends React.Component {
+  public render(): JSX.Element {
+    return (
+      <>
+        <OBSectionHeader>Understanding Ether (ETH)</OBSectionHeader>
+        <OBSectionDescription>
+          ETH is used to pay for gas fees to complete the transactions in your Newsroom Smart Contract, as well as to
+          buy Civil tokens later in this process.
+        </OBSectionDescription>
+      </>
+    );
+  }
+}

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -5,12 +5,10 @@ import { LetsGetStartedPage } from "./LetsGetStartedPage";
 import { Button, buttonSizes } from "@joincivil/components";
 
 export interface SmartContractProps {
+  currentStep: number;
   profileWalletAddress?: EthAddress;
   charter: Partial<CharterData>;
-}
-
-export interface SmartContractState {
-  currentStep: number;
+  navigate(go: 1 | -1): void;
 }
 
 const ContinueButton = styled(Button)`
@@ -23,18 +21,12 @@ const ContinueButtonContainer = styled.div`
   justify-content: center;
 `;
 
-export class SmartContract extends React.Component<SmartContractProps, SmartContractState> {
-  constructor(props: SmartContractProps) {
-    super(props);
-    this.state = {
-      currentStep: 0,
-    };
-  }
+export class SmartContract extends React.Component<SmartContractProps> {
   public renderButtons(): JSX.Element | void {
-    if (this.state.currentStep === 0) {
+    if (this.props.currentStep === 0) {
       return (
         <ContinueButtonContainer>
-          <ContinueButton onClick={this.goNext} size={buttonSizes.MEDIUM_WIDE}>
+          <ContinueButton onClick={() => this.props.navigate(+1)} size={buttonSizes.MEDIUM_WIDE}>
             Continue
           </ContinueButton>
         </ContinueButtonContainer>
@@ -45,7 +37,7 @@ export class SmartContract extends React.Component<SmartContractProps, SmartCont
     const steps = [
       <LetsGetStartedPage walletAddress={this.props.profileWalletAddress} name={this.props.charter.name!} />,
     ];
-    return steps[this.state.currentStep];
+    return steps[this.props.currentStep];
   }
   public render(): JSX.Element {
     return (
@@ -55,7 +47,4 @@ export class SmartContract extends React.Component<SmartContractProps, SmartCont
       </>
     );
   }
-  private goNext = (): void => {
-    this.setState({ currentStep: this.state.currentStep + 1 });
-  };
 }

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -27,7 +27,7 @@ export class SmartContract extends React.Component<SmartContractProps> {
     if (this.props.currentStep === 0) {
       return (
         <ContinueButtonContainer>
-          <ContinueButton onClick={() => this.props.navigate(+1)} size={buttonSizes.MEDIUM_WIDE}>
+          <ContinueButton onClick={() => this.props.navigate(1)} size={buttonSizes.MEDIUM_WIDE}>
             Continue
           </ContinueButton>
         </ContinueButtonContainer>

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { EthAddress, CharterData } from "@joincivil/core";
 import { LetsGetStartedPage } from "./LetsGetStartedPage";
+import { UnderstandingEth } from "./UnderstandingEth";
 import { Button, buttonSizes } from "@joincivil/components";
 
 export interface SmartContractProps {
@@ -36,6 +37,7 @@ export class SmartContract extends React.Component<SmartContractProps> {
   public renderCurrentStep(): JSX.Element {
     const steps = [
       <LetsGetStartedPage walletAddress={this.props.profileWalletAddress} name={this.props.charter.name!} />,
+      <UnderstandingEth />,
     ];
     return steps[this.props.currentStep];
   }


### PR DESCRIPTION
- Step stuff
    - Lift step state up to parent `<Newsroom>` manager component
    - Single step # for all sections, defined by enums
    - Support for navigating across sections
- Auto-advance past grant step when grant approved/rejected or if user is on deprecated "waiting after skip" state
- Misc updates/fixes

@am9u @sruddy tagging for visibility if you if you want to integrate your stuff into step flow, but also very happy do the merge and hook up your components into this flow whenever they're ready