### PR TITLE
Revert post token transfer modal flash fix

### DIFF
--- a/packages/newsroom-signup/src/ApplyToTCR/TransferToMultisig.tsx
+++ b/packages/newsroom-signup/src/ApplyToTCR/TransferToMultisig.tsx
@@ -175,8 +175,7 @@ const TransferToMultisig: React.SFC<
                 isTransactionProgressModalOpen: false,
                 isTransactionSuccessModalOpen: true,
               });
-              // Don't call postTransfer (which hydrates multisig balance) until user clicks ok on success modal, otherwise UI updates and this whole component is removed, resulting in flash of success modal.
-              props.setHandleTransactionSuccessButtonClick(postTransfer);
+              postTransfer();
             },
           },
         ];


### PR DESCRIPTION
Seemed like a good idea but it's buggy so reverting it - better a flash of a success modal than missing the multisig balance rehydration.