### PR TITLE
Newsroom signup GA integration [CIVIL-477]

### DIFF
--- a/packages/dapp/src/redux/analytics.ts
+++ b/packages/dapp/src/redux/analytics.ts
@@ -2,8 +2,11 @@ import { LOCATION_CHANGE } from "connected-react-router";
 import { createMiddleware } from "redux-beacon";
 import GoogleAnalytics, { trackPageView, trackEvent } from "@redux-beacon/google-analytics";
 import { errorActions } from "./actionCreators/errors";
+import { newsroomSignupAnalyticsEvents } from "@joincivil/newsroom-signup";
 
 const eventsMap = {
+  ...newsroomSignupAnalyticsEvents,
+
   [LOCATION_CHANGE]: trackPageView((action: any) => {
     return {
       page: action.payload.location.pathname,

--- a/packages/newsroom-signup/package.json
+++ b/packages/newsroom-signup/package.json
@@ -27,10 +27,12 @@
     "react-add-to-calendar": "^0.1.5",
     "react-apollo": "^2.3.3",
     "react-select": "^2.4.2",
+    "redux-beacon": "^2.0.5",
     "sanitize-html": "^1.20.0"
   },
   "devDependencies": {
     "@joincivil/typescript-types": "^1.3.1",
+    "@redux-beacon/google-analytics": "^1.2.0",
     "@types/react-router-dom": "^4.2.5",
     "@types/react-select": "^2.0.15",
     "@types/redux-thunk": "^2.1.0",

--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -24,6 +24,8 @@ import {
   addConstitutionHash,
   addConstitutionUri,
   fetchConstitution,
+  navigateStep,
+  reachedNewStep,
 } from "./actionCreators";
 import { AuthWrapper } from "./AuthWrapper";
 import { DataWrapper } from "./DataWrapper";
@@ -257,7 +259,7 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
       this.props.dispatch!(fetchConstitution(uri));
     }
 
-    this.saveStep(this.props.savedStep); // lazy way to update `lastSeen` - can't bear to make another separate mutation
+    this.saveStep(this.props.savedStep, true); // lazy way to update `lastSeen` - can't bear to make another separate mutation
   }
 
   public async componentDidUpdate(prevProps: NewsroomProps & DispatchProp<any>): Promise<void> {
@@ -409,7 +411,14 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
     }
     this.setState({ currentStep: newStep });
   };
-  private saveStep(step: STEP): void {
+  private saveStep(step: STEP, doNotTrack?: boolean): void {
+    if (!doNotTrack) {
+      this.props.dispatch!(navigateStep(step));
+      if (step > this.state.furthestStep) {
+        this.props.dispatch!(reachedNewStep(step));
+      }
+    }
+
     const furthestStep = Math.max(step, this.state.furthestStep);
     this.setState({ furthestStep });
     this.props

--- a/packages/newsroom-signup/src/NewsroomProfile/GrantApplication.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/GrantApplication.tsx
@@ -12,7 +12,7 @@ import {
 import { urlConstants } from "@joincivil/utils";
 import styled from "styled-components";
 import { connect, DispatchProp } from "react-redux";
-import { setGrant, setSkip } from "../actionCreators";
+import { setGrant, setSkip, grantSubmitted, grantSkipped } from "../actionCreators";
 import { StateWithNewsroom } from "../reducers";
 import { WaitingAfterSkip } from "./WaitingAfterSkip";
 import { WaitingForGrant } from "./WaitingForGrant";
@@ -181,6 +181,7 @@ class GrantApplicationComponent extends React.Component<GrantApplicationProps & 
                 <BorderlessButton onClick={this.deselectGrant}>Cancel</BorderlessButton>
                 <BorderlessButton
                   onClick={async () => {
+                    this.props.dispatch!(grantSubmitted());
                     return requestGrant({
                       variables: {
                         input: true,
@@ -238,6 +239,7 @@ class GrantApplicationComponent extends React.Component<GrantApplicationProps & 
                 <BorderlessButton onClick={this.deselectSkip}>Cancel</BorderlessButton>
                 <BorderlessButton
                   onClick={async () => {
+                    this.props.dispatch!(grantSkipped());
                     return requestGrant({
                       variables: {
                         input: false,

--- a/packages/newsroom-signup/src/actionCreators.ts
+++ b/packages/newsroom-signup/src/actionCreators.ts
@@ -38,12 +38,27 @@ export enum governmentActions {
 export enum grantActions {
   SET_GRANT = "CHOOSE_GRANT",
   SET_SKIP = "CHOOSE_SKIP",
-  APPLICATION_SUBMITTED = "APPLICATION_SUBMITTED",
-  APPLICATION_SKIPPED = "APPLICATION_SKIPPED",
 }
 
 export enum listingActions {
   ADD_OR_UPDATE_LISTING = "ADD_OR_UPDATE_LISTING",
+}
+
+export enum analyticsActions {
+  NAVIGATE_STEP = "NAVIGATE_STEP",
+  REACHED_NEW_STEP = "REACHED_NEW_STEP",
+  APPLICATION_SUBMITTED = "APPLICATION_SUBMITTED",
+  APPLICATION_SKIPPED = "APPLICATION_SKIPPED",
+  TRACK_TX = "TRACK_TX",
+  PUBLISH_CHARTER = "PUBLISH_CHARTER",
+}
+
+export enum TX_TYPE {
+  CREATE_NEWSROOM = "CREATE_NEWSROOM",
+  CHANGE_NAME = "CHANGE_NAME",
+  TRANSFER_TOKENS = "TRANSFER_TOKENS",
+  APPROVE_TOKENS = "APPROVE_TOKENS",
+  APPLY_TO_TCR = "APPLY_TO_TCR",
 }
 
 export const getEditors = (address: EthAddress, civil: Civil): any => async (
@@ -337,5 +352,48 @@ export const setSkip = (value: boolean): AnyAction => {
   return {
     type: grantActions.SET_SKIP,
     data: value,
+  };
+};
+
+export const grantSubmitted = (): AnyAction => {
+  return {
+    type: analyticsActions.APPLICATION_SUBMITTED,
+  };
+};
+export const grantSkipped = (): AnyAction => {
+  return {
+    type: analyticsActions.APPLICATION_SKIPPED,
+  };
+};
+
+export const trackTx = (txType: TX_TYPE, state: "start" | "complete" | "error", txHash?: string): AnyAction => {
+  return {
+    type: analyticsActions.TRACK_TX,
+    data: {
+      txType,
+      state,
+      txHash,
+    },
+  };
+};
+
+export const publishCharter = (ipfsHash: string): AnyAction => {
+  return {
+    type: analyticsActions.PUBLISH_CHARTER,
+    data: ipfsHash,
+  };
+};
+
+export const navigateStep = (step: number, path: string = "/apply-to-registry"): AnyAction => {
+  return {
+    type: analyticsActions.NAVIGATE_STEP,
+    step,
+    path,
+  };
+};
+export const reachedNewStep = (step: number): AnyAction => {
+  return {
+    type: analyticsActions.REACHED_NEW_STEP,
+    step,
   };
 };

--- a/packages/newsroom-signup/src/analytics.ts
+++ b/packages/newsroom-signup/src/analytics.ts
@@ -1,0 +1,49 @@
+import { trackPageView, trackEvent } from "@redux-beacon/google-analytics";
+import { analyticsActions } from "./actionCreators";
+
+export const newsroomSignupAnalyticsEvents = {
+  [analyticsActions.NAVIGATE_STEP]: trackPageView((action: any) => {
+    return {
+      page: `${action.path}/${action.step}`,
+    };
+  }),
+  [analyticsActions.REACHED_NEW_STEP]: trackEvent((action: any) => {
+    return {
+      category: "Newsroom Signup",
+      action: "Reached Step",
+      value: action.step,
+    };
+  }),
+
+  [analyticsActions.APPLICATION_SUBMITTED]: trackEvent((action: any) => {
+    return {
+      category: "Newsroom Signup",
+      action: "Grant Application",
+      label: "submitted",
+    };
+  }),
+  [analyticsActions.APPLICATION_SKIPPED]: trackEvent((action: any) => {
+    return {
+      category: "Newsroom Signup",
+      action: "Grant Application",
+      label: "skipped",
+    };
+  }),
+
+  [analyticsActions.TRACK_TX]: trackEvent((action: any) => {
+    const { txType, state, txHash } = action.data;
+    return {
+      category: "Newsroom Signup",
+      action: `TX - ${txType} - ${state}`,
+      label: txHash,
+    };
+  }),
+
+  [analyticsActions.PUBLISH_CHARTER]: trackEvent((action: any) => {
+    return {
+      category: "Newsroom Signup",
+      action: "Published Charter",
+      label: action.data,
+    };
+  }),
+};

--- a/packages/newsroom-signup/src/index.ts
+++ b/packages/newsroom-signup/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./analytics";
 export * from "./Newsroom";
 export * from "./reducers";
 export * from "./actionCreators";

--- a/packages/newsroom-signup/src/reducers.ts
+++ b/packages/newsroom-signup/src/reducers.ts
@@ -142,8 +142,6 @@ export function grantApplication(
       return state.set("chooseGrant", action.data);
     case grantActions.SET_SKIP:
       return state.set("chooseSkip", action.data);
-    case grantActions.APPLICATION_SUBMITTED:
-    case grantActions.APPLICATION_SKIPPED:
     default:
       return state;
   }


### PR DESCRIPTION
This tracks step movement as pageviews, and has events for newly reaching a further step, as well as grant apply/skip and contract creation TXs.

Events and actions are set up for tracking other TXs (tokens, applying) and charter publish, but adding them all in was dragging on so I will do the rest after launch.