### PR TITLE
Update copy for IPFS progress modal

### DIFF
--- a/packages/dapp/src/components/utility/TransactionStatusModalsHOC.tsx
+++ b/packages/dapp/src/components/utility/TransactionStatusModalsHOC.tsx
@@ -160,7 +160,7 @@ export const hasTransactionStatusModals = (transactionStatusModalConfig: Transac
           <ModalStepLabel>{stepLabel}</ModalStepLabel>
           <ModalHeading>Posting to IPFS</ModalHeading>
           <ModalContentInsetContainer>
-            <ModalContent>This can take several minutes. Please don't close the tab.</ModalContent>
+            <ModalContent>This can take several moments. Please don't close the tab.</ModalContent>
             <ModalContent>
               How about taking a little breather and standing for a bit? Maybe even stretching?
             </ModalContent>


### PR DESCRIPTION
Say that the posting to IPFS will take "moments" instead of "minutes" per suggestion from @nickreynolds