### PR TITLE
Improvements to handling post-grant transition [CIVIL-582]

### DIFF
--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -453,11 +453,13 @@ class NewsroomComponent extends React.Component<NewsroomProps & DispatchProp<any
     this.setState({ currentStep: newStep });
   };
   private navigate = (go: 1 | -1): void => {
-    const newStep = this.state.currentStep + go;
+    let newStep = this.state.currentStep + go;
     this.saveStep(newStep);
     if (newStep === STEP.APPLIED) {
       // Dummy step we don't actually update view for, but need to send to API.
       return;
+    } else if (newStep === STEP.PROFILE_GRANT && !this.props.waitingOnGrant) {
+      newStep += go; // skip the step and go one further in the requested direction
     }
     document.documentElement.scrollTop = document.body.scrollTop = 0;
     this.setState({ currentStep: newStep });

--- a/packages/newsroom-signup/src/NewsroomProfile/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/index.tsx
@@ -17,7 +17,7 @@ export interface NewsroomProfileProps {
   currentStep: number;
   charter: Partial<CharterData>;
   grantRequested?: boolean;
-  grantApproved?: boolean;
+  waitingOnGrant?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
   navigate(go: 1 | -1): void;
 }
@@ -61,8 +61,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
         return false;
       },
       () => {
-        const waitingOnGrant = this.props.grantRequested && typeof this.props.grantApproved !== "boolean";
-        return waitingOnGrant || this.props.grantRequested === null;
+        return this.props.waitingOnGrant || typeof this.props.grantRequested !== "boolean";
       },
     ];
 
@@ -86,8 +85,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
   }
 
   public renderButtons(): JSX.Element | null {
-    const waitingOnGrant = this.props.grantRequested && typeof this.props.grantApproved !== "boolean";
-    if (!this.state.showButtons || waitingOnGrant) {
+    if (!this.state.showButtons || this.props.waitingOnGrant) {
       return null;
     }
     return (

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -24,16 +24,6 @@ export interface SmartContractProps {
   updateCharter(charter: Partial<CharterData>): void;
 }
 
-const ContinueButton = styled(Button)`
-  margin: 45px auto;
-  font-weight: bold;
-`;
-
-const ContinueButtonContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
 export class SmartContract extends React.Component<SmartContractProps> {
   public getDisabled(index: number): () => boolean {
     const functions = [
@@ -55,16 +45,6 @@ export class SmartContract extends React.Component<SmartContractProps> {
   }
 
   public renderButtons(): JSX.Element | void {
-    if (this.props.currentStep === 0) {
-      return (
-        <ContinueButtonContainer>
-          <ContinueButton onClick={() => this.props.navigate(1)} size={buttonSizes.MEDIUM_WIDE}>
-            Continue
-          </ContinueButton>
-        </ContinueButtonContainer>
-      );
-    }
-
     return <NextBack navigate={this.props.navigate} nextDisabled={this.getDisabled(this.props.currentStep)} />;
   }
   public renderCurrentStep(): JSX.Element {

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
-import styled from "styled-components";
 import { EthAddress, CharterData, TxHash } from "@joincivil/core";
 import { NextBack } from "../styledComponents";
 import { LetsGetStartedPage } from "./LetsGetStartedPage";
 import { UnderstandingEth } from "./UnderstandingEth";
 import { CreateNewsroomContract } from "./CreateNewsroomContract";
 import { AddMembersToContract } from "./AddMembersToContract";
-import { Button, buttonSizes } from "@joincivil/components";
 import { Mutation, MutationFunc } from "react-apollo";
 import { getCharterQuery } from "../queries";
 import { SaveAddressMutation, SaveTxMutation } from "../mutations";

--- a/packages/newsroom-signup/src/actionCreators.ts
+++ b/packages/newsroom-signup/src/actionCreators.ts
@@ -49,6 +49,7 @@ export enum listingActions {
 }
 
 export enum analyticsActions {
+  EVENT = "EVENT",
   NAVIGATE_STEP = "NAVIGATE_STEP",
   REACHED_NEW_STEP = "REACHED_NEW_STEP",
   APPLICATION_SUBMITTED = "APPLICATION_SUBMITTED",
@@ -454,5 +455,17 @@ export const reachedNewStep = (step: number): AnyAction => {
   return {
     type: analyticsActions.REACHED_NEW_STEP,
     step,
+  };
+};
+
+export const analyticsEvent = (event: {
+  category?: string;
+  action: string;
+  label?: string;
+  value?: number;
+}): AnyAction => {
+  return {
+    type: analyticsActions.EVENT,
+    event,
   };
 };

--- a/packages/newsroom-signup/src/analytics.ts
+++ b/packages/newsroom-signup/src/analytics.ts
@@ -15,6 +15,13 @@ export const newsroomSignupAnalyticsEvents = {
     };
   }),
 
+  [analyticsActions.EVENT]: trackEvent((action: any) => {
+    return {
+      category: "Newsroom Signup",
+      ...action.event,
+    };
+  }),
+
   [analyticsActions.APPLICATION_SUBMITTED]: trackEvent((action: any) => {
     return {
       category: "Newsroom Signup",

--- a/packages/newsroom-signup/src/constants.ts
+++ b/packages/newsroom-signup/src/constants.ts
@@ -13,7 +13,7 @@ export const questionsCopy = {
   [charterQuestions.REVENUE]:
     "What are your Newsroom's current or planned revenue sources? e.g. membership, subscriptions, advertising, sponsored content",
   [charterQuestions.ENCUMBRANCES]:
-    "Do you have any conflicts of interests that may impact your editorial independence? e.g. advocacy organization, commercial interests, corporate ownership",
+    "Do you have any conflicts of interest that may impact your editorial independence? e.g. advocacy organization, commercial interests, corporate ownership",
   [charterQuestions.MISCELLANEOUS]:
     "Is there anything else the Civil community should know about your Newsroom to support its inclusion on the Registry?",
 };


### PR DESCRIPTION
We've had a lot of support tickets about people stuck on the "waiting on grant" step. Some of these were from foundation not actually using the link that sets the "grant approved" flag in DB, but we've gotten at least two users for whom the flag is set correctly but they're still stuck. To combat this and track it down:

- Refactor "waiting on grant" logic to be simpler and more centralized
- Act as if grant was approved if the user has enough CVL to apply (most likely because they received grant)
- Add some GA events to help debug
- Also, replaces solo "continue" button on Smart Contract step with the same back/next buttons as every other step, since people are getting lost navigating and this could help a little