### PR TITLE
don't prepopulate airswap amount

### DIFF
--- a/packages/components/src/Tokens/buy/AirswapBuyCVL.tsx
+++ b/packages/components/src/Tokens/buy/AirswapBuyCVL.tsx
@@ -36,7 +36,7 @@ class BuyCVLBase extends React.Component<BuyCVLProps> {
         env: environment,
         token: tokenAddress,
         address: buyFromAddress,
-        amount: amountString,
+        // amount: amountString,
         onComplete: () => {
           this.props.onComplete();
         },


### PR DESCRIPTION
doesn't appear to be working properly - the value is prepopulating correctly, but when you actually get the quote it returns an insane amount