### PR TITLE
Fix for Test Env Starting Up with Master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,33 @@ jobs:
                     - .kubernetes_ns
                     - .kube
 
+    # Adds specific test images so we can both push specific branches via circleci, but
+    # also start up an fresh test container with the last test image in k8s
+    push-test-containers:
+        <<: *defaults
+        docker:
+            - image: civilmedia/gcloud-node:latest
+        steps:
+            - checkout
+            - attach_workspace:
+                at: /root
+            - setup_remote_docker
+            - run:
+                name: Build Container
+                command: |
+                    TAG=`echo $CIRCLE_BRANCH | sed 's/\\//_/g'`
+                    docker build -f Dockerfile-dapp . \
+                    -t gcr.io/$GOOGLE_PROJECT_ID/dapp:$TAG \
+                    -t gcr.io/$GOOGLE_PROJECT_ID/dapp:$TAG-$CIRCLE_SHA1
+                    -t gcr.io/$GOOGLE_PROJECT_ID/dapp:test
+                    -t gcr.io/$GOOGLE_PROJECT_ID/dapp:test-$CIRCLE_SHA1
+            - deploy:
+                name: Push Containers to Registry
+                command: |
+                    gcloud config list
+                    echo "pushing $GOOGLE_PROJECT_ID"
+                    docker push gcr.io/$GOOGLE_PROJECT_ID/dapp
+
     push-containers:
         <<: *defaults
         docker:
@@ -120,6 +147,7 @@ jobs:
                     gcloud config list
                     echo "pushing $GOOGLE_PROJECT_ID"
                     docker push gcr.io/$GOOGLE_PROJECT_ID/dapp
+
     deploy-test:
         <<: *defaults
         docker:
@@ -207,6 +235,14 @@ workflows:
                             - master
                             - production
                             - /test.*/
+            - push-test-containers:
+                context: gcp-common
+                requires:
+                    - setup-gcp
+                filters:
+                    branches:
+                        only:
+                            - /test.*/
             - push-containers:
                 context: gcp-common
                 requires:
@@ -216,7 +252,6 @@ workflows:
                         only:
                             - master
                             - production
-                            - /test.*/
             - deploy-test:
                 context: gcp-common
                 requires:


### PR DESCRIPTION
In our k8s config, it uses `dapp:master` as the default image to use when the dapp pod starts up.  In the event that the pod gets killed outside of our CircleCI deploy, this seems to be the reason why our test env returns to that master image. 

This creates an image based on the branch name, but also on a general `test` name.  This is so we can key off the `test` tag in k8s to ensure when those start up, they use the last `test` image.