### PR TITLE
Updates to UI and copy to improve the DApp's Voting experience

### DIFF
--- a/packages/components/src/Account/Auth/__snapshots__/EmailAuth.stories.storyshot
+++ b/packages/components/src/Account/Auth/__snapshots__/EmailAuth.stories.storyshot
@@ -27,10 +27,10 @@ exports[`Storyshots Common / Auth / Email Signup Flow AccountEmailAuth 1`] = `
         />
       </div>
       <ul
-        className="sc-iKiVwC idmrno"
+        className="sc-emjYpo bOkvvA"
       >
         <li
-          className="sc-guDjWT hORSLC"
+          className="sc-iKiVwC eBBOOl"
         >
           <label>
             <label
@@ -48,7 +48,7 @@ exports[`Storyshots Common / Auth / Email Signup Flow AccountEmailAuth 1`] = `
               />
             </label>
             <span
-              className="sc-kqEXUp kyKUlV"
+              className="sc-guDjWT itveHH"
             >
               I agree to Civil's 
               <a
@@ -61,7 +61,7 @@ exports[`Storyshots Common / Auth / Email Signup Flow AccountEmailAuth 1`] = `
           </label>
         </li>
         <li
-          className="sc-guDjWT hORSLC"
+          className="sc-iKiVwC eBBOOl"
         >
           <label>
             <label
@@ -79,7 +79,7 @@ exports[`Storyshots Common / Auth / Email Signup Flow AccountEmailAuth 1`] = `
               />
             </label>
             <span
-              className="sc-kqEXUp kyKUlV"
+              className="sc-guDjWT itveHH"
             >
               Get notified of news and announcements from Civil.
             </span>
@@ -87,7 +87,7 @@ exports[`Storyshots Common / Auth / Email Signup Flow AccountEmailAuth 1`] = `
         </li>
       </ul>
       <div
-        className="sc-gxbSSY flWTKs"
+        className="sc-kqEXUp gxNTfD"
       >
         <button
           className="sc-kEYyzF jJDVkO sc-hMqMXs gLVzHd disabled"

--- a/packages/components/src/Account/Auth/__snapshots__/EthAuth.stories.storyshot
+++ b/packages/components/src/Account/Auth/__snapshots__/EthAuth.stories.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots Common / Auth / ETH AccountEthAuth 1`] = `
       </span>
       
       <button
-        className="sc-imAxmJ kUWOcX sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
+        className="sc-hqGPoI lcInRT sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
         onClick={[Function]}
         size="MEDIUM_WIDE"
         theme={
@@ -45,7 +45,7 @@ exports[`Storyshots Common / Auth / ETH AccountEthAuth 1`] = `
         type="button"
       >
         <div
-          className="sc-iWadT bfJcev"
+          className="sc-imAxmJ fdWCTr"
         >
           <img
             className="sc-cmTdod kcwOOi"

--- a/packages/components/src/Account/Auth/__snapshots__/VerifyToken.stories.storyshot
+++ b/packages/components/src/Account/Auth/__snapshots__/VerifyToken.stories.storyshot
@@ -30,7 +30,7 @@ exports[`Storyshots Common / Auth / VerifyToken Complete 1`] = `
     >
       <div>
         <div
-          className="sc-hhaNoI gVofaA sc-bXopBW cPPbdy"
+          className="sc-bXopBW gjhUTm sc-gxbSSY kuPlli"
         />
       </div>
     </div>
@@ -707,7 +707,7 @@ exports[`Storyshots Common / Auth / VerifyToken Loading 1`] = `
     >
       <div>
         <div
-          className="sc-hhaNoI gVofaA sc-bXopBW cPPbdy"
+          className="sc-bXopBW gjhUTm sc-gxbSSY kuPlli"
         />
       </div>
     </div>

--- a/packages/components/src/BrowserCompatible/__snapshots__/BrowserCompatible.stories.storyshot
+++ b/packages/components/src/BrowserCompatible/__snapshots__/BrowserCompatible.stories.storyshot
@@ -11,28 +11,28 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
     }
   >
     <div
-      className="sc-geAPOV gZZGjK"
+      className="sc-DNdyV gDuQJl"
     >
       <h2
-        className="sc-dKEPtC ifgmSc"
+        className="sc-isBZXS fyOESt"
       >
         Can we switch to a different browser?
       </h2>
       <p
-        className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+        className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
       >
         Civil Registry applications and token purchases currently only work in browsers with Ethereum wallet support, like desktop Chrome and Firefox. We’re working to support other browsers.
       </p>
       <p
-        className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+        className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
       >
         In the meantime, please…
       </p>
       <div
-        className="sc-PLyBE cwLzMt"
+        className="sc-bJTOcE ekgNfA"
       >
         <a
-          className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+          className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
           href="https://www.google.com/chrome/"
           size="MEDIUM_WIDE"
           target="_blank"
@@ -44,7 +44,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
           }
         >
           <img
-            className="sc-bJTOcE bzlFKu"
+            className="sc-geAPOV SnXGd"
             src={
               Object {
                 "0": "t",
@@ -68,7 +68,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
           Get Google Chrome
         </a>
         <a
-          className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+          className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
           href="https://www.mozilla.org/en-US/firefox/"
           size="MEDIUM_WIDE"
           target="_blank"
@@ -80,7 +80,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
           }
         >
           <img
-            className="sc-bJTOcE bzlFKu"
+            className="sc-geAPOV SnXGd"
             src={
               Object {
                 "0": "t",
@@ -105,16 +105,16 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
         </a>
       </div>
       <p
-        className="sc-jHXLhC QTGuD sc-dwztqd dyoYrM"
+        className="sc-fgrSAo bwDbMg sc-dvpmds hbXpB"
       >
         <a
-          className="sc-kkwfeq gHvceh"
+          className="sc-dPNhBE eQSTEy"
           href="mailto:support@civil.co"
         >
           Contact Us
         </a>
         <a
-          className="sc-kkwfeq gHvceh"
+          className="sc-dPNhBE eQSTEy"
           href="https://help.civil.co/hc/en-us/articles/360022147571-Browser-Support"
           target="_blank"
         >

--- a/packages/components/src/ChallengeResultsChart/__snapshots__/ChallengeResults.stories.storyshot
+++ b/packages/components/src/ChallengeResultsChart/__snapshots__/ChallengeResults.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry Challenge Results Chart 1`] = `
     }
   >
     <div
-      className="sc-eIvgmF jQKEzm"
+      className="sc-rzOft cbHEYG"
     >
       <div>
         <h4

--- a/packages/components/src/CurrencyConverter/__snapshots__/CurrencyConverter.stories.storyshot
+++ b/packages/components/src/CurrencyConverter/__snapshots__/CurrencyConverter.stories.storyshot
@@ -11,24 +11,24 @@ exports[`Storyshots Common / Currency / Currency Converter CVL to ETH 1`] = `
     }
   >
     <div
-      className="sc-izfUZz ggeqfF"
+      className="sc-jklikK bEMYaB"
     >
       <div>
         (exchange rate is 2x)
       </div>
       <div
-        className="sc-dYcyhn djGZFM"
+        className="sc-fdJbru iUZNGS"
       >
         <div
-          className="sc-cIbcTr ggLpvL"
+          className="sc-dYcyhn iGfeZl"
         >
           <div
-            className="sc-hmyDHa eASlKJ"
+            className="sc-cIbcTr jlLDzO"
           >
             Enter CVL Amount
           </div>
           <div
-            className="sc-jTNJqp kdeLPN"
+            className="sc-hmyDHa bEMMca"
           >
             <div
               className="sc-iRbamj dUGcDR"
@@ -56,7 +56,7 @@ exports[`Storyshots Common / Currency / Currency Converter CVL to ETH 1`] = `
           </div>
         </div>
         <div
-          className="sc-bQduHL brTibK"
+          className="sc-MKjYC gpaETM"
         >
           <svg
             height="14"
@@ -82,19 +82,19 @@ exports[`Storyshots Common / Currency / Currency Converter CVL to ETH 1`] = `
           </svg>
         </div>
         <div
-          className="sc-cIbcTr ggLpvL"
+          className="sc-dYcyhn iGfeZl"
         >
           <div
-            className="sc-hmyDHa eASlKJ"
+            className="sc-cIbcTr jlLDzO"
           >
             Converted ETH
           </div>
           <div
-            className="sc-fAfrNB iFqpEH"
+            className="sc-jTNJqp gaRALl"
           >
             0
             <div
-              className="sc-MKjYC cDAqSd"
+              className="sc-fAfrNB pRSml"
             >
               ETH
             </div>
@@ -731,24 +731,24 @@ exports[`Storyshots Common / Currency / Currency Converter USD to ETH 1`] = `
     }
   >
     <div
-      className="sc-izfUZz ggeqfF"
+      className="sc-jklikK bEMYaB"
     >
       <div>
         (exchange rate is 0.5x)
       </div>
       <div
-        className="sc-dYcyhn djGZFM"
+        className="sc-fdJbru iUZNGS"
       >
         <div
-          className="sc-cIbcTr ggLpvL"
+          className="sc-dYcyhn iGfeZl"
         >
           <div
-            className="sc-hmyDHa eASlKJ"
+            className="sc-cIbcTr jlLDzO"
           >
             Enter USD Amount
           </div>
           <div
-            className="sc-jTNJqp kdeLPN"
+            className="sc-hmyDHa bEMMca"
           >
             <div
               className="sc-iRbamj dUGcDR"
@@ -776,7 +776,7 @@ exports[`Storyshots Common / Currency / Currency Converter USD to ETH 1`] = `
           </div>
         </div>
         <div
-          className="sc-bQduHL brTibK"
+          className="sc-MKjYC gpaETM"
         >
           <svg
             height="14"
@@ -802,19 +802,19 @@ exports[`Storyshots Common / Currency / Currency Converter USD to ETH 1`] = `
           </svg>
         </div>
         <div
-          className="sc-cIbcTr ggLpvL"
+          className="sc-dYcyhn iGfeZl"
         >
           <div
-            className="sc-hmyDHa eASlKJ"
+            className="sc-cIbcTr jlLDzO"
           >
             Converted ETH
           </div>
           <div
-            className="sc-fAfrNB iFqpEH"
+            className="sc-jTNJqp gaRALl"
           >
             0
             <div
-              className="sc-MKjYC cDAqSd"
+              className="sc-fAfrNB pRSml"
             >
               ETH
             </div>

--- a/packages/components/src/EmailSignup/__snapshots__/EmailSignup.stories.storyshot
+++ b/packages/components/src/EmailSignup/__snapshots__/EmailSignup.stories.storyshot
@@ -11,13 +11,13 @@ exports[`Storyshots Registry / Mailing List Signup Component Mailing List Signup
     }
   >
     <div
-      className="sc-kUQWMX HLNkz"
+      className="sc-eqGige jBAsba"
     >
       <div
-        className="sc-fHlXLc cmCbum"
+        className="sc-idjmjb edbFgZ"
       >
         <div
-          className="sc-evWYkj gXgENv"
+          className="sc-exdmVY ldoUDW"
         >
           <svg
             height="24"
@@ -39,7 +39,7 @@ exports[`Storyshots Registry / Mailing List Signup Component Mailing List Signup
            Get the Civil Registry Alerts
         </div>
         <p
-          className="sc-idjmjb kwASjp"
+          className="sc-evWYkj IkJOW"
         >
           Receive real-time email alerts when a new event occurs on the Civil Registry. These events include new applications, challenges, when voting begins / ends and more. By subscribing, you'll ensure you have maximum time to make decisions about how you will participate in Civil's governance.
         </p>
@@ -90,7 +90,7 @@ exports[`Storyshots Registry / Mailing List Signup Component Mailing List Signup
           </div>
         </div>
         <p
-          className="sc-idjmjb kwASjp"
+          className="sc-evWYkj IkJOW"
         >
           <b>
             Follow us on twitter for alerts
@@ -472,10 +472,10 @@ exports[`Storyshots Registry / Mailing List Signup Component Mailing List Signup
     }
   >
     <div
-      className="sc-kUQWMX HLNkz"
+      className="sc-eqGige jBAsba"
     >
       <div
-        className="sc-iKpIOp kvABdQ sc-fHlXLc cmCbum"
+        className="sc-fHlXLc jJzHNn sc-idjmjb edbFgZ"
       >
         <svg
           height="36"
@@ -497,17 +497,17 @@ exports[`Storyshots Registry / Mailing List Signup Component Mailing List Signup
           />
         </svg>
         <div
-          className="sc-evWYkj gXgENv"
+          className="sc-exdmVY ldoUDW"
         >
           Thanks for signing up!
         </div>
         <p
-          className="sc-idjmjb kwASjp"
+          className="sc-evWYkj IkJOW"
         >
           Please check your email to confirm your subscription.
         </p>
         <p
-          className="sc-idjmjb kwASjp"
+          className="sc-evWYkj IkJOW"
         >
           <b>
             Follow us on twitter for alerts

--- a/packages/components/src/EthAddressViewer/__snapshots__/EthAddressViewer.stories.storyshot
+++ b/packages/components/src/EthAddressViewer/__snapshots__/EthAddressViewer.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Common / Ethereum / EthAddress Viewer EthAddress Viewer 1`] 
     }
   >
     <div
-      className="sc-bCQtTp juLMaA"
+      className="sc-kUQWMX cdjjjS"
     >
       <div
         className="sc-eTpRJs hVCsQg"

--- a/packages/components/src/ListingDetailHeader/__snapshots__/ListingDetailHeader.stories.storyshot
+++ b/packages/components/src/ListingDetailHeader/__snapshots__/ListingDetailHeader.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header Accepting Votes 
     }
   >
     <div
-      className="sc-fepxGN gYvIj"
+      className="sc-dcmekm jerUfL"
     >
       <div>
         <div
@@ -741,7 +741,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header In Application 1
     }
   >
     <div
-      className="sc-fepxGN gYvIj"
+      className="sc-dcmekm jerUfL"
     >
       <div>
         <div
@@ -1471,7 +1471,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header No phase label 1
     }
   >
     <div
-      className="sc-fepxGN gYvIj"
+      className="sc-dcmekm jerUfL"
     >
       <div>
         <div
@@ -2214,7 +2214,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header Revealing Votes 
     }
   >
     <div
-      className="sc-fepxGN gYvIj"
+      className="sc-dcmekm jerUfL"
     >
       <div>
         <div

--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeRevealVoteCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeRevealVoteCard.tsx
@@ -152,7 +152,7 @@ export class AppealChallengeRevealVoteCard extends React.Component<
   }
 
   private renderRevealVote = (): JSX.Element => {
-    if (!this.props.userHasCommittedVote) {
+    if (this.props.userHasCommittedVote === false) {
       return (
         <>
           <FormHeader>

--- a/packages/components/src/ListingDetailPhaseCard/ChallengeRevealVoteCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/ChallengeRevealVoteCard.tsx
@@ -132,7 +132,7 @@ export class ChallengeRevealVoteCard extends React.Component<
   }
 
   private renderRevealVote = (): JSX.Element => {
-    if (!this.props.userHasCommittedVote) {
+    if (this.props.userHasCommittedVote === false) {
       return (
         <>
           <FormHeader>

--- a/packages/components/src/ListingDetailPhaseCard/__snapshots__/ListingDetailsPhaseCard.stories.storyshot
+++ b/packages/components/src/ListingDetailPhaseCard/__snapshots__/ListingDetailsPhaseCard.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Appeal Chall
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -552,7 +552,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Appeal Chall
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -1093,7 +1093,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Appeal Chall
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -1634,7 +1634,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Appeal Chall
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -2175,7 +2175,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Appeal Chall
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -2716,7 +2716,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card In Applicati
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -3257,7 +3257,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Rejected 1`]
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -3798,7 +3798,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Resolve Appl
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -4339,7 +4339,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Appeal
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -4880,7 +4880,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Appeal
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -5421,7 +5421,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Appeal
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -5962,7 +5962,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Appeal
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -6503,7 +6503,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Challe
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -7044,7 +7044,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Challe
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -7585,7 +7585,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Challe
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -8126,7 +8126,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Challe
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -8667,7 +8667,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Challe
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -9208,7 +9208,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Under Challe
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>
@@ -9749,7 +9749,7 @@ exports[`Storyshots Registry / Listing / Listing Details Phase Card Whitelisted 
     }
   >
     <div
-      className="sc-bAtgIc dREebz"
+      className="sc-fepxGN cpLbsI"
     >
       <div />
     </div>

--- a/packages/components/src/ListingHistoryEvent/__snapshots__/ListingHistoryEvent.stories.storyshot
+++ b/packages/components/src/ListingHistoryEvent/__snapshots__/ListingHistoryEvent.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Listing / Listing History Event Default 1`] = `
     }
   >
     <div
-      className="sc-csuNZv dyIPFJ"
+      className="sc-bAtgIc kUVYoI"
     />
   </div>
   <button
@@ -550,7 +550,7 @@ exports[`Storyshots Registry / Listing / Listing History Event History Events Ti
     }
   >
     <div
-      className="sc-csuNZv dyIPFJ"
+      className="sc-bAtgIc kUVYoI"
     />
   </div>
   <button

--- a/packages/components/src/ListingSummary/__snapshots__/ListingSummary.stories.storyshot
+++ b/packages/components/src/ListingSummary/__snapshots__/ListingSummary.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card 1`] = `
     }
   >
     <div
-      className="sc-eghKGU deGcap"
+      className="sc-csuNZv gDmtEI"
     >
       <div>
         <div
@@ -25,7 +25,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card 1`] = `
               className="sc-bAeIUo kscUCY"
             >
               <div
-                className="sc-iujRgT cfFiAO"
+                className="sc-iujRgT QtQUy"
               >
                 <figure
                   className="sc-fYiAbW kBrJxG"
@@ -603,7 +603,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
     }
   >
     <div
-      className="sc-eghKGU deGcap"
+      className="sc-csuNZv gDmtEI"
     >
       <div>
         <div
@@ -621,7 +621,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
                   className="sc-bAeIUo kscUCY"
                 >
                   <div
-                    className="sc-iujRgT cfFiAO"
+                    className="sc-iujRgT QtQUy"
                   >
                     <figure
                       className="sc-fYiAbW kBrJxG"
@@ -673,7 +673,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
                   className="sc-bAeIUo kscUCY"
                 >
                   <div
-                    className="sc-iujRgT cfFiAO"
+                    className="sc-iujRgT QtQUy"
                   >
                     <figure
                       className="sc-fYiAbW kBrJxG"
@@ -725,7 +725,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
                   className="sc-bAeIUo kscUCY"
                 >
                   <div
-                    className="sc-iujRgT cfFiAO"
+                    className="sc-iujRgT QtQUy"
                   >
                     <figure
                       className="sc-fYiAbW kBrJxG"
@@ -777,7 +777,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
                   className="sc-bAeIUo kscUCY"
                 >
                   <div
-                    className="sc-iujRgT cfFiAO"
+                    className="sc-iujRgT QtQUy"
                   >
                     <figure
                       className="sc-fYiAbW kBrJxG"
@@ -829,7 +829,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
                   className="sc-bAeIUo kscUCY"
                 >
                   <div
-                    className="sc-iujRgT cfFiAO"
+                    className="sc-iujRgT QtQUy"
                   >
                     <figure
                       className="sc-fYiAbW kBrJxG"
@@ -881,7 +881,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
                   className="sc-bAeIUo kscUCY"
                 >
                   <div
-                    className="sc-iujRgT cfFiAO"
+                    className="sc-iujRgT QtQUy"
                   >
                     <figure
                       className="sc-fYiAbW kBrJxG"
@@ -1461,7 +1461,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Rejected 1`] = `
     }
   >
     <div
-      className="sc-eghKGU deGcap"
+      className="sc-csuNZv gDmtEI"
     >
       <div />
     </div>

--- a/packages/components/src/ListingSummary/styledComponents.tsx
+++ b/packages/components/src/ListingSummary/styledComponents.tsx
@@ -60,7 +60,7 @@ export const StyledListingSummary: StyledComponentClass<StyledListingSummaryProp
 export const StyledListingSummaryTop = styled.div`
   border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
   display: flex;
-  height: 140px;
+  height: 190px;
   padding: 0 22px 25px;
 `;
 

--- a/packages/components/src/NavBar/UserAccount.tsx
+++ b/packages/components/src/NavBar/UserAccount.tsx
@@ -75,7 +75,7 @@ const UserAccount: React.FunctionComponent<NavUserAccountProps> = props => {
         } else if (civilUser && enableEthereum && !userEthAddress) {
           return (
             <LogInButton onClick={props.enableEthereum} size={buttonSizes.SMALL}>
-              Enable Ethereum
+              Connect Wallet
             </LogInButton>
           );
         }

--- a/packages/components/src/Notice/__snapshots__/Notice.stories.storyshot
+++ b/packages/components/src/Notice/__snapshots__/Notice.stories.storyshot
@@ -1339,7 +1339,7 @@ exports[`Storyshots Pattern Library / Notices Notice - All types 1`] = `
     }
   >
     <div
-      className="sc-jIyBzM cPRQbh"
+      className="sc-cxZfpC gVRxEI"
     >
       <div
         className="sc-kDhYZr jdTuch"

--- a/packages/components/src/Parameterizer/ChallengeProposalReviewVote.tsx
+++ b/packages/components/src/Parameterizer/ChallengeProposalReviewVote.tsx
@@ -55,8 +55,6 @@ export interface ChallengeProposalReviewVoteProps extends FullScreenModalProps {
   revealEndDate: number;
   transactions: any[];
   modalContentComponents?: any;
-  gasFaqURL: string;
-  votingContractFaqURL: string;
   handleClose(): void;
   postExecuteTransactions?(): void;
 }
@@ -138,7 +136,6 @@ export class ChallengeProposalReviewVote extends React.Component<ChallengePropos
   public render(): JSX.Element {
     const {
       open,
-      votingContractFaqURL,
       challengeID,
       salt,
       commitEndDate,
@@ -150,7 +147,6 @@ export class ChallengeProposalReviewVote extends React.Component<ChallengePropos
       transactions,
       postExecuteTransactions,
       handleClose,
-      gasFaqURL,
     } = this.props;
 
     const { didSaveSalt } = this.state;
@@ -163,7 +159,7 @@ export class ChallengeProposalReviewVote extends React.Component<ChallengePropos
               <ReviewVoteHeaderTitleText />
             </StyledReviewVoteHeaderTitle>
             <StyledReviewVoteContentCopy>
-              <ReviewVoteCopyText handlePrintClick={printThis} votingContractFaqURL={votingContractFaqURL} />
+              <ReviewVoteCopyText handlePrintClick={printThis} />
             </StyledReviewVoteContentCopy>
 
             <StyledReviewVoteContent>
@@ -245,7 +241,7 @@ export class ChallengeProposalReviewVote extends React.Component<ChallengePropos
               </StyledButtonContainer>
 
               <StyledTransactionFinePrint>
-                <TransactionFinePrintText gasFaqURL={gasFaqURL} />
+                <TransactionFinePrintText />
               </StyledTransactionFinePrint>
             </StyledReviewVoteContent>
           </ModalContent>

--- a/packages/components/src/Parameterizer/__snapshots__/Parameterizer.stories.storyshot
+++ b/packages/components/src/Parameterizer/__snapshots__/Parameterizer.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Parameterizer Create Proposal 1`] = `
     }
   >
     <div
-      className="sc-fVHxE cHegkS"
+      className="sc-jIyBzM jYQqbs"
     >
       <div />
     </div>

--- a/packages/components/src/PhaseCountdown/__snapshots__/PhaseCountdown.stories.storyshot
+++ b/packages/components/src/PhaseCountdown/__snapshots__/PhaseCountdown.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Application Phase Countdown Timer Progress Bar Ti
     }
   >
     <div
-      className="sc-jvjHmY cKaBKb"
+      className="sc-fVHxE gktAXX"
     />
   </div>
   <button
@@ -259,7 +259,7 @@ exports[`Storyshots Registry / Application Phase Countdown Timer Text Timers 1`]
     }
   >
     <div
-      className="sc-jvjHmY cKaBKb"
+      className="sc-fVHxE gktAXX"
     />
   </div>
   <button
@@ -507,7 +507,7 @@ exports[`Storyshots Registry / Application Phase Countdown Timer Two Phase Progr
     }
   >
     <div
-      className="sc-jvjHmY cKaBKb"
+      className="sc-fVHxE gktAXX"
     />
   </div>
   <button

--- a/packages/components/src/ReviewVote/ReviewVote.stories.tsx
+++ b/packages/components/src/ReviewVote/ReviewVote.stories.tsx
@@ -30,8 +30,6 @@ storiesOf("Registry / Review Vote", module).add("Review Vote Modal", () => {
     commitEndDate: 1533916728,
     revealEndDate: 1533917128,
     transactions: [],
-    votingContractFaqURL: "#voting-contract-faq",
-    gasFaqURL: "#gas-faq",
     handleClose,
   };
 

--- a/packages/components/src/ReviewVote/ReviewVote.stories.tsx
+++ b/packages/components/src/ReviewVote/ReviewVote.stories.tsx
@@ -30,6 +30,8 @@ storiesOf("Registry / Review Vote", module).add("Review Vote Modal", () => {
     commitEndDate: 1533916728,
     revealEndDate: 1533917128,
     transactions: [],
+    votingContractFaqURL: "#voting-contract-faq",
+    gasFaqURL: "#gas-faq",
     handleClose,
   };
 

--- a/packages/components/src/ReviewVote/ReviewVoteModal.tsx
+++ b/packages/components/src/ReviewVote/ReviewVoteModal.tsx
@@ -58,8 +58,6 @@ export interface ReviewVoteProps extends FullScreenModalProps {
   revealEndDate: number;
   transactions: any[];
   modalContentComponents?: any;
-  gasFaqURL: string;
-  votingContractFaqURL: string;
   handleClose(): void;
   postExecuteTransactions?(): void;
 }
@@ -141,7 +139,6 @@ export class ReviewVote extends React.Component<ReviewVoteProps, ReviewVoteState
   public render(): JSX.Element {
     const {
       open,
-      votingContractFaqURL,
       challengeID,
       salt,
       commitEndDate,
@@ -154,7 +151,6 @@ export class ReviewVote extends React.Component<ReviewVoteProps, ReviewVoteState
       transactions,
       postExecuteTransactions,
       handleClose,
-      gasFaqURL,
     } = this.props;
 
     const { didSaveSalt } = this.state;
@@ -167,7 +163,7 @@ export class ReviewVote extends React.Component<ReviewVoteProps, ReviewVoteState
               <ReviewVoteHeaderTitleText />
             </StyledReviewVoteHeaderTitle>
             <StyledReviewVoteContentCopy>
-              <ReviewVoteCopyText handlePrintClick={printThis} votingContractFaqURL={votingContractFaqURL} />
+              <ReviewVoteCopyText handlePrintClick={printThis} />
             </StyledReviewVoteContentCopy>
 
             <StyledReviewVoteContent>
@@ -252,7 +248,7 @@ export class ReviewVote extends React.Component<ReviewVoteProps, ReviewVoteState
               </StyledButtonContainer>
 
               <StyledTransactionFinePrint>
-                <TransactionFinePrintText gasFaqURL={gasFaqURL} />
+                <TransactionFinePrintText />
               </StyledTransactionFinePrint>
             </StyledReviewVoteContent>
           </ModalContent>

--- a/packages/components/src/ReviewVote/ReviewVoteModal.tsx
+++ b/packages/components/src/ReviewVote/ReviewVoteModal.tsx
@@ -3,49 +3,46 @@ import AddToCalendar from "react-add-to-calendar";
 import { EthAddress } from "@joincivil/core";
 import { saltToWords, getFormattedEthAddress, getLocalDateTimeStrings, padString } from "@joincivil/utils";
 import { FullScreenModal, FullScreenModalProps } from "../FullscreenModal";
-import { buttonSizes, InvertedButton } from "../Button";
+import { buttonSizes, CancelButton } from "../Button";
 import { TransactionButtonNoModal } from "../TransactionButton";
 import { QuestionToolTip } from "../QuestionToolTip";
+import { Checkbox, CheckboxSizes } from "../input/Checkbox";
+import { MetaMaskLogoButton } from "../";
 import {
   ReviewVoteHeaderTitleText,
-  ReviewVoteHeaderCopyText,
   ReviewVoteCopyText,
   SaltLabelText,
   ReviewVoteDecisionText,
   AppealChallengeReviewVoteDecisionText,
   ReviewVoteDepositedCVLLabelText,
   ReviewVoteMyAddressLabelText,
-  ConfirmVotesHeaderText,
-  ConfirmVotesSaveSaltCopyText,
-  WriteItDownText,
-  TakeAScreenShotText,
-  PrintThisText,
-  EmailYourselfText,
+  ConfirmVotesLabelText,
   TransactionButtonText,
   SaltPhraseToolTipText,
+  TransactionFinePrintText,
+  SaveSaltCheckboxLabelText,
 } from "./textComponents";
 import {
   ModalOuter,
   ModalContent,
-  StyledReviewVoteHeader,
   StyledReviewVoteHeaderTitle,
-  StyledReviewVoteHeaderCopy,
   StyledReviewVoteContent,
   StyledReviewVoteContentCopy,
-  StyledReviewVoteContentGrid,
   StyledReviewVoteDetails,
-  StyledReviewVoteDates,
   MetaRow,
+  MetaRowSalt,
   MetaItemLabel,
   MetaItemLabelSalt,
   MetaItemValue,
   MetaItemValueUser,
   MetaItemValueSalt,
-  StyledReviewVoteDatesHeader,
-  StyledReviewVoteDatesRange,
+  MetaItemValueTwoCol,
+  StyledAddToCalendarContainer,
+  StyledConfirmVoteDateRange,
   StyledAddToCalendar,
-  StyledDateAction,
   StyledButtonContainer,
+  StyledTransactionFinePrint,
+  StyledDidSaveSaltContainer,
 } from "./styledComponents";
 
 export interface ReviewVoteProps extends FullScreenModalProps {
@@ -61,8 +58,14 @@ export interface ReviewVoteProps extends FullScreenModalProps {
   revealEndDate: number;
   transactions: any[];
   modalContentComponents?: any;
+  gasFaqURL: string;
+  votingContractFaqURL: string;
   handleClose(): void;
   postExecuteTransactions?(): void;
+}
+
+interface ReviewVoteState {
+  didSaveSalt: boolean;
 }
 
 function printThis(): void {
@@ -130,116 +133,135 @@ const AddRevealPhaseToCalendar: React.FunctionComponent<ReviewVoteProps> = props
   );
 };
 
-export const ReviewVote: React.FunctionComponent<ReviewVoteProps> = props => {
-  return (
-    <FullScreenModal open={props.open || false}>
-      <ModalOuter>
-        <ModalContent>
-          <StyledReviewVoteHeader>
+export class ReviewVote extends React.Component<ReviewVoteProps, ReviewVoteState> {
+  public state = {
+    didSaveSalt: false,
+  };
+
+  public render(): JSX.Element {
+    const {
+      open,
+      votingContractFaqURL,
+      challengeID,
+      salt,
+      commitEndDate,
+      revealEndDate,
+      isAppealChallenge,
+      voteOption,
+      newsroomName,
+      numTokens,
+      userAccount,
+      transactions,
+      postExecuteTransactions,
+      handleClose,
+      gasFaqURL,
+    } = this.props;
+
+    const { didSaveSalt } = this.state;
+
+    return (
+      <FullScreenModal open={open || false}>
+        <ModalOuter>
+          <ModalContent>
             <StyledReviewVoteHeaderTitle>
               <ReviewVoteHeaderTitleText />
             </StyledReviewVoteHeaderTitle>
-            <StyledReviewVoteHeaderCopy>
-              <ReviewVoteHeaderCopyText />
-            </StyledReviewVoteHeaderCopy>
-          </StyledReviewVoteHeader>
-
-          <StyledReviewVoteContent>
             <StyledReviewVoteContentCopy>
-              <ReviewVoteCopyText />
+              <ReviewVoteCopyText handlePrintClick={printThis} votingContractFaqURL={votingContractFaqURL} />
             </StyledReviewVoteContentCopy>
 
-            <StyledReviewVoteContentGrid>
-              <StyledReviewVoteDetails>
-                <MetaRow>
-                  <MetaItemLabelSalt>
-                    <SaltLabelText />
-                    <QuestionToolTip explainerText={<SaltPhraseToolTipText />} positionBottom={true} />
-                  </MetaItemLabelSalt>
+            <StyledReviewVoteContent>
+              <div>
+                <StyledReviewVoteDetails>
+                  <MetaRowSalt>
+                    <MetaItemLabelSalt>
+                      <SaltLabelText challengeID={challengeID} />
+                      <QuestionToolTip explainerText={<SaltPhraseToolTipText />} positionBottom={true} />
+                    </MetaItemLabelSalt>
 
-                  <MetaItemValueSalt>{getSaltyWords(props.salt)}</MetaItemValueSalt>
-                </MetaRow>
-                <MetaRow>
-                  <MetaItemLabel>Challenge ID {props.challengeID}</MetaItemLabel>
+                    <MetaItemValueSalt>{getSaltyWords(salt)}</MetaItemValueSalt>
+                  </MetaRowSalt>
 
-                  <MetaItemValue>
-                    {props.isAppealChallenge ? (
-                      <AppealChallengeReviewVoteDecisionText
-                        voteOption={props.voteOption}
-                        newsroomName={props.newsroomName}
-                      />
-                    ) : (
-                      <ReviewVoteDecisionText voteOption={props.voteOption} newsroomName={props.newsroomName} />
-                    )}
-                  </MetaItemValue>
-                </MetaRow>
-                <MetaRow>
-                  <MetaItemLabel>
-                    <ReviewVoteDepositedCVLLabelText />
-                  </MetaItemLabel>
+                  <MetaRow>
+                    <MetaItemLabel>
+                      <ConfirmVotesLabelText />
+                    </MetaItemLabel>
 
-                  <MetaItemValue>{props.numTokens}</MetaItemValue>
-                </MetaRow>
+                    <MetaItemValueTwoCol>
+                      <StyledConfirmVoteDateRange>
+                        {getReadableRevealDateRange(commitEndDate, revealEndDate)}
+                      </StyledConfirmVoteDateRange>
 
-                <MetaRow>
-                  <MetaItemLabel>
-                    <ReviewVoteMyAddressLabelText />
-                  </MetaItemLabel>
+                      <StyledAddToCalendarContainer>
+                        <AddRevealPhaseToCalendar {...this.props} />
+                        <p>Remember to set event to Private</p>
+                      </StyledAddToCalendarContainer>
+                    </MetaItemValueTwoCol>
+                  </MetaRow>
 
-                  <MetaItemValueUser>
-                    {props.userAccount && getFormattedEthAddress(props.userAccount)}
-                  </MetaItemValueUser>
-                </MetaRow>
-              </StyledReviewVoteDetails>
+                  <MetaRow>
+                    <MetaItemLabel>Challenge ID {challengeID}</MetaItemLabel>
 
-              <StyledReviewVoteDates>
-                <StyledReviewVoteDatesHeader>
-                  <ConfirmVotesHeaderText />
-                </StyledReviewVoteDatesHeader>
+                    <MetaItemValue>
+                      {isAppealChallenge ? (
+                        <AppealChallengeReviewVoteDecisionText voteOption={voteOption} newsroomName={newsroomName} />
+                      ) : (
+                        <ReviewVoteDecisionText voteOption={voteOption} newsroomName={newsroomName} />
+                      )}
+                    </MetaItemValue>
+                  </MetaRow>
+                  <MetaRow>
+                    <MetaItemLabel>
+                      <ReviewVoteDepositedCVLLabelText />
+                    </MetaItemLabel>
 
-                <StyledReviewVoteDatesRange>
-                  {getReadableRevealDateRange(props.commitEndDate, props.revealEndDate)}
-                </StyledReviewVoteDatesRange>
+                    <MetaItemValue>{numTokens}</MetaItemValue>
+                  </MetaRow>
 
-                <AddRevealPhaseToCalendar {...props} />
+                  <MetaRow>
+                    <MetaItemLabel>
+                      <ReviewVoteMyAddressLabelText />
+                    </MetaItemLabel>
 
-                <p>
-                  <ConfirmVotesSaveSaltCopyText />
-                </p>
+                    <MetaItemValueUser>{userAccount && getFormattedEthAddress(userAccount)}</MetaItemValueUser>
+                  </MetaRow>
+                </StyledReviewVoteDetails>
+              </div>
 
-                <ol>
-                  <li>
-                    <WriteItDownText />
-                  </li>
-                  <li>
-                    <TakeAScreenShotText />
-                  </li>
-                  <li onClick={printThis}>
-                    <StyledDateAction>
-                      <PrintThisText />
-                    </StyledDateAction>
-                  </li>
-                  <li>
-                    <EmailYourselfText />
-                  </li>
-                </ol>
-              </StyledReviewVoteDates>
-            </StyledReviewVoteContentGrid>
+              <StyledDidSaveSaltContainer>
+                <div>
+                  <Checkbox size={CheckboxSizes.SMALL} checked={didSaveSalt} onClick={this.toggleHasSavedSalt} />
+                </div>
+                <div>
+                  <SaveSaltCheckboxLabelText />
+                </div>
+              </StyledDidSaveSaltContainer>
 
-            <StyledButtonContainer>
-              <InvertedButton size={buttonSizes.MEDIUM} onClick={props.handleClose}>
-                Cancel
-              </InvertedButton>
-              <TransactionButtonNoModal
-                transactions={props.transactions}
-                postExecuteTransactions={props.postExecuteTransactions}
-              >
-                <TransactionButtonText />
-              </TransactionButtonNoModal>
-            </StyledButtonContainer>
-          </StyledReviewVoteContent>
-        </ModalContent>
-      </ModalOuter>
-    </FullScreenModal>
-  );
-};
+              <StyledButtonContainer>
+                <TransactionButtonNoModal
+                  transactions={transactions}
+                  postExecuteTransactions={postExecuteTransactions}
+                  Button={MetaMaskLogoButton}
+                  disabled={!didSaveSalt}
+                >
+                  <TransactionButtonText />
+                </TransactionButtonNoModal>
+                <CancelButton size={buttonSizes.SMALL} onClick={handleClose}>
+                  Cancel
+                </CancelButton>
+              </StyledButtonContainer>
+
+              <StyledTransactionFinePrint>
+                <TransactionFinePrintText gasFaqURL={gasFaqURL} />
+              </StyledTransactionFinePrint>
+            </StyledReviewVoteContent>
+          </ModalContent>
+        </ModalOuter>
+      </FullScreenModal>
+    );
+  }
+
+  private toggleHasSavedSalt = (): void => {
+    this.setState({ didSaveSalt: !this.state.didSaveSalt });
+  };
+}

--- a/packages/components/src/ReviewVote/__snapshots__/ReviewVote.stories.storyshot
+++ b/packages/components/src/ReviewVote/__snapshots__/ReviewVote.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Review Vote Review Vote Modal 1`] = `
     }
   >
     <div
-      className="sc-jTqLGJ fJGDHt"
+      className="sc-dtmqqe jcbxmd"
     >
       <div>
         <p>

--- a/packages/components/src/ReviewVote/styledComponents.tsx
+++ b/packages/components/src/ReviewVote/styledComponents.tsx
@@ -11,26 +11,26 @@ export const ModalOuter = styled.div`
 `;
 
 export const ModalContent = styled.div`
-  padding: 32px 0 156px;
+  padding: 100px 0 156px;
   width: 800px;
-`;
 
-export const StyledReviewVoteHeader = styled.div`
-  background: ${colors.accent.CIVIL_GRAY_4};
-  border-top: 6px solid ${colors.accent.CIVIL_BLUE};
-  padding: 27px 42px;
+  a {
+    border-bottom: transparent 1px solid;
+    color: ${colors.accent.CIVIL_BLUE};
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  a:hover {
+    border-bottom-color: ${colors.accent.CIVIL_BLUE};
+  }
 `;
 
 export const StyledReviewVoteHeaderTitle = styled.h2`
-  font-family: ${fonts.SERIF};
-  font-size: 32px;
-  line-height: 40px;
+  font-size: 24px;
+  line-height: 30px;
+  letter-spacing: -0.17px;
   margin: 0 0 2px;
-`;
-
-export const StyledReviewVoteHeaderCopy = styled.p`
-  font-size: 14px;
-  line-height: 33px;
 `;
 
 export const StyledReviewVoteContent = styled.div`
@@ -39,20 +39,19 @@ export const StyledReviewVoteContent = styled.div`
 
 export const StyledReviewVoteContentCopy = styled.div`
   color: ${colors.primary.CIVIL_GRAY_1};
-  font-size: 14px;
-  line-height: 20px;
-  padding: 0 65px;
-  margin: 17px 0 32px;
-`;
+  font-size: 16px;
+  line-height: 26px;
+  margin: 12px 0 30px;
 
-export const StyledReviewVoteContentGrid = styled.div`
-  border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
-  display: flex;
-  padding: 0 0 32px;
-  margin: 0 0 38px;
+  span {
+    border-bottom: transparent 1px solid;
+    color: ${colors.accent.CIVIL_BLUE};
+    cursor: pointer;
+    text-decoration: none;
+  }
 
-  & > div {
-    width: 50%;
+  span:hover {
+    border-bottom-color: ${colors.accent.CIVIL_BLUE};
   }
 `;
 
@@ -62,30 +61,19 @@ export const StyledReviewVoteDetails = styled.div`
   padding: 33px 30px;
 `;
 
-export const StyledReviewVoteDates = styled.div`
-  color: ${colors.primary.CIVIL_GRAY_1};
-  font-size: 14px;
-  line-height: 20px;
-  padding-left: 63px;
-
-  p {
-    margin: 40px 0 12px;
-  }
-
-  ol {
-    margin: 0;
-    padding: 0 0 0 16px;
-  }
-
-  li {
-    margin: 0 0 10px;
-  }
+export const MetaRowSalt = styled.div`
+  background: ${colors.accent.CIVIL_TEAL_FADED};
+  margin: -33px -30px 24px;
+  padding: 33px 30px;
 `;
 
 export const MetaRow = styled.div`
-  border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
-  padding: 0 0 19px;
-  margin: 0 0 19px;
+  margin: 0 0 18px;
+
+  & ~ & {
+    border-top: 1px solid ${colors.accent.CIVIL_GRAY_4};
+    padding: 19px 0 0;
+  }
 `;
 
 export const MetaItemLabel = styled.div`
@@ -98,12 +86,35 @@ export const MetaItemLabel = styled.div`
 `;
 
 export const MetaItemLabelSalt = styled(MetaItemLabel)`
-  text-align: center;
+  color: ${colors.primary.BLACK}
+  font-size: 18px;
+  line-height: 21px;
+  margin-bottom: 10px;
 `;
 
 export const MetaItemValue = styled.div`
-  font-size: 18px;
   line-height: 33px;
+`;
+
+export const MetaItemValueTwoCol = styled(MetaItemValue)`
+  display: flex;
+  font-size: 18px;
+  justify-content: space-between;
+`;
+
+export const StyledConfirmVoteDateRange = styled.div`
+  width: 50%;
+`;
+
+export const StyledAddToCalendarContainer = styled.div`
+  width: 207px;
+
+  p {
+    color: ${colors.primary.CIVIL_GRAY_1};
+    font-size: 12px;
+    line-height: 15px;
+    margin: 6px 0 0;
+  }
 `;
 
 export const MetaItemValueUser = styled(MetaItemValue)`
@@ -111,25 +122,12 @@ export const MetaItemValueUser = styled(MetaItemValue)`
 `;
 
 export const MetaItemValueSalt = styled.div`
-  background: ${colors.accent.CIVIL_TEAL_FADED};
+  background: ${colors.basic.WHITE};
   font-family: ${fonts.MONOSPACE};
-  font-size: 20px;
-  line-height: 35px;
-  padding: 10px 0;
-  text-align: center;
-`;
-
-export const StyledReviewVoteDatesHeader = styled.div`
   font-size: 21px;
-  font-weight: bold;
-  line-height: 25px;
-  margin: 0 0 15px;
-`;
-
-export const StyledReviewVoteDatesRange = styled.div`
-  font-weight: 18px;
-  line-height: 33px;
-  margin: 0 0 16px;
+  line-height: 14px;
+  padding: 10px 27px;
+  text-align: center;
 `;
 
 export const StyledAddToCalendar = styled.div`
@@ -138,8 +136,8 @@ export const StyledAddToCalendar = styled.div`
     text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.004);
     position: relative;
     display: inline-block;
-    margin: 0 auto;
-    width: 175px;
+    margin: 0 auto 6px;
+    white-space: nowrap;
   }
 
   .react-add-to-calendar__wrapper {
@@ -148,14 +146,17 @@ export const StyledAddToCalendar = styled.div`
   }
 
   .react-add-to-calendar__button {
-    padding: 10px;
-    background-color: #f9f9f9;
-    border: 1px solid #aab9d4;
-    border-radius: 3px;
-    color: #000;
+    background-color: ${colors.basic.WHITE};
+    border: 1px solid ${colors.accent.CIVIL_BLUE_VERY_FADED};
+    border-radius: 0px;
+    font-weight: bold;
+    color: ${colors.accent.CIVIL_BLUE};
+    font-size: 14px;
+    line-height: 17px;
+    padding: 15px 35px;
 
     .react-add-to-calendar--light {
-      background-color: #fff;
+      background-color: ${colors.basic.WHITE};
     }
   }
 
@@ -171,7 +172,7 @@ export const StyledAddToCalendar = styled.div`
 
   .react-add-to-calendar__dropdown {
     position: absolute;
-    top: 30px;
+    top: 42px;
     left: 1px;
     width: 93%;
     padding: 5px 0 5px 8px;
@@ -189,6 +190,7 @@ export const StyledAddToCalendar = styled.div`
         padding: 0 0 5px;
 
         a {
+          font-size: 14px;
           text-decoration: none;
 
           &:hover {
@@ -204,13 +206,35 @@ export const StyledAddToCalendar = styled.div`
   }
 `;
 
-export const StyledDateAction = styled.span`
-  color: ${colors.accent.CIVIL_BLUE};
-  cursor: pointer;
-`;
-
 export const StyledButtonContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  margin-bottom: 16px;
+  text-align: right;
+
+  & > button {
+    margin-left: 10px;
+  }
+`;
+
+export const StyledDidSaveSaltContainer = styled.div`
+  display: flex;
+  font-size: 15px;
+  letter-spacing: -0.1px;
+  line-height: 26px;
+  padding: 0 30px;
+  margin: 58px 0 51px;
+
+  & > div + div {
+    margin: -8px 0 0 8px;
+  }
+`;
+
+export const StyledTransactionFinePrint = styled.div`
+  color: ${colors.primary.CIVIL_GRAY_1};
+  font-size: 13px;
+  line-height: 16px;
   margin-bottom: 150px;
+  text-align: right;
 `;

--- a/packages/components/src/ReviewVote/textComponents.tsx
+++ b/packages/components/src/ReviewVote/textComponents.tsx
@@ -8,33 +8,52 @@ import {
 
 // Review Vote modal
 export const ReviewVoteHeaderTitleText: React.FunctionComponent = props => {
-  return <>Review Voting Information</>;
+  return <>Review and Save Your Voting Information</>;
 };
 
-export const ReviewVoteHeaderCopyText: React.FunctionComponent = props => {
-  return <>Save this information to reveal and confirm your votes in the “Confirm Vote” phase.</>;
-};
+export interface ReviewVoteCopyTextProps {
+  votingContractFaqURL: string;
+  handlePrintClick(): void;
+}
 
-export const ReviewVoteCopyText: React.FunctionComponent = props => {
+export const ReviewVoteCopyText: React.FunctionComponent<ReviewVoteCopyTextProps> = props => {
   return (
     <>
-      Your votes are concealed with a given secret phrase until the end of the commit voting period. This is to prevent
-      decision bias, and to minimize the risk of “groupthink” affecting voter rationale when assessing the merits of the
-      challenge. You will need the secret phrase to reveal your votes in the “Confirm Vote” phase, so keep it safe.
+      <p>
+        Civil does not store your voting information; it is stored in a{" "}
+        <a href={props.votingContractFaqURL} target="_blank">
+          voting smart contract
+        </a>.
+      </p>
+
+      <p>
+        You need to carefully <b>save your unique 4-word voting code</b> for the next voting stage. If you forget this
+        voting code when you confirm your vote in the next voting stage, your vote will not be counted.
+      </p>
+
+      <p>
+        We recommend writing your voting code down and emailing it to yourself, taking a screenshot of this page, or{" "}
+        <span onClick={props.handlePrintClick}>print this out</span>. Or, <b>add a reminder to your calendar</b> so you
+        don’t forget to confirm your vote.
+      </p>
     </>
   );
 };
 
 export const ReviewVoteDepositedCVLLabelText: React.FunctionComponent = props => {
-  return <>My Deposited CVL</>;
+  return <>Amount of Voting Tokens Submitted</>;
 };
 
 export const ReviewVoteMyAddressLabelText: React.FunctionComponent = props => {
   return <>My Public Address</>;
 };
 
-export const SaltLabelText: React.FunctionComponent = props => {
-  return <>My Secret Phrase</>;
+export interface SaltLabelTextProps {
+  challengeID: string;
+}
+
+export const SaltLabelText: React.FunctionComponent<SaltLabelTextProps> = props => {
+  return <>Unique 4-word Voting Code for Challenge #{props.challengeID}</>;
 };
 
 export interface ReviewVoteDecisionTextProps {
@@ -67,32 +86,12 @@ export const AppealChallengeReviewVoteDecisionText: React.FunctionComponent<Revi
   );
 };
 
-export const ConfirmVotesHeaderText: React.FunctionComponent = props => {
+export const ConfirmVotesLabelText: React.FunctionComponent = props => {
   return <>Confirm Vote Dates</>;
 };
 
-export const ConfirmVotesSaveSaltCopyText: React.FunctionComponent = props => {
-  return <>We also recommend doing one of the following to save your information:</>;
-};
-
-export const WriteItDownText: React.FunctionComponent = props => {
-  return <>Write it down</>;
-};
-
-export const TakeAScreenShotText: React.FunctionComponent = props => {
-  return <>Take a screenshot</>;
-};
-
-export const PrintThisText: React.FunctionComponent = props => {
-  return <>Print this out</>;
-};
-
-export const EmailYourselfText: React.FunctionComponent = props => {
-  return <>Email it to yourself</>;
-};
-
 export const TransactionButtonText: React.FunctionComponent = props => {
-  return <>Confirm With Metamask</>;
+  return <>Open MetaMask to Approve</>;
 };
 
 export const SaltPhraseToolTipText: React.FunctionComponent = props => {
@@ -106,6 +105,31 @@ export const SaltPhraseToolTipText: React.FunctionComponent = props => {
         Be sure to record your secret phrase for safekeeping. If you lose your secret phrase, your vote is lost.
         Unfortunately, we can not recover it for you.
       </p>
+    </>
+  );
+};
+
+export interface TransactionFinePrintTextProps {
+  gasFaqURL: string;
+}
+
+export const TransactionFinePrintText: React.FunctionComponent<TransactionFinePrintTextProps> = props => {
+  return (
+    <>
+      This will open a new window asking to confirm and process your transaction. A small transaction fee will be added
+      for all votes. This fee does not go to the Civil Media Company.{" "}
+      <a href={props.gasFaqURL} target="_blank">
+        Learn more
+      </a>.
+    </>
+  );
+};
+
+export const SaveSaltCheckboxLabelText: React.FunctionComponent = props => {
+  return (
+    <>
+      I have saved my voting information by one of the following ways: <b>Added to My Calendar</b>, wrote down the
+      voting code, took a screenshot or printed this page.{" "}
     </>
   );
 };

--- a/packages/components/src/ReviewVote/textComponents.tsx
+++ b/packages/components/src/ReviewVote/textComponents.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import { urlConstants as links } from "@joincivil/utils";
+
 import {
   WhitelistActionText,
   RemoveActionText,
@@ -12,7 +14,6 @@ export const ReviewVoteHeaderTitleText: React.FunctionComponent = props => {
 };
 
 export interface ReviewVoteCopyTextProps {
-  votingContractFaqURL: string;
   handlePrintClick(): void;
 }
 
@@ -21,7 +22,7 @@ export const ReviewVoteCopyText: React.FunctionComponent<ReviewVoteCopyTextProps
     <>
       <p>
         Civil does not store your voting information; it is stored in a{" "}
-        <a href={props.votingContractFaqURL} target="_blank">
+        <a href={links.FAQ_WHAT_IS_PLCR_CONTRACT} target="_blank">
           voting smart contract
         </a>.
       </p>
@@ -109,16 +110,12 @@ export const SaltPhraseToolTipText: React.FunctionComponent = props => {
   );
 };
 
-export interface TransactionFinePrintTextProps {
-  gasFaqURL: string;
-}
-
-export const TransactionFinePrintText: React.FunctionComponent<TransactionFinePrintTextProps> = props => {
+export const TransactionFinePrintText: React.FunctionComponent = props => {
   return (
     <>
       This will open a new window asking to confirm and process your transaction. A small transaction fee will be added
       for all votes. This fee does not go to the Civil Media Company.{" "}
-      <a href={props.gasFaqURL} target="_blank">
+      <a href={links.FAQ_GAS} target="_blank">
         Learn more
       </a>.
     </>

--- a/packages/components/src/Table/__snapshots__/Table.stories.storyshot
+++ b/packages/components/src/Table/__snapshots__/Table.stories.storyshot
@@ -11,76 +11,76 @@ exports[`Storyshots Pattern Library / Table Default 1`] = `
     }
   >
     <div
-      className="sc-wRHdD iuZmvI"
+      className="sc-jTqLGJ kbAmmp"
     >
       <table
-        className="sc-ckYZGd eRCkro"
+        className="sc-igwadP LTaRI"
         width="100%"
       >
         <tr
-          className="sc-dXLFzO flXwKE"
+          className="sc-cnTzU evNIQd"
         >
           <th
-            className="sc-eweMDZ jMltTD"
+            className="sc-ckYZGd LkalZ"
           >
             Default Header
           </th>
           <th
-            className="sc-eweMDZ bVwjNg"
+            className="sc-ckYZGd inWXzw"
           >
             Right aligned
           </th>
           <th
-            className="sc-eweMDZ dpYbi"
+            className="sc-ckYZGd cZYHUO"
             colSpan={2}
           >
             Accent Col spanned header
           </th>
         </tr>
         <tr
-          className="sc-dXLFzO flXwKE"
+          className="sc-cnTzU evNIQd"
         >
           <td
-            className="sc-igwadP fZUcjn"
+            className="sc-dNoQZL iaLUNG"
           >
             Default cell
           </td>
           <td
-            className="sc-igwadP fmWwYY"
+            className="sc-dNoQZL giRjfF"
           >
             Default cell
           </td>
           <td
-            className="sc-igwadP fggngw"
+            className="sc-dNoQZL jNPGcy"
           >
             Pasta
           </td>
           <td
-            className="sc-igwadP fggngw"
+            className="sc-dNoQZL jNPGcy"
           >
             Pho
           </td>
         </tr>
         <tr
-          className="sc-dXLFzO flXwKE"
+          className="sc-cnTzU evNIQd"
         >
           <td
-            className="sc-igwadP fZUcjn"
+            className="sc-dNoQZL iaLUNG"
           >
             Pizza is delicious
           </td>
           <td
-            className="sc-igwadP fmWwYY"
+            className="sc-dNoQZL giRjfF"
           >
             Ramen is tasty too
           </td>
           <td
-            className="sc-igwadP fggngw"
+            className="sc-dNoQZL jNPGcy"
           >
             Pasta
           </td>
           <td
-            className="sc-igwadP fggngw"
+            className="sc-dNoQZL jNPGcy"
           >
             Pho
           </td>

--- a/packages/components/src/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -4461,7 +4461,7 @@ exports[`Storyshots Common / Tabs Tabs with before/after elements in nav 1`] = `
           className="sc-ejGVNB kCvXwc"
         >
           <span
-            className="sc-kRCAcj iFXBvv"
+            className="sc-jgwFWF dipaRt"
           >
             <span>
               before!
@@ -4480,7 +4480,7 @@ exports[`Storyshots Common / Tabs Tabs with before/after elements in nav 1`] = `
             Sign
           </li>
           <span
-            className="sc-kRCAcj iFXBvv"
+            className="sc-jgwFWF dipaRt"
           >
             <span>
               after!

--- a/packages/components/src/TokenTutorial/__snapshots__/TokenTutorial.stories.storyshot
+++ b/packages/components/src/TokenTutorial/__snapshots__/TokenTutorial.stories.storyshot
@@ -11,16 +11,16 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
     }
   >
     <div
-      className="sc-esExBO gyXXTS"
+      className="sc-dWcDbm eGVCTn"
     >
       <div
-        className="sc-hENMEE hkyHEe"
+        className="sc-dpiBDp ivEwOy"
       >
         <h2>
           Choose a topic below to get started
         </h2>
         <div
-          className="sc-dCaJBF evTkMq"
+          className="sc-hENMEE kEPIvJ"
         >
           <svg
             height="18"
@@ -46,13 +46,13 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
         </div>
       </div>
       <div
-        className="sc-cXHFlN liWgqJ"
+        className="sc-dCaJBF kBkDym"
       >
         <p>
           If you’ve read the Civil Constitution and FAQ, skip to the quiz.
         </p>
         <button
-          className="sc-ihiiSJ dwZrHy sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
+          className="sc-cXHFlN hxeobl sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
           onClick={[Function]}
           theme={
             Object {
@@ -66,10 +66,10 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
         </button>
       </div>
       <div
-        className="sc-gJTSre jQmkTZ"
+        className="sc-ihiiSJ duDXFM"
       >
         <button
-          className="sc-cLmFfZ okQvX sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
+          className="sc-fdqjUm eRAqhZ sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
           disabled={false}
           onClick={[Function]}
           theme={
@@ -81,7 +81,7 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
           type="button"
         >
           <div
-            className="sc-fdqjUm imsYFw"
+            className="sc-gJTSre kFURKu"
           >
             <div>
               <svg
@@ -128,7 +128,7 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
             </svg>
           </div>
           <div
-            className="sc-eAyhxF hIHpjM"
+            className="sc-cLmFfZ xtbuT"
           >
             You have 
             4
@@ -136,19 +136,19 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
             s
              left
             <div
-              className="sc-kbdWBx bROajm"
+              className="sc-eAyhxF fnqkKT"
             >
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <b>
                 0
@@ -160,10 +160,10 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
         </button>
       </div>
       <div
-        className="sc-gJTSre jQmkTZ"
+        className="sc-ihiiSJ duDXFM"
       >
         <button
-          className="sc-cLmFfZ bVXAKK sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg disabled"
+          className="sc-fdqjUm KIrjn sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg disabled"
           disabled={true}
           onClick={[Function]}
           theme={
@@ -175,7 +175,7 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
           type="button"
         >
           <div
-            className="sc-fdqjUm imsYFw"
+            className="sc-gJTSre kFURKu"
           >
             <div>
               <svg
@@ -225,7 +225,7 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
             </svg>
           </div>
           <div
-            className="sc-eAyhxF hIHpjM"
+            className="sc-cLmFfZ xtbuT"
           >
             You have 
             4
@@ -233,19 +233,19 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
             s
              left
             <div
-              className="sc-kbdWBx bROajm"
+              className="sc-eAyhxF fnqkKT"
             >
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <b>
                 0
@@ -257,10 +257,10 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
         </button>
       </div>
       <div
-        className="sc-gJTSre jQmkTZ"
+        className="sc-ihiiSJ duDXFM"
       >
         <button
-          className="sc-cLmFfZ bVXAKK sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg disabled"
+          className="sc-fdqjUm KIrjn sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg disabled"
           disabled={true}
           onClick={[Function]}
           theme={
@@ -272,7 +272,7 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
           type="button"
         >
           <div
-            className="sc-fdqjUm imsYFw"
+            className="sc-gJTSre kFURKu"
           >
             <div>
               <svg
@@ -329,7 +329,7 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
             </svg>
           </div>
           <div
-            className="sc-eAyhxF hIHpjM"
+            className="sc-cLmFfZ xtbuT"
           >
             You have 
             4
@@ -337,19 +337,19 @@ exports[`Storyshots Storefront / Token Tutorial Tutorial Landing 1`] = `
             s
              left
             <div
-              className="sc-kbdWBx bROajm"
+              className="sc-eAyhxF fnqkKT"
             >
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <div
-                className="sc-eVrGFk hbOFFq"
+                className="sc-kbdWBx oQsMZ"
               />
               <b>
                 0

--- a/packages/components/src/Tokens/__snapshots__/TokensAccount.stories.storyshot
+++ b/packages/components/src/Tokens/__snapshots__/TokensAccount.stories.storyshot
@@ -11,23 +11,23 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
     }
   >
     <div
-      className="sc-ixltIz juZnne"
+      className="sc-fyjYeE fUYUgc"
     >
       <div>
         <div
-          className="sc-ldcLGC gBBbDY"
+          className="sc-fObBmV fuALqD"
         >
           <ul
             className="sc-ejGVNB kCvXwc"
           >
             <li
-              className="sc-fObBmV fpyGmO"
+              className="sc-ePAWwb fxshGr"
               onClick={[Function]}
             >
               Buy
             </li>
             <li
-              className="sc-fObBmV cpTEud"
+              className="sc-ePAWwb doiGUd"
               onClick={[Function]}
             >
               Sell
@@ -54,7 +54,7 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
         </div>
         <div>
           <div
-            className="sc-lhLRcH fHsYIk"
+            className="sc-kAKrxA eNzQhn"
           >
             <div
               className="sc-kDhYZr gtlbsg"
@@ -92,10 +92,10 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
               </div>
             </div>
             <div
-              className="sc-ccvjgv gtdjDq"
+              className="sc-jMtzgO huExqa"
             >
               <div
-                className="sc-ccvjgv gtdjDq"
+                className="sc-jMtzgO huExqa"
               >
                 <h3>
                   Contribute to the Civil Foundation
@@ -116,7 +116,7 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
                   <div />
                 </div>
                 <div
-                  className="sc-iUpOdG jylwPB"
+                  className="sc-bQduHL lbuFTb"
                 >
                   <span>
                     You are 
@@ -148,7 +148,7 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
                   Buy CVL from Civil Media Company in Airswap
                 </button>
                 <div
-                  className="sc-hTQSVH dGMcSY"
+                  className="sc-hXhGGG gNmfNk"
                 >
                   By clicking buy to purchase Civil tokens, you agree to the
                    
@@ -702,13 +702,13 @@ exports[`Storyshots Storefront / User Token Account Signup Section 1`] = `
     }
   >
     <div
-      className="sc-ixltIz juZnne"
+      className="sc-fyjYeE fUYUgc"
     >
       <div
-        className="sc-jGkVzM jnvWTq"
+        className="sc-clWJBl fWycZh"
       >
         <div
-          className="sc-fYAFcb ekkGOS"
+          className="sc-jGkVzM dqDLCj"
           step="active"
         >
           <svg
@@ -736,7 +736,7 @@ exports[`Storyshots Storefront / User Token Account Signup Section 1`] = `
           Use your wallet to safely store your cryptocurrencies like Ether (ETH) and Civil tokens (CVL)
         </p>
         <a
-          className="sc-fxgLge gZccvA sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
+          className="sc-iysEgW fvPEaP sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
           href="/auth/wallet"
           onClick={[Function]}
           theme={
@@ -1293,10 +1293,10 @@ exports[`Storyshots Storefront / User Token Account Tutorial Verify 1`] = `
     }
   >
     <div
-      className="sc-ixltIz juZnne"
+      className="sc-fyjYeE fUYUgc"
     >
       <div
-        className="sc-clWJBl FMGdz"
+        className="sc-cANqwJ dEdRiT"
       >
         <h3>
           Take the Civil Tutorial
@@ -1306,11 +1306,11 @@ exports[`Storyshots Storefront / User Token Account Tutorial Verify 1`] = `
         </p>
       </div>
       <div
-        className="sc-jGkVzM jnvWTq"
+        className="sc-clWJBl fWycZh"
         step="active"
       >
         <div
-          className="sc-fYAFcb ekkGOS"
+          className="sc-jGkVzM dqDLCj"
           step="active"
         >
           <svg
@@ -1349,7 +1349,7 @@ exports[`Storyshots Storefront / User Token Account Tutorial Verify 1`] = `
           It will take about 30 minutes to complete if you're a novice. If at any point you answer incorrectly, don’t worry. You will be able to answer the questions again.
         </p>
         <button
-          className="sc-fxgLge gZccvA sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
+          className="sc-iysEgW fvPEaP sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
           onClick={[Function]}
           theme={
             Object {

--- a/packages/components/src/Tokens/buy/__snapshots__/TokensTabBuy.stories.storyshot
+++ b/packages/components/src/Tokens/buy/__snapshots__/TokensTabBuy.stories.storyshot
@@ -11,10 +11,10 @@ exports[`Storyshots Storefront / Buy Tab Buy Complete 1`] = `
     }
   >
     <div
-      className="sc-gOhSNZ jNUuFS"
+      className="sc-wRHdD kdZZUV"
     >
       <div
-        className="sc-fjdPjP ePnGun"
+        className="sc-gCKARq IQvSC"
       >
         <svg
           height="48"
@@ -622,7 +622,7 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
     }
   >
     <div
-      className="sc-gOhSNZ jNUuFS"
+      className="sc-wRHdD kdZZUV"
     >
       <div
         className="sc-kDhYZr gtlbsg"
@@ -660,10 +660,10 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
         </div>
       </div>
       <div
-        className="sc-ccvjgv gtdjDq"
+        className="sc-jMtzgO huExqa"
       >
         <div
-          className="sc-ccvjgv gtdjDq"
+          className="sc-jMtzgO huExqa"
         >
           <h3>
             Contribute to the Civil Foundation
@@ -684,7 +684,7 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
             <div />
           </div>
           <div
-            className="sc-iUpOdG jylwPB"
+            className="sc-bQduHL lbuFTb"
           >
             <span>
               You are 
@@ -716,7 +716,7 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
             Buy CVL from Civil Media Company in Airswap
           </button>
           <div
-            className="sc-hTQSVH dGMcSY"
+            className="sc-hXhGGG gNmfNk"
           >
             By clicking buy to purchase Civil tokens, you agree to the
              
@@ -729,7 +729,7 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
           </div>
         </div>
         <div
-          className="sc-fNHLbd eXnfdM"
+          className="sc-ccbnFN hRHOpF"
         >
           <p>
             or
@@ -745,7 +745,7 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
           <div />
         </div>
         <div
-          className="sc-hTQSVH dGMcSY"
+          className="sc-hXhGGG gNmfNk"
         >
           By clicking buy to purchase Civil tokens, you agree to the
            
@@ -1295,7 +1295,7 @@ exports[`Storyshots Storefront / Buy Tab Buy from Airswap 1`] = `
     }
   >
     <div
-      className="sc-gOhSNZ jNUuFS"
+      className="sc-wRHdD kdZZUV"
     >
       <button
         className="sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
@@ -1854,7 +1854,7 @@ exports[`Storyshots Storefront / Buy Tab Buy from Uniswap 1`] = `
     }
   >
     <div
-      className="sc-gOhSNZ jNUuFS"
+      className="sc-wRHdD kdZZUV"
     >
       <div>
         loading price...

--- a/packages/components/src/Tokens/sell/__snapshots__/TokensTabSell.stories.storyshot
+++ b/packages/components/src/Tokens/sell/__snapshots__/TokensTabSell.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Storefront / Sell Tab Coming Soon 1`] = `
     }
   >
     <div
-      className="sc-jwJjzT bdckUx"
+      className="sc-gOhSNZ jNUuFS"
     />
   </div>
   <button
@@ -550,13 +550,13 @@ exports[`Storyshots Storefront / Sell Tab Need to Unlock 1`] = `
     }
   >
     <div
-      className="sc-jwJjzT bdckUx"
+      className="sc-gOhSNZ jNUuFS"
     >
       <p>
         You must unlock your tokens to remove the restrictions to sell. Once your tokens are unlocked, you will be eligible to sell them here.
       </p>
       <div
-        className="sc-ePAWwb hqDZV"
+        className="sc-fjdPjP jHxmDV"
       >
         <h4>
           <svg
@@ -590,7 +590,7 @@ exports[`Storyshots Storefront / Sell Tab Need to Unlock 1`] = `
           . And that’s it.
         </p>
         <a
-          className="sc-hDgvsY gdSJll sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
+          className="sc-fxgLge gZccvA sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
           href="/dashboard/tasks/transfer-voting-tokens"
           onClick={[Function]}
           theme={
@@ -1141,7 +1141,7 @@ exports[`Storyshots Storefront / Sell Tab Sell Tab 1`] = `
     }
   >
     <div
-      className="sc-jwJjzT bdckUx"
+      className="sc-gOhSNZ jNUuFS"
     >
       <div
         className="sc-kDhYZr jdTuch"
@@ -1694,7 +1694,7 @@ exports[`Storyshots Storefront / Sell Tab Uniswap 1`] = `
     }
   >
     <div
-      className="sc-jwJjzT bdckUx"
+      className="sc-gOhSNZ jNUuFS"
     >
       <div>
         <div>

--- a/packages/components/src/Tutorial/__snapshots__/Tutorial.stories.storyshot
+++ b/packages/components/src/Tutorial/__snapshots__/Tutorial.stories.storyshot
@@ -11,21 +11,21 @@ exports[`Storyshots Common / Tutorial Tutorial Info 1`] = `
     }
   >
     <div
-      className="sc-kyCyAI krAZeW"
+      className="sc-iNovjJ iGzTKr"
     >
       <div
-        className="sc-fEVUGC oyDFL"
+        className="sc-kyCyAI lieZYF"
       >
         <div
-          className="sc-dchYKM kDTkQZ"
+          className="sc-fEVUGC fGMzQb"
         />
       </div>
     </div>
     <div
-      className="sc-dhVevo cnjexe"
+      className="sc-jLrYHE iQsnju"
     >
       <div
-        className="sc-fqCOlO jvdZVo"
+        className="sc-dhVevo iIROCl"
       >
         <h2>
           What is Civil?
@@ -42,13 +42,13 @@ exports[`Storyshots Common / Tutorial Tutorial Info 1`] = `
       </div>
     </div>
     <div
-      className="sc-eomEcv grpNWT"
+      className="sc-hAcydR bXHHWO"
     >
       <div
-        className="sc-gcJTYu bHHNqh"
+        className="sc-eomEcv lhLkRK"
       >
         <button
-          className="sc-eklfrZ eTdRtX sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
+          className="sc-cCbPEh bAYKLs sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
           onClick={[Function]}
           theme={
             Object {
@@ -61,7 +61,7 @@ exports[`Storyshots Common / Tutorial Tutorial Info 1`] = `
           Back
         </button>
         <button
-          className="sc-cCbPEh glpPFL sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
+          className="sc-iBfVdv lmajDK sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
           onClick={[Function]}
           theme={
             Object {
@@ -474,34 +474,34 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
     }
   >
     <div
-      className="sc-kyCyAI krAZeW"
+      className="sc-iNovjJ iGzTKr"
     >
       <div
-        className="sc-fEVUGC oyDFL"
+        className="sc-kyCyAI lieZYF"
       >
         <div
-          className="sc-jLrYHE hmuasD"
+          className="sc-dchYKM ktxFFO"
         >
           1
            of 
           3
         </div>
         <div
-          className="sc-dchYKM kDTkQZ"
+          className="sc-fEVUGC fGMzQb"
         />
       </div>
     </div>
     <div
-      className="sc-dhVevo cnjexe"
+      className="sc-jLrYHE iQsnju"
     >
       <h2
-        className="sc-bscRGj kiUyjO"
+        className="sc-csSMhA cFnJBK"
       >
         Quiz: 
         Quiz: Considerations before buying tokens
       </h2>
       <h3
-        className="sc-hlELIx iQClEf"
+        className="sc-bscRGj HJyqx"
       >
         <span>
           1
@@ -515,7 +515,7 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
         >
           <div>
             <div
-              className="sc-cIwbeI hXwXYj"
+              className="sc-eetwQk hUNQqm"
             >
               <input
                 name="topic1-1"
@@ -524,7 +524,7 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
                 value="Option 1"
               />
               <button
-                className="sc-dUcZlc dsrutB sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
+                className="sc-cIwbeI jFJMkL sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
                 onClick={[Function]}
                 theme={
                   Object {
@@ -538,13 +538,13 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
                 type="button"
               >
                 <div
-                  className="sc-eetwQk bNRazD"
+                  className="sc-eGXxtx ljueKO"
                 />
                 Option 1
               </button>
             </div>
             <div
-              className="sc-cIwbeI hXwXYj"
+              className="sc-eetwQk hUNQqm"
             >
               <input
                 name="topic1-1"
@@ -553,7 +553,7 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
                 value="Option 2"
               />
               <button
-                className="sc-dUcZlc dsrutB sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
+                className="sc-cIwbeI jFJMkL sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
                 onClick={[Function]}
                 theme={
                   Object {
@@ -567,13 +567,13 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
                 type="button"
               >
                 <div
-                  className="sc-eetwQk bNRazD"
+                  className="sc-eGXxtx ljueKO"
                 />
                 Option 2
               </button>
             </div>
             <div
-              className="sc-cIwbeI hXwXYj"
+              className="sc-eetwQk hUNQqm"
             >
               <input
                 name="topic1-1"
@@ -582,7 +582,7 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
                 value="Option 3"
               />
               <button
-                className="sc-dUcZlc dsrutB sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
+                className="sc-cIwbeI jFJMkL sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
                 onClick={[Function]}
                 theme={
                   Object {
@@ -596,7 +596,7 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
                 type="button"
               >
                 <div
-                  className="sc-eetwQk bNRazD"
+                  className="sc-eGXxtx ljueKO"
                 />
                 Option 3
               </button>
@@ -606,13 +606,13 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
       </div>
     </div>
     <div
-      className="sc-eomEcv grpNWT"
+      className="sc-hAcydR bXHHWO"
     >
       <div
-        className="sc-gcJTYu bHHNqh"
+        className="sc-eomEcv lhLkRK"
       >
         <button
-          className="sc-eklfrZ eTdRtX sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
+          className="sc-cCbPEh bAYKLs sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
           onClick={[Function]}
           theme={
             Object {
@@ -625,7 +625,7 @@ exports[`Storyshots Common / Tutorial Tutorial Question 1`] = `
           Back to Tutorial
         </button>
         <button
-          className="sc-cCbPEh glpPFL sc-kEYyzF bnmMlI sc-hMqMXs gXdhII disabled"
+          className="sc-iBfVdv lmajDK sc-kEYyzF bnmMlI sc-hMqMXs gXdhII disabled"
           disabled={true}
           onClick={[Function]}
           theme={
@@ -1264,7 +1264,7 @@ exports[`Storyshots Common / Tutorial Tutorial Topic Completed 1`] = `
     }
   >
     <div
-      className="sc-dhVevo bVkfKo"
+      className="sc-jLrYHE bYslKZ"
     >
       <svg
         height="50"
@@ -1294,17 +1294,17 @@ exports[`Storyshots Common / Tutorial Tutorial Topic Completed 1`] = `
         </g>
       </svg>
       <p
-        className="sc-erOsFi gTqTeF"
+        className="sc-hlELIx fEZOHN"
       >
         Nice! You’ve completed Topic 1
       </p>
       <p
-        className="sc-eGXxtx fUPlGl"
+        className="sc-erOsFi fkjRjG"
       >
         Buying tokens, like any financial decision, is a risk. The price of tokens can fluctuate depending on various factors. It’ a good rule of thumb to look at the team behind the token – the founders, the advisors – as well as the token design and its supply.  It’s also important to diversify your portfolio across many investment vehicles – crypto assets and non-crypto assets.
       </p>
       <button
-        className="sc-cCbPEh glpPFL sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
+        className="sc-iBfVdv lmajDK sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
         onClick={[Function]}
         theme={
           Object {
@@ -1748,26 +1748,26 @@ exports[`Storyshots Common / Tutorial Tutorial Topic Intro 1`] = `
     }
   >
     <div
-      className="sc-kyCyAI krAZeW"
+      className="sc-iNovjJ iGzTKr"
     >
       <div
-        className="sc-fEVUGC oyDFL"
+        className="sc-kyCyAI lieZYF"
       >
         <div
-          className="sc-dchYKM hDVfNl"
+          className="sc-fEVUGC KfmqZ"
         />
       </div>
     </div>
     <div
-      className="sc-dhVevo cnjexe"
+      className="sc-jLrYHE iQsnju"
     >
       <div
-        className="sc-BOulX ebaMGG"
+        className="sc-fqCOlO hQSODA"
       >
         Topic 1: How to use Civil tokens
       </div>
       <div
-        className="sc-hAcydR gyeqny"
+        className="sc-BOulX gWOOLw"
       >
         <p>
           <b>
@@ -1789,14 +1789,14 @@ exports[`Storyshots Common / Tutorial Tutorial Topic Intro 1`] = `
       </div>
     </div>
     <div
-      className="sc-eomEcv grpNWT"
+      className="sc-hAcydR bXHHWO"
     >
       <div
-        className="sc-gcJTYu gowMqL"
+        className="sc-eomEcv gOkzeT"
       >
         <div>
           <button
-            className="sc-csSMhA lglxUe sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
+            className="sc-eklfrZ llIltY sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
             onClick={[Function]}
             theme={
               Object {
@@ -1809,7 +1809,7 @@ exports[`Storyshots Common / Tutorial Tutorial Topic Intro 1`] = `
             Skip to the quiz
           </button>
           <button
-            className="sc-cCbPEh glpPFL sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
+            className="sc-iBfVdv lmajDK sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
             onClick={[Function]}
             theme={
               Object {

--- a/packages/components/src/UserStatement/__snapshots__/UserStatement.stories.storyshot
+++ b/packages/components/src/UserStatement/__snapshots__/UserStatement.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / User Statement Forms Submit Appeal Statement 1`] 
     }
   >
     <div
-      className="sc-jRnjsG bQrokH"
+      className="sc-jwJjzT ikdZVz"
     >
       <div />
     </div>
@@ -552,7 +552,7 @@ exports[`Storyshots Registry / User Statement Forms Submit Challenge Statement 1
     }
   >
     <div
-      className="sc-jRnjsG bQrokH"
+      className="sc-jwJjzT ikdZVz"
     >
       <div />
     </div>

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.connected.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.connected.stories.storyshot
@@ -11,13 +11,13 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
     }
   >
     <div
-      className="sc-cbMPqi kleslB"
+      className="sc-izvnbC glAZCu"
     >
       <h2
-        className="sc-dKEPtC ifgmSc"
+        className="sc-isBZXS fyOESt"
       >
         <svg
-          className="sc-RmnOB bqGdQc"
+          className="sc-MYvYT lcTovh"
           height="32"
           viewBox="0 0 20 20"
           width="32"
@@ -47,35 +47,35 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
         Wallet Connected
       </h2>
       <p
-        className="sc-blIhvV eHzJWZ sc-dvpmds iBCiBb"
+        className="sc-jtHxuu eckKyC sc-dBAPYN loWVKK"
       >
         Your crypto wallet is connected. Your public wallet address will be linked to your email address on the Civil network so you can log in using your wallet.
       </p>
       <div
-        className="sc-jPPmml eNbaye"
+        className="sc-RmnOB iFnFSS"
       >
         <p
-          className="sc-cgzHhG gEtByq"
+          className="sc-iLVFha doWFea"
         >
           Public Wallet Address
         </p>
         <div
-          className="sc-bIKvTM iYfsxt"
+          className="sc-jPPmml iWDvXm"
         >
           0xabc1230000000000000000000000000000abc123
         </div>
       </div>
       <p
-        className="sc-dNoQZL fdoUWk"
+        className="sc-bIKvTM bWKSyd"
       >
         <span
-          className="sc-ileJJU hzTqJd"
+          className="sc-eqPNPO hxAORS"
         >
           Make sure you've backed up and saved your MetaMask login and account details, such as your seed phrase, username and password in a safe place. We can’t help you restore or regain access if you lose it.
         </span>
       </p>
       <div
-        className="sc-MYvYT eslMID"
+        className="sc-gQNndl iwfMdK"
       >
         <button
           className="sc-kEYyzF bnmMlI sc-hMqMXs djbzrj"
@@ -100,29 +100,29 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
         </button>
       </div>
       <div
-        className="sc-eMRERa trxnc sc-cNQqM kKGjHf"
+        className="sc-clBsIJ jNOFKa sc-iFUGim eGFCJA"
       >
         <span
-          className="sc-eqPNPO bYyLDY"
+          className="sc-eMRERa djybFN"
         >
           Using a different wallet?
         </span>
         <span
-          className="sc-ileJJU hzTqJd"
+          className="sc-eqPNPO hxAORS"
         >
           Make sure it's unlocked
           . You may need to refresh.
         </span>
       </div>
       <div
-        className="sc-bOCYYb ipJlqQ"
+        className="sc-jHXLhC jVTofC"
       >
         <div
           className="sc-hXRMBi bifNjO"
           onClick={[Function]}
         >
           <h4
-            className="sc-iFUGim sBTzz"
+            className="sc-bOCYYb krDNFf"
           >
              What is a cryptocurrency wallet?
           </h4>
@@ -138,31 +138,31 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
           open={false}
         >
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             A cryptocurrency wallet is where you will store your CVL tokens and other crypto assets. It is also one of the main tools you'll need to log in to the Civil Registry and use the Civil plugin.
           </p>
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             Cryptocurrency wallets don’t store any actual money – they store the Public and Private Keys that provide access to those assets. You keep your cryptocurrency including ETH and CVL tokens in a wallet. When using your wallet on Civil, you use your wallet to pay for fees or transactions. Your wallet address also acts as your identity on the Ethereum blockchain.
           </p>
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             Consider it like your passport to the Civil economy. With your MetaMask wallet you will be able to store CVL tokens, apply, vote, engage on the Registry, and sign, index, archive content using the Publisher plugin.
           </p>
         </div>
       </div>
       <div
-        className="sc-bOCYYb ipJlqQ"
+        className="sc-jHXLhC jVTofC"
       >
         <div
           className="sc-hXRMBi bifNjO"
           onClick={[Function]}
         >
           <h4
-            className="sc-iFUGim sBTzz"
+            className="sc-bOCYYb krDNFf"
           >
              Why do I need a cryptocurrency wallet?
           </h4>
@@ -178,7 +178,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
           open={false}
         >
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             Having a wallet is required. We recommend
              
@@ -192,12 +192,12 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
             to log in and manage your transactions.
           </p>
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             You will also use your MetaMask wallet to set up and manage your Newsroom Smart Contract, manage your tokens, as well as sign and index posts to the Ethereum blockchain.
           </p>
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             After you've set up MetaMask, you'll receive a public wallet address. You'll need to fund your wallet with ETH. You can buy ETH with your bank or credit card on a variety of cryptocurrency exchanges.
              
@@ -207,21 +207,21 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
              Processing times can vary, and it can take up to 7 days for the ETH to be deposited in your wallet.
           </p>
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             Make sure you've backed up and saved your MetaMask login and seed phrase in a safe place. We can’t help you regain access if you lose it.
           </p>
         </div>
       </div>
       <div
-        className="sc-bOCYYb ipJlqQ"
+        className="sc-jHXLhC jVTofC"
       >
         <div
           className="sc-hXRMBi bifNjO"
           onClick={[Function]}
         >
           <h4
-            className="sc-iFUGim sBTzz"
+            className="sc-bOCYYb krDNFf"
           >
              Need help setting up your wallet?
           </h4>
@@ -237,7 +237,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
           open={false}
         >
           <p
-            className="sc-dwztqd dyoYrM"
+            className="sc-dvpmds hbXpB"
           >
             Head over to our
              
@@ -253,7 +253,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
         </div>
       </div>
       <p
-        className="sc-gQNndl eZYMCQ sc-dwztqd dyoYrM"
+        className="sc-gFXMyG koXipZ sc-dvpmds hbXpB"
       >
         Need more info before you start using a crypto wallet?
          
@@ -264,7 +264,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
           Learn more in our support area
            
           <span
-            className="sc-iLVFha ezwGZB"
+            className="sc-dYzWWc gxxccw"
           >
             <svg
               height="11"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.locked.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.locked.stories.storyshot
@@ -11,31 +11,31 @@ exports[`Storyshots Common / Wallet Onboarding V2/Locked Locked 1`] = `
     }
   >
     <div
-      className="sc-cbMPqi kleslB"
+      className="sc-izvnbC glAZCu"
     >
       <div
-        className="sc-geAPOV gZZGjK"
+        className="sc-DNdyV gDuQJl"
       >
         <h2
-          className="sc-dKEPtC ifgmSc"
+          className="sc-isBZXS fyOESt"
         >
           Can we switch to a different browser?
         </h2>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           Civil Registry applications and token purchases currently only work in browsers with Ethereum wallet support, like desktop Chrome and Firefox. We’re working to support other browsers.
         </p>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           In the meantime, please…
         </p>
         <div
-          className="sc-PLyBE cwLzMt"
+          className="sc-bJTOcE ekgNfA"
         >
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.google.com/chrome/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -47,7 +47,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Locked Locked 1`] = `
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -71,7 +71,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Locked Locked 1`] = `
             Get Google Chrome
           </a>
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.mozilla.org/en-US/firefox/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -83,7 +83,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Locked Locked 1`] = `
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -108,16 +108,16 @@ exports[`Storyshots Common / Wallet Onboarding V2/Locked Locked 1`] = `
           </a>
         </div>
         <p
-          className="sc-jHXLhC QTGuD sc-dwztqd dyoYrM"
+          className="sc-fgrSAo bwDbMg sc-dvpmds hbXpB"
         >
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="mailto:support@civil.co"
           >
             Contact Us
           </a>
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="https://help.civil.co/hc/en-us/articles/360022147571-Browser-Support"
             target="_blank"
           >

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.mismatch.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.mismatch.stories.storyshot
@@ -11,31 +11,31 @@ exports[`Storyshots Common / Wallet Onboarding V2/Mismatch Civil account vs. Met
     }
   >
     <div
-      className="sc-cbMPqi kleslB"
+      className="sc-izvnbC glAZCu"
     >
       <div
-        className="sc-geAPOV gZZGjK"
+        className="sc-DNdyV gDuQJl"
       >
         <h2
-          className="sc-dKEPtC ifgmSc"
+          className="sc-isBZXS fyOESt"
         >
           Can we switch to a different browser?
         </h2>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           Civil Registry applications and token purchases currently only work in browsers with Ethereum wallet support, like desktop Chrome and Firefox. We’re working to support other browsers.
         </p>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           In the meantime, please…
         </p>
         <div
-          className="sc-PLyBE cwLzMt"
+          className="sc-bJTOcE ekgNfA"
         >
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.google.com/chrome/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -47,7 +47,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Mismatch Civil account vs. Met
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -71,7 +71,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Mismatch Civil account vs. Met
             Get Google Chrome
           </a>
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.mozilla.org/en-US/firefox/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -83,7 +83,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Mismatch Civil account vs. Met
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -108,16 +108,16 @@ exports[`Storyshots Common / Wallet Onboarding V2/Mismatch Civil account vs. Met
           </a>
         </div>
         <p
-          className="sc-jHXLhC QTGuD sc-dwztqd dyoYrM"
+          className="sc-fgrSAo bwDbMg sc-dvpmds hbXpB"
         >
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="mailto:support@civil.co"
           >
             Contact Us
           </a>
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="https://help.civil.co/hc/en-us/articles/360022147571-Browser-Support"
             target="_blank"
           >

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.network.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.network.stories.storyshot
@@ -11,31 +11,31 @@ exports[`Storyshots Common / Wallet Onboarding V2/ Wrong Network Wrong Network 1
     }
   >
     <div
-      className="sc-cbMPqi kleslB"
+      className="sc-izvnbC glAZCu"
     >
       <div
-        className="sc-geAPOV gZZGjK"
+        className="sc-DNdyV gDuQJl"
       >
         <h2
-          className="sc-dKEPtC ifgmSc"
+          className="sc-isBZXS fyOESt"
         >
           Can we switch to a different browser?
         </h2>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           Civil Registry applications and token purchases currently only work in browsers with Ethereum wallet support, like desktop Chrome and Firefox. We’re working to support other browsers.
         </p>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           In the meantime, please…
         </p>
         <div
-          className="sc-PLyBE cwLzMt"
+          className="sc-bJTOcE ekgNfA"
         >
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.google.com/chrome/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -47,7 +47,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/ Wrong Network Wrong Network 1
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -71,7 +71,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/ Wrong Network Wrong Network 1
             Get Google Chrome
           </a>
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.mozilla.org/en-US/firefox/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -83,7 +83,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/ Wrong Network Wrong Network 1
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -108,16 +108,16 @@ exports[`Storyshots Common / Wallet Onboarding V2/ Wrong Network Wrong Network 1
           </a>
         </div>
         <p
-          className="sc-jHXLhC QTGuD sc-dwztqd dyoYrM"
+          className="sc-fgrSAo bwDbMg sc-dvpmds hbXpB"
         >
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="mailto:support@civil.co"
           >
             Contact Us
           </a>
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="https://help.civil.co/hc/en-us/articles/360022147571-Browser-Support"
             target="_blank"
           >

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.save.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.save.stories.storyshot
@@ -11,31 +11,31 @@ exports[`Storyshots Common / Wallet Onboarding V2 / Save Address Save address to
     }
   >
     <div
-      className="sc-cbMPqi kleslB"
+      className="sc-izvnbC glAZCu"
     >
       <div
-        className="sc-geAPOV gZZGjK"
+        className="sc-DNdyV gDuQJl"
       >
         <h2
-          className="sc-dKEPtC ifgmSc"
+          className="sc-isBZXS fyOESt"
         >
           Can we switch to a different browser?
         </h2>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           Civil Registry applications and token purchases currently only work in browsers with Ethereum wallet support, like desktop Chrome and Firefox. We’re working to support other browsers.
         </p>
         <p
-          className="sc-izvnbC heZoKg sc-dvpmds iBCiBb"
+          className="sc-kkwfeq iLdAHQ sc-dBAPYN loWVKK"
         >
           In the meantime, please…
         </p>
         <div
-          className="sc-PLyBE cwLzMt"
+          className="sc-bJTOcE ekgNfA"
         >
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.google.com/chrome/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -47,7 +47,7 @@ exports[`Storyshots Common / Wallet Onboarding V2 / Save Address Save address to
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -71,7 +71,7 @@ exports[`Storyshots Common / Wallet Onboarding V2 / Save Address Save address to
             Get Google Chrome
           </a>
           <a
-            className="sc-dPNhBE bEuFVM sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
+            className="sc-PLyBE evpDMw sc-kkGfuU hYLHhU sc-hMqMXs dxbbGc"
             href="https://www.mozilla.org/en-US/firefox/"
             size="MEDIUM_WIDE"
             target="_blank"
@@ -83,7 +83,7 @@ exports[`Storyshots Common / Wallet Onboarding V2 / Save Address Save address to
             }
           >
             <img
-              className="sc-bJTOcE bzlFKu"
+              className="sc-geAPOV SnXGd"
               src={
                 Object {
                   "0": "t",
@@ -108,16 +108,16 @@ exports[`Storyshots Common / Wallet Onboarding V2 / Save Address Save address to
           </a>
         </div>
         <p
-          className="sc-jHXLhC QTGuD sc-dwztqd dyoYrM"
+          className="sc-fgrSAo bwDbMg sc-dvpmds hbXpB"
         >
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="mailto:support@civil.co"
           >
             Contact Us
           </a>
           <a
-            className="sc-kkwfeq gHvceh"
+            className="sc-dPNhBE eQSTEy"
             href="https://help.civil.co/hc/en-us/articles/360022147571-Browser-Support"
             target="_blank"
           >

--- a/packages/components/src/__snapshots__/ApplicationPhaseStatusLabels.stories.storyshot
+++ b/packages/components/src/__snapshots__/ApplicationPhaseStatusLabels.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
     }
   >
     <div
-      className="sc-fxMfqs igpLhh"
+      className="sc-OnmeF dufyOC"
     >
       <div
         className="sc-esOvli gVXqWV sc-iuJeZd hHelJB"

--- a/packages/components/src/__snapshots__/Button.stories.storyshot
+++ b/packages/components/src/__snapshots__/Button.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Buttons Button 1`] = `
     }
   >
     <div
-      className="sc-rzOft isGZwk"
+      className="sc-fxMfqs igpLhh"
     >
       <button
         className="sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"
@@ -610,7 +610,7 @@ exports[`Storyshots Pattern Library / Buttons DarkButton 1`] = `
     }
   >
     <div
-      className="sc-rzOft isGZwk"
+      className="sc-fxMfqs igpLhh"
     >
       <button
         className="sc-hSdWYo jhPlkS sc-hMqMXs fSKkRg"
@@ -1165,7 +1165,7 @@ exports[`Storyshots Pattern Library / Buttons InvertedButton 1`] = `
     }
   >
     <div
-      className="sc-rzOft isGZwk"
+      className="sc-fxMfqs igpLhh"
     >
       <button
         className="sc-kkGfuU hYLHhU sc-hMqMXs fSKkRg"
@@ -1717,7 +1717,7 @@ exports[`Storyshots Pattern Library / Buttons SecondaryButton 1`] = `
     }
   >
     <div
-      className="sc-rzOft isGZwk"
+      className="sc-fxMfqs igpLhh"
     >
       <button
         className="sc-iAyFgw gKvJnO sc-hMqMXs fSKkRg"
@@ -2272,7 +2272,7 @@ exports[`Storyshots Pattern Library / Buttons sizes 1`] = `
     }
   >
     <div
-      className="sc-rzOft isGZwk"
+      className="sc-fxMfqs igpLhh"
     >
       <button
         className="sc-kEYyzF bnmMlI sc-hMqMXs gXdhII"

--- a/packages/components/src/__snapshots__/ClipLoader.stories.storyshot
+++ b/packages/components/src/__snapshots__/ClipLoader.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Loading / Clip Loader Default Size (32px x
     }
   >
     <div
-      className="sc-bkypNX kHqKvZ"
+      className="sc-eIvgmF edipNh"
     >
       <div>
         <div
@@ -506,7 +506,7 @@ exports[`Storyshots Pattern Library / Loading / Clip Loader Prop-defined size (1
     }
   >
     <div
-      className="sc-bkypNX kHqKvZ"
+      className="sc-eIvgmF edipNh"
     >
       <div>
         <div

--- a/packages/components/src/__snapshots__/Collapsable.stories.storyshot
+++ b/packages/components/src/__snapshots__/Collapsable.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Collapsable closed 1`] = `
     }
   >
     <div
-      className="sc-jklikK iLQOaA"
+      className="sc-bkypNX jcKRMl"
     >
       <div>
         <div
@@ -496,7 +496,7 @@ exports[`Storyshots Pattern Library / Collapsable disabled 1`] = `
     }
   >
     <div
-      className="sc-jklikK iLQOaA"
+      className="sc-bkypNX jcKRMl"
     >
       <div>
         <div
@@ -990,7 +990,7 @@ exports[`Storyshots Pattern Library / Collapsable open 1`] = `
     }
   >
     <div
-      className="sc-jklikK iLQOaA"
+      className="sc-bkypNX jcKRMl"
     >
       <div>
         <div
@@ -1457,7 +1457,7 @@ exports[`Storyshots Pattern Library / Collapsable with custom arrow 1`] = `
     }
   >
     <div
-      className="sc-jklikK iLQOaA"
+      className="sc-bkypNX jcKRMl"
     >
       <div>
         <div
@@ -1467,7 +1467,7 @@ exports[`Storyshots Pattern Library / Collapsable with custom arrow 1`] = `
           Hello
            
           <div
-            className="sc-kBzFSH dTIEdb"
+            className="sc-bjPkoM eWHOcJ"
             open={false}
           />
         </div>
@@ -1967,7 +1967,7 @@ exports[`Storyshots Pattern Library / Collapsable with open text 1`] = `
     }
   >
     <div
-      className="sc-jklikK iLQOaA"
+      className="sc-bkypNX jcKRMl"
     >
       <div>
         <div

--- a/packages/components/src/__snapshots__/DetailTransactionButton.stories.storyshot
+++ b/packages/components/src/__snapshots__/DetailTransactionButton.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Common / Ethereum / DetailTransactionButton detail transacti
     }
   >
     <div
-      className="sc-eqGige bGuPGS"
+      className="sc-izfUZz dHgyRw"
     />
   </div>
   <button
@@ -259,7 +259,7 @@ exports[`Storyshots Common / Ethereum / DetailTransactionButton detail transacti
     }
   >
     <div
-      className="sc-eqGige bGuPGS"
+      className="sc-izfUZz dHgyRw"
     />
   </div>
   <button

--- a/packages/components/src/__snapshots__/Heading.stories.storyshot
+++ b/packages/components/src/__snapshots__/Heading.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Typography / Headings Headings 1`] = `
     }
   >
     <div
-      className="sc-dcmekm cFLhfZ"
+      className="sc-bCQtTp jeEYdK"
     >
       <div>
         <h1

--- a/packages/components/src/__snapshots__/LoadingIndicator.stories.storyshot
+++ b/packages/components/src/__snapshots__/LoadingIndicator.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Loading / Loading Indicator Default Size (
     }
   >
     <div
-      className="sc-fUKxqW kYQhoG"
+      className="sc-eghKGU deGcap"
     >
       <div>
         <svg
@@ -388,7 +388,7 @@ exports[`Storyshots Pattern Library / Loading / Loading Indicator Prop-defined s
     }
   >
     <div
-      className="sc-fUKxqW kYQhoG"
+      className="sc-eghKGU deGcap"
     >
       <div>
         <svg

--- a/packages/components/src/__snapshots__/Message.stories.storyshot
+++ b/packages/components/src/__snapshots__/Message.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Notices / Messages (deprecate this?) Info 
     }
   >
     <div
-      className="sc-kwclOP kknbvI"
+      className="sc-fUKxqW kYQhoG"
     >
       <div>
         <div

--- a/packages/components/src/__snapshots__/Modal.stories.storyshot
+++ b/packages/components/src/__snapshots__/Modal.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Modals Fullscreen Modal 1`] = `
     }
   >
     <div
-      className="sc-bWkBrx liwwsT"
+      className="sc-kwclOP OdcsB"
     >
       <div>
         <p>
@@ -372,7 +372,7 @@ exports[`Storyshots Pattern Library / Modals Modal 1`] = `
     }
   >
     <div
-      className="sc-bWkBrx liwwsT"
+      className="sc-kwclOP OdcsB"
     >
       <div>
         <p>

--- a/packages/components/src/__snapshots__/ModalContent.stories.storyshot
+++ b/packages/components/src/__snapshots__/ModalContent.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Modals content 1`] = `
     }
   >
     <div
-      className="sc-cxZfpC eLbNft"
+      className="sc-bWkBrx liXlgJ"
     >
       <div>
         <h2

--- a/packages/components/src/__snapshots__/QuestionToolTip.stories.storyshot
+++ b/packages/components/src/__snapshots__/QuestionToolTip.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / Tooltips / QuestionToolTip tooltip 1`] = `
     }
   >
     <div
-      className="sc-dtmqqe ieShhn"
+      className="sc-jvjHmY cAeQqT"
     >
       <div
         className="sc-gxMtzJ jpYkcZ"

--- a/packages/components/src/__snapshots__/WalletOnboarding.stories.storyshot
+++ b/packages/components/src/__snapshots__/WalletOnboarding.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Common / Wallet Onboarding CMS profile vs. MetaMask address 
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <h4
         className="sc-EHOje gTvBKb"
@@ -28,18 +28,18 @@ exports[`Storyshots Common / Wallet Onboarding CMS profile vs. MetaMask address 
         Your WordPress user profile wallet address does not match your MetaMask wallet address
       </p>
       <p
-        className="sc-imDfJI bFfDJS"
+        className="sc-jWxkHr edWjih"
       >
         Profile wallet address
       </p>
       <span
-        className="sc-cNnxps rCvMZ"
+        className="sc-fAJaQT chZELy"
       >
         0x123abc00000000000000000000000000000x123abc
       </span>
        
       <p
-        className="sc-imDfJI bFfDJS"
+        className="sc-jWxkHr edWjih"
       >
         Connected wallet address
       </p>
@@ -76,7 +76,7 @@ exports[`Storyshots Common / Wallet Onboarding CMS profile vs. MetaMask address 
       </div>
        
       <div
-        className="sc-jWxkHr bBekit"
+        className="sc-dPPMrM gJIGaC"
       >
         <button
           className="sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
@@ -533,7 +533,7 @@ exports[`Storyshots Common / Wallet Onboarding Connected 1`] = `
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <h4
         className="sc-EHOje gTvBKb"
@@ -541,7 +541,7 @@ exports[`Storyshots Common / Wallet Onboarding Connected 1`] = `
         Wallet Connected
       </h4>
       <p
-        className="sc-imDfJI bFfDJS"
+        className="sc-jWxkHr edWjih"
       >
         Your wallet address
       </p>
@@ -946,10 +946,10 @@ exports[`Storyshots Common / Wallet Onboarding Locked 1`] = `
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <img
-        className="sc-DNdyV fGXcGD"
+        className="sc-hAnkBK bmqIIF"
         src={
           Object {
             "0": "t",
@@ -989,7 +989,7 @@ exports[`Storyshots Common / Wallet Onboarding Locked 1`] = `
       </p>
       <p>
         <button
-          className="sc-fdQOMr igHlBf sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
+          className="sc-jotlie hUJfTK sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
           onClick={[Function]}
           size="MEDIUM_WIDE"
           theme={
@@ -1359,7 +1359,7 @@ exports[`Storyshots Common / Wallet Onboarding No Provider 1`] = `
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <h4
         className="sc-EHOje gTvBKb"
@@ -1377,7 +1377,7 @@ exports[`Storyshots Common / Wallet Onboarding No Provider 1`] = `
         </a>
          
         <img
-          className="sc-hAnkBK ielSdv sc-cmTdod kcwOOi"
+          className="sc-imDfJI kqaJpk sc-cmTdod kcwOOi"
           src={
             Object {
               "0": "t",
@@ -1429,7 +1429,7 @@ exports[`Storyshots Common / Wallet Onboarding No Provider 1`] = `
           Open MetaMask.io
            
           <span
-            className="sc-dPPMrM dWQZYB"
+            className="sc-cNnxps iUpRAy"
           >
             <svg
               height="11"
@@ -1866,7 +1866,7 @@ exports[`Storyshots Common / Wallet Onboarding Not Enabled 1`] = `
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <h4
         className="sc-EHOje gTvBKb"
@@ -1878,7 +1878,7 @@ exports[`Storyshots Common / Wallet Onboarding Not Enabled 1`] = `
       </p>
       <p>
         <button
-          className="sc-fdQOMr igHlBf sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
+          className="sc-jotlie hUJfTK sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
           onClick={[Function]}
           size="MEDIUM_WIDE"
           theme={
@@ -1901,7 +1901,7 @@ exports[`Storyshots Common / Wallet Onboarding Not Enabled 1`] = `
       <p>
         If you do not see the MetaMask popup, please click the 
         <img
-          className="sc-hAnkBK ielSdv sc-cmTdod kcwOOi"
+          className="sc-imDfJI kqaJpk sc-cmTdod kcwOOi"
           src={
             Object {
               "0": "t",
@@ -2274,7 +2274,7 @@ exports[`Storyshots Common / Wallet Onboarding Save address to CMS profile 1`] =
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <h4
         className="sc-EHOje gTvBKb"
@@ -2285,7 +2285,7 @@ exports[`Storyshots Common / Wallet Onboarding Save address to CMS profile 1`] =
         Your wallet is connected. Now you can add your public wallet address to your WordPress user profile.
       </p>
       <p
-        className="sc-imDfJI bFfDJS"
+        className="sc-jWxkHr edWjih"
       >
         Your wallet address
       </p>
@@ -2322,7 +2322,7 @@ exports[`Storyshots Common / Wallet Onboarding Save address to CMS profile 1`] =
       </div>
        
       <div
-        className="sc-jWxkHr bBekit"
+        className="sc-dPPMrM gJIGaC"
       >
         <button
           className="sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
@@ -2740,10 +2740,10 @@ exports[`Storyshots Common / Wallet Onboarding Wrong Network 1`] = `
     }
   >
     <div
-      className="sc-jotlie cbTlro"
+      className="sc-ileJJU errTZB"
     >
       <img
-        className="sc-DNdyV fGXcGD"
+        className="sc-hAnkBK bmqIIF"
         src={
           Object {
             "0": "t",
@@ -2784,7 +2784,7 @@ exports[`Storyshots Common / Wallet Onboarding Wrong Network 1`] = `
          
         to switch networks in MetaMask 
         <img
-          className="sc-hAnkBK ielSdv sc-cmTdod kcwOOi"
+          className="sc-imDfJI kqaJpk sc-cmTdod kcwOOi"
           src={
             Object {
               "0": "t",
@@ -2811,7 +2811,7 @@ exports[`Storyshots Common / Wallet Onboarding Wrong Network 1`] = `
       </p>
       <p>
         <button
-          className="sc-fdQOMr igHlBf sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
+          className="sc-jotlie hUJfTK sc-kEYyzF bnmMlI sc-hMqMXs bMlmhm"
           onClick={[Function]}
           size="MEDIUM_WIDE"
           theme={

--- a/packages/components/src/icons/__snapshots__/icon.stories.storyshot
+++ b/packages/components/src/icons/__snapshots__/icon.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ApplicationInProgressIco
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="18"
@@ -339,7 +339,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ApprovedNewsroomsIcon 1`
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="18"
@@ -673,7 +673,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ArticleIndexIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height={24}
@@ -1011,7 +1011,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ArticleIndexPanelIcon 1`
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="18"
@@ -1356,7 +1356,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ArticleSignIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="24"
@@ -1704,7 +1704,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ArticleSignPanelIcon 1`]
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="20"
@@ -2048,7 +2048,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons BellIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="24"
@@ -2381,7 +2381,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons BookreaderIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="70"
@@ -2810,7 +2810,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons BrainIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="74"
@@ -3289,7 +3289,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons CVLToken 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="33"
@@ -3646,7 +3646,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons CivilTutorialIcon 1`] = 
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="20"
@@ -3987,7 +3987,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ClockIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="18"
@@ -4323,7 +4323,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons CloseXIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="42"
@@ -4651,7 +4651,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons CommitVoteSuccessIcon 1`
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="100"
@@ -5003,7 +5003,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons DisclosureArrowIcon 1`] 
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="12"
@@ -5340,7 +5340,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons DropdownArrow 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="5"
@@ -5668,7 +5668,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ErrorIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="28"
@@ -6004,7 +6004,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ExamIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="70"
@@ -6451,7 +6451,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ExchangeArrowsIcon 1`] =
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="14"
@@ -6789,7 +6789,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ExpandDownArrow 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="12"
@@ -7118,7 +7118,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons FacebookIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         className="sc-kafWEX iCzvJu"
@@ -7448,7 +7448,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons GreenCheckMark 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="26"
@@ -7783,7 +7783,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons HamburgerIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="42"
@@ -8111,7 +8111,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons HollowGreenCheck 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="20"
@@ -8454,7 +8454,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons HollowRedNoGood 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="20"
@@ -8792,7 +8792,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons InfoNotification 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="28"
@@ -9131,7 +9131,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons LockOpenIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="18"
@@ -9464,7 +9464,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons MetaMaskFrontIcon 1`] = 
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <img
         className="sc-cmTdod kcwOOi"
@@ -9802,7 +9802,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons MetaMaskSideIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <img
         className="sc-cmTdod kcwOOi"
@@ -10140,7 +10140,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons NetworkIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="44"
@@ -10470,7 +10470,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons NorthEastArrow 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="11"
@@ -10798,7 +10798,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons OctopusErrorIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="73"
@@ -11137,7 +11137,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons RegistryEmptyIcon 1`] = 
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="155"
@@ -11507,7 +11507,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons RejectedNewsroomsIcon 1`
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="18"
@@ -11834,7 +11834,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons RequestAppealSuccessIcon
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="100"
@@ -12251,7 +12251,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons RevealVoteSuccessIcon 1`
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="100"
@@ -12612,7 +12612,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons ReviewIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="24"
@@ -12948,7 +12948,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons SubmitChallengeSuccessIc
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="100"
@@ -13392,7 +13392,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons TokenWalletIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="21"
@@ -13725,7 +13725,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons TrendsIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="48"
@@ -14065,7 +14065,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons TwitterIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         className="sc-btzYZH eNcUGn"
@@ -14395,7 +14395,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons VerifyIdentityIcon 1`] =
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="22"
@@ -14736,7 +14736,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons WaitForApply 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="54"
@@ -15070,7 +15070,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons WarningIcon 1`] = `
     }
   >
     <div
-      className="sc-bjPkoM eqYSJO"
+      className="sc-jRnjsG ggyYyd"
     >
       <svg
         height="28"

--- a/packages/dapp/src/components/Dashboard/Dashboard.tsx
+++ b/packages/dapp/src/components/Dashboard/Dashboard.tsx
@@ -68,7 +68,7 @@ const DashboardComponent = (props: DashboardProps & DashboardReduxProps) => {
               <StyledAuthButtonContainer>
                 <p>Enable Ethereum to view Your Civil Registry Dashboard</p>
                 <Button onClick={() => (window as any).ethereum.enable()} size={buttonSizes.SMALL}>
-                  Enable Ethereum
+                  Connect Wallet
                 </Button>
               </StyledAuthButtonContainer>
             );

--- a/packages/dapp/src/components/Parameterizer/ChallengeProposalCommitVote.tsx
+++ b/packages/dapp/src/components/Parameterizer/ChallengeProposalCommitVote.tsx
@@ -12,7 +12,6 @@ import {
   ModalUnorderedList,
   ModalListItem,
 } from "@joincivil/components";
-import { urlConstants as links } from "@joincivil/utils";
 
 import { approveVotingRightsForCommit, commitVote } from "../../apis/civilTCR";
 import { InjectedTransactionStatusModalProps, hasTransactionStatusModals } from "../utility/TransactionStatusModalsHOC";
@@ -147,8 +146,6 @@ class ChallengeProposalCommitVote extends React.Component<
       transactions: this.getTransactions(),
       postExecuteTransactions: this.closeReviewModalAndChallengeDrawer,
       handleClose: this.closeReviewVoteModal,
-      gasFaqURL: links.FAQ_GAS,
-      votingContractFaqURL: links.FAQ_WHAT_IS_PLCR_CONTRACT,
     };
 
     return <ChallengeProposalReviewVote {...props} />;

--- a/packages/dapp/src/components/Parameterizer/ChallengeProposalCommitVote.tsx
+++ b/packages/dapp/src/components/Parameterizer/ChallengeProposalCommitVote.tsx
@@ -12,6 +12,7 @@ import {
   ModalUnorderedList,
   ModalListItem,
 } from "@joincivil/components";
+import { urlConstants as links } from "@joincivil/utils";
 
 import { approveVotingRightsForCommit, commitVote } from "../../apis/civilTCR";
 import { InjectedTransactionStatusModalProps, hasTransactionStatusModals } from "../utility/TransactionStatusModalsHOC";
@@ -146,6 +147,8 @@ class ChallengeProposalCommitVote extends React.Component<
       transactions: this.getTransactions(),
       postExecuteTransactions: this.closeReviewModalAndChallengeDrawer,
       handleClose: this.closeReviewVoteModal,
+      gasFaqURL: links.FAQ_GAS,
+      votingContractFaqURL: links.FAQ_WHAT_IS_PLCR_CONTRACT,
     };
 
     return <ChallengeProposalReviewVote {...props} />;

--- a/packages/dapp/src/components/listing/AppealChallengeCommitVote.tsx
+++ b/packages/dapp/src/components/listing/AppealChallengeCommitVote.tsx
@@ -208,6 +208,8 @@ class AppealChallengeCommitVote extends React.Component<
       transactions,
       postExecuteTransactions: this.closeReviewVoteModal,
       handleClose: this.closeReviewVoteModal,
+      gasFaqURL: links.FAQ_GAS,
+      votingContractFaqURL: links.FAQ_WHAT_IS_PLCR_CONTRACT,
     };
 
     return <ReviewVote {...props} />;

--- a/packages/dapp/src/components/listing/ChallengeCommitVote.tsx
+++ b/packages/dapp/src/components/listing/ChallengeCommitVote.tsx
@@ -199,6 +199,8 @@ class ChallengeCommitVote extends React.Component<
       revealEndDate: challenge.poll.revealEndDate.toNumber(),
       transactions: this.getTransactions(),
       handleClose: this.closeReviewVoteModal,
+      gasFaqURL: links.FAQ_GAS,
+      votingContractFaqURL: links.FAQ_WHAT_IS_PLCR_CONTRACT,
     };
 
     return <ReviewVote {...props} />;

--- a/packages/dapp/src/components/listing/ChallengeCommitVote.tsx
+++ b/packages/dapp/src/components/listing/ChallengeCommitVote.tsx
@@ -14,7 +14,7 @@ import {
   PhaseWithExpiryProps,
   ChallengePhaseProps,
 } from "@joincivil/components";
-import { getFormattedTokenBalance, urlConstants as links } from "@joincivil/utils";
+import { getFormattedTokenBalance } from "@joincivil/utils";
 
 import { routes } from "../../constants";
 import { commitVote, approveVotingRightsForCommit } from "../../apis/civilTCR";
@@ -151,7 +151,6 @@ class ChallengeCommitVote extends React.Component<
       voteOption: this.state.voteOption,
       numTokens: this.state.numTokens,
       key: this.state.key,
-      faqURL: links.FAQ_VOTING_SECTION,
     };
 
     return (
@@ -199,8 +198,6 @@ class ChallengeCommitVote extends React.Component<
       revealEndDate: challenge.poll.revealEndDate.toNumber(),
       transactions: this.getTransactions(),
       handleClose: this.closeReviewVoteModal,
-      gasFaqURL: links.FAQ_GAS,
-      votingContractFaqURL: links.FAQ_WHAT_IS_PLCR_CONTRACT,
     };
 
     return <ReviewVote {...props} />;

--- a/packages/utils/src/urlConstants.ts
+++ b/packages/utils/src/urlConstants.ts
@@ -44,6 +44,7 @@ export const urlConstants = {
     "/hc/en-us/articles/360024853311-What-is-the-Civil-Registry-community-vetting-process-for-a-Newsroom-",
   FAQ_CAN_REJECTED_NEWSROOMS_REAPPLY:
     FAQ_BASE_URL + "/hc/en-us/articles/360024545152-Can-rejected-Newsrooms-re-apply-to-the-Civil-Registry-",
+  FAQ_GAS: FAQ_BASE_URL + "/hc/en-us/articles/360016788791-What-is-Gas-",
   FAQ_GRANT: FAQ_BASE_URL + "/hc/en-us/articles/360021942132-Civil-Foundation-Token-Grant",
   FAQ_HOW_TO_CHALLENGE: FAQ_BASE_URL + "/hc/en-us/articles/360024546932-How-do-I-challenge-a-Newsroom-",
   FAQ_HOW_TO_VOTE: FAQ_BASE_URL + "/hc/en-us/articles/360024855271-How-do-I-vote-in-a-challenge-",


### PR DESCRIPTION
This PR includes the following updates:

- Update Challenge / Appeal Challenge Reveal Vote cards on Listing Detail page to show Confirm UI, not You Didn't Vote UI, by default. This should help alleviate some user confusion when the page loads first loads, especially because of the lag between loading the Listing data via GraphQL and User Challenge Data via Web3 (#1201)

- Change 'Enable Ethereum' text to 'Connect Wallet' in the Top Nav /
User Dashboard to be more user-friendly/less tech-speak

- Increase the height of the title/description portion of the Registry Homepage
cards to be 190px, to accommodate newsrooms with long names that span 3 lines ([CIVIL-607](https://civilmedia.atlassian.net/browse/CIVIL-607))

- Update Review Vote view per the latest design, which includes a checkbox that asks the user if they have saved their salt / voting information (#1187)

- Add text suggesting setting the Reveal Vote calendar event's visibility to Private to the Review Vote view (#1195)