### PR TITLE
GH-1094 Create Proposal/Listing Challenges subtabs under Claim Rewards / Rescue Tokens in the Dashboard

### DIFF
--- a/packages/dapp/src/components/Dashboard/ChallengesWithRewardsToClaim.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithRewardsToClaim.tsx
@@ -5,6 +5,9 @@ import BigNumber from "bignumber.js";
 import { TwoStepEthTransaction, TxHash } from "@joincivil/core";
 
 import {
+  Tabs,
+  Tab,
+  StyledDashboardSubTab,
   ClaimRewardsDescriptionText,
   ModalContent,
   StyledDashboardActivityDescription,
@@ -14,7 +17,13 @@ import {
 import { multiClaimRewards } from "../../apis/civilTCR";
 import { InjectedTransactionStatusModalProps, hasTransactionStatusModals } from "../utility/TransactionStatusModalsHOC";
 
-import { ChallengesToProcess, StyledBatchButtonContainer, getChallengesToProcess, getSalts } from "./DashboardActivity";
+import {
+  ChallengesToProcess,
+  StyledBatchButtonContainer,
+  getChallengesToProcess,
+  getSalts,
+  StyledTabsComponent,
+} from "./DashboardActivity";
 import ActivityListItemClaimReward from "./ActivityListItemClaimReward";
 
 enum TransactionTypes {
@@ -80,12 +89,13 @@ class ChallengesWithRewardsToClaim extends React.Component<
   }
 
   public componentWillUnmount(): void {
-    this.setState(() => ({ challengesToClaim: {} }));
+    this.resetChallengesToMultiClaim();
   }
 
   public render(): JSX.Element {
     const isClaimRewardsButtonDisabled = this.isEmpty(this.state.challengesToClaim);
     const transactions = this.getTransactions();
+    const { resetChallengesToMultiClaim } = this;
 
     return (
       <>
@@ -93,28 +103,45 @@ class ChallengesWithRewardsToClaim extends React.Component<
           <ClaimRewardsDescriptionText />
         </StyledDashboardActivityDescription>
 
-        {this.props.challenges
-          .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
-          .map((c: string) => (
-            <ActivityListItemClaimReward key={c} challengeID={c!} toggleSelect={this.setChallengesToMultiClaim} />
-          ))}
+        <Tabs
+          TabComponent={StyledDashboardSubTab}
+          TabsNavComponent={StyledTabsComponent}
+          onActiveTabChange={resetChallengesToMultiClaim}
+        >
+          <Tab title="Listing Challenges">
+            <>
+              {this.props.challenges
+                .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
+                .map((c: string) => (
+                  <ActivityListItemClaimReward key={c} challengeID={c!} toggleSelect={this.setChallengesToMultiClaim} />
+                ))}
 
-        {this.props.appealChallenges
-          .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
-          .map((c: string) => (
-            <ActivityListItemClaimReward key={c} appealChallengeID={c!} toggleSelect={this.setChallengesToMultiClaim} />
-          ))}
-
-        {this.props.proposalChallenges
-          .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
-          .map((c: string) => (
-            <ActivityListItemClaimReward
-              key={c}
-              isProposalChallenge={true}
-              challengeID={c!}
-              toggleSelect={this.setChallengesToMultiClaim}
-            />
-          ))}
+              {this.props.appealChallenges
+                .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
+                .map((c: string) => (
+                  <ActivityListItemClaimReward
+                    key={c}
+                    appealChallengeID={c!}
+                    toggleSelect={this.setChallengesToMultiClaim}
+                  />
+                ))}
+            </>
+          </Tab>
+          <Tab title="Parameter Proposal Challenges">
+            <>
+              {this.props.proposalChallenges
+                .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
+                .map((c: string) => (
+                  <ActivityListItemClaimReward
+                    key={c}
+                    isProposalChallenge={true}
+                    challengeID={c!}
+                    toggleSelect={this.setChallengesToMultiClaim}
+                  />
+                ))}
+            </>
+          </Tab>
+        </Tabs>
 
         <StyledBatchButtonContainer>
           <TransactionButtonNoModal
@@ -181,6 +208,10 @@ class ChallengesWithRewardsToClaim extends React.Component<
         challengesToClaim: { ...newChallengesToClaim },
       }));
     }
+  };
+
+  private resetChallengesToMultiClaim = (): void => {
+    this.setState(() => ({ challengesToClaim: {} }));
   };
 
   private multiClaim = async (): Promise<TwoStepEthTransaction | void> => {

--- a/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengesWithTokensToRescue.tsx
@@ -5,6 +5,9 @@ import BigNumber from "bignumber.js";
 import { TwoStepEthTransaction, TxHash } from "@joincivil/core";
 
 import {
+  Tabs,
+  Tab,
+  StyledDashboardSubTab,
   RescueTokensDescriptionText,
   ModalContent,
   StyledDashboardActivityDescription,
@@ -14,7 +17,12 @@ import {
 import { rescueTokensInMultiplePolls } from "../../apis/civilTCR";
 import { InjectedTransactionStatusModalProps, hasTransactionStatusModals } from "../utility/TransactionStatusModalsHOC";
 
-import { ChallengesToProcess, StyledBatchButtonContainer, getChallengesToProcess } from "./DashboardActivity";
+import {
+  ChallengesToProcess,
+  StyledBatchButtonContainer,
+  getChallengesToProcess,
+  StyledTabsComponent,
+} from "./DashboardActivity";
 import ActivityListItemRescueTokens from "./ActivityListItemRescueTokens";
 
 enum TransactionTypes {
@@ -71,24 +79,22 @@ class ChallengesWithTokensToRescue extends React.Component<
   ChallengesWithTokensToRescueProps & InjectedTransactionStatusModalProps,
   ChallengesWithTokensToRescueState
 > {
-  constructor(props: ChallengesWithTokensToRescueProps & InjectedTransactionStatusModalProps) {
-    super(props);
-    this.state = {
-      challengesToRescue: {},
-    };
-  }
+  public state = {
+    challengesToRescue: {},
+  };
 
   public componentWillMount(): void {
     this.props.setTransactions(this.getTransactions());
   }
 
   public componentWillUnmount(): void {
-    this.setState(() => ({ challengesToRescue: {} }));
+    this.resetChallengesToMultiRescue();
   }
 
   public render(): JSX.Element {
     const isRescueTokensButtonDisabled = this.isEmpty(this.state.challengesToRescue);
     const transactions = this.getTransactions();
+    const { resetChallengesToMultiRescue } = this;
 
     return (
       <>
@@ -96,32 +102,49 @@ class ChallengesWithTokensToRescue extends React.Component<
           <RescueTokensDescriptionText />
         </StyledDashboardActivityDescription>
 
-        {this.props.challenges
-          .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
-          .map((c: string) => (
-            <ActivityListItemRescueTokens key={c} challengeID={c!} toggleSelect={this.setChallengesToMultiRescue} />
-          ))}
+        <Tabs
+          TabComponent={StyledDashboardSubTab}
+          TabsNavComponent={StyledTabsComponent}
+          onActiveTabChange={resetChallengesToMultiRescue}
+        >
+          <Tab title="Listing Challenges">
+            <>
+              {this.props.challenges
+                .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
+                .map((c: string) => (
+                  <ActivityListItemRescueTokens
+                    key={c}
+                    challengeID={c!}
+                    toggleSelect={this.setChallengesToMultiRescue}
+                  />
+                ))}
 
-        {this.props.appealChallenges
-          .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
-          .map((c: string) => (
-            <ActivityListItemRescueTokens
-              key={c}
-              appealChallengeID={c!}
-              toggleSelect={this.setChallengesToMultiRescue}
-            />
-          ))}
-
-        {this.props.proposalChallenges
-          .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
-          .map((c: string) => (
-            <ActivityListItemRescueTokens
-              key={c}
-              isProposalChallenge={true}
-              challengeID={c!}
-              toggleSelect={this.setChallengesToMultiRescue}
-            />
-          ))}
+              {this.props.appealChallenges
+                .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
+                .map((c: string) => (
+                  <ActivityListItemRescueTokens
+                    key={c}
+                    appealChallengeID={c!}
+                    toggleSelect={this.setChallengesToMultiRescue}
+                  />
+                ))}
+            </>
+          </Tab>
+          <Tab title="Parameter Proposal Challenges">
+            <>
+              {this.props.proposalChallenges
+                .sort((a: string, b: string) => parseInt(a, 10) - parseInt(b, 10))
+                .map((c: string) => (
+                  <ActivityListItemRescueTokens
+                    key={c}
+                    isProposalChallenge={true}
+                    challengeID={c!}
+                    toggleSelect={this.setChallengesToMultiRescue}
+                  />
+                ))}
+            </>
+          </Tab>
+        </Tabs>
 
         <StyledBatchButtonContainer>
           <TransactionButtonNoModal
@@ -188,6 +211,10 @@ class ChallengesWithTokensToRescue extends React.Component<
         challengesToRescue: { ...newChallengesToRescue },
       }));
     }
+  };
+
+  private resetChallengesToMultiRescue = (): void => {
+    this.setState(() => ({ challengesToRescue: {} }));
   };
 
   private multiRescue = async (): Promise<TwoStepEthTransaction | void> => {

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -107,7 +107,7 @@ export interface DashboardActivityState {
   fromBalanceType: number;
 }
 
-const StyledTabsComponent = styled.div`
+export const StyledTabsComponent = styled.div`
   margin-left: 26px;
 `;
 


### PR DESCRIPTION
Issue #1094 

This update moves Param Proposal Challenges and Listing Challenges into separate sub-tabs under the Claim Rewards and Rescue tabs. 

Param Proposal and Listings can't be part of the same multi-Claim or multi-Rescue transaction, so this update is a UI solution to handle accordingly.