### PR TITLE
Fix 'Awaiting Request to Appeal label in the Dapp

### DIFF
--- a/packages/components/src/ApplicationPhaseStatusLabels.stories.tsx
+++ b/packages/components/src/ApplicationPhaseStatusLabels.stories.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import styled from "styled-components";
 import {
   AwaitingApprovalStatusLabel,
+  AwaitingAppealRequestLabel,
   AwaitingDecisionStatusLabel,
   AwaitingAppealChallengeStatusLabel,
   CommitVoteStatusLabel,
   RevealVoteStatusLabel,
-  RequestingAppealStatusLabel,
   ReadyToCompleteStatusLabel,
 } from "./ApplicationPhaseStatusLabels";
 
@@ -25,6 +25,8 @@ storiesOf("Registry / Application Status Labels", module).add("Labels", () => {
     <Container>
       <AwaitingApprovalStatusLabel />
       <br />
+      <AwaitingAppealRequestLabel />
+      <br />
       <AwaitingDecisionStatusLabel />
       <br />
       <AwaitingAppealChallengeStatusLabel />
@@ -32,8 +34,6 @@ storiesOf("Registry / Application Status Labels", module).add("Labels", () => {
       <CommitVoteStatusLabel />
       <br />
       <RevealVoteStatusLabel />
-      <br />
-      <RequestingAppealStatusLabel />
       <br />
       <ReadyToCompleteStatusLabel />
     </Container>

--- a/packages/components/src/ApplicationPhaseStatusLabels.tsx
+++ b/packages/components/src/ApplicationPhaseStatusLabels.tsx
@@ -43,7 +43,7 @@ export const AwaitingApprovalStatusLabel: React.FunctionComponent = props => {
 };
 
 export const AwaitingAppealRequestLabel: React.FunctionComponent = props => {
-  return <StyledAwaitingAppealStatuslabel>Requesting Appeal</StyledAwaitingAppealStatuslabel>;
+  return <StyledAwaitingStatuslabel>Awaiting Request to Appeal</StyledAwaitingStatuslabel>;
 };
 
 export const AwaitingDecisionStatusLabel: React.FunctionComponent = props => {
@@ -60,10 +60,6 @@ export const CommitVoteStatusLabel: React.FunctionComponent = props => {
 
 export const RevealVoteStatusLabel: React.FunctionComponent = props => {
   return <StyledRevealVoteStatus>Confirm Vote</StyledRevealVoteStatus>;
-};
-
-export const RequestingAppealStatusLabel: React.FunctionComponent = props => {
-  return <StyledAwaitingAppealStatuslabel>Requesting Appeal</StyledAwaitingAppealStatuslabel>;
 };
 
 export const ReadyToCompleteStatusLabel: React.FunctionComponent = props => {

--- a/packages/components/src/ListingDetailHeader/ListingDetailHeader.tsx
+++ b/packages/components/src/ListingDetailHeader/ListingDetailHeader.tsx
@@ -5,14 +5,7 @@ import { CharterData } from "@joincivil/core";
 import { NorthEastArrow, TwitterIcon, FacebookIcon } from "../icons";
 import { buttonSizes } from "../Button";
 import { StyledContentRow } from "../Layout";
-import {
-  AwaitingApprovalStatusLabel,
-  CommitVoteStatusLabel,
-  RevealVoteStatusLabel,
-  ReadyToCompleteStatusLabel,
-  AwaitingDecisionStatusLabel,
-  AwaitingAppealChallengeStatusLabel,
-} from "../ApplicationPhaseStatusLabels";
+import ListingPhaseLabel from "../ListingSummary/ListingPhaseLabel";
 import { colors } from "../styleConstants";
 
 import {
@@ -91,7 +84,7 @@ export class ListingDetailHeader extends React.Component<ListingDetailHeaderProp
           <StyledContentRow>
             <StyledNewsroomIcon>{logoURL && <StyledNewsroomLogo src={logoURL} />}</StyledNewsroomIcon>
             <div>
-              {this.renderPhaseLabel()}
+              <ListingPhaseLabel {...this.props} />
 
               <ListingDetailNewsroomName>{this.props.newsroomName}</ListingDetailNewsroomName>
 
@@ -160,25 +153,4 @@ export class ListingDetailHeader extends React.Component<ListingDetailHeaderProp
       </StyledRegistryLinkContainer>
     );
   }
-
-  private renderPhaseLabel = (): JSX.Element | undefined => {
-    if (this.props.isInApplication) {
-      return <AwaitingApprovalStatusLabel />;
-    } else if (this.props.inChallengeCommitVotePhase || this.props.isInAppealChallengeCommitPhase) {
-      return <CommitVoteStatusLabel />;
-    } else if (this.props.inChallengeRevealPhase || this.props.isInAppealChallengeRevealPhase) {
-      return <RevealVoteStatusLabel />;
-    } else if (
-      this.props.canBeWhitelisted ||
-      this.props.canResolveChallenge ||
-      this.props.canListingAppealChallengeBeResolved
-    ) {
-      return <ReadyToCompleteStatusLabel />;
-    } else if (this.props.isAwaitingAppealJudgement) {
-      return <AwaitingDecisionStatusLabel />;
-    } else if (this.props.isAwaitingAppealChallenge) {
-      return <AwaitingAppealChallengeStatusLabel />;
-    }
-    return;
-  };
 }

--- a/packages/components/src/ListingSummary/ListingPhaseLabel.tsx
+++ b/packages/components/src/ListingSummary/ListingPhaseLabel.tsx
@@ -8,9 +8,9 @@ import {
   AwaitingDecisionStatusLabel,
   AwaitingAppealChallengeStatusLabel,
 } from "../ApplicationPhaseStatusLabels";
-import { ListingSummaryComponentProps } from "./types";
+import { ListingChallengeStatusProps } from "./types";
 
-const ListingPhaseLabel: React.FunctionComponent<ListingSummaryComponentProps> = props => {
+const ListingPhaseLabel: React.FunctionComponent<ListingChallengeStatusProps> = props => {
   const {
     isInApplication,
     inChallengeCommitVotePhase,

--- a/packages/components/src/ListingSummary/types.ts
+++ b/packages/components/src/ListingSummary/types.ts
@@ -1,16 +1,6 @@
 import { EthAddress, AppealData, CharterData } from "@joincivil/core";
 
-export interface ListingSummaryComponentProps {
-  listingAddress?: EthAddress;
-  name?: string;
-  charter?: CharterData;
-  listingDetailURL?: string;
-  challengeID?: string;
-  challengeStatementSummary?: string;
-  appeal?: AppealData;
-  appealRequested?: boolean;
-  appealGranted?: boolean;
-  appealStatementSummary?: string;
+export interface ListingChallengeStatusProps {
   isInApplication?: boolean;
   canBeChallenged?: boolean;
   canBeWhitelisted?: boolean;
@@ -29,6 +19,19 @@ export interface ListingSummaryComponentProps {
   isWhitelisted?: boolean;
   isUnderChallenge?: boolean;
   canListingAppealChallengeBeResolved?: boolean;
+}
+
+export interface ListingSummaryComponentProps extends ListingChallengeStatusProps {
+  listingAddress?: EthAddress;
+  name?: string;
+  charter?: CharterData;
+  listingDetailURL?: string;
+  challengeID?: string;
+  challengeStatementSummary?: string;
+  appeal?: AppealData;
+  appealRequested?: boolean;
+  appealGranted?: boolean;
+  appealStatementSummary?: string;
   whitelistedTimestamp?: number;
   appExpiry?: number;
   commitEndDate?: number;

--- a/packages/components/src/__snapshots__/ApplicationPhaseStatusLabels.stories.storyshot
+++ b/packages/components/src/__snapshots__/ApplicationPhaseStatusLabels.stories.storyshot
@@ -22,6 +22,12 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
       <div
         className="sc-esOvli gVXqWV sc-iuJeZd hHelJB"
       >
+        Awaiting Request to Appeal
+      </div>
+      <br />
+      <div
+        className="sc-esOvli gVXqWV sc-iuJeZd hHelJB"
+      >
         Awaiting Decision
       </div>
       <br />
@@ -41,12 +47,6 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
         className="sc-cLQEGU fYfYbT sc-iuJeZd hHelJB"
       >
         Confirm Vote
-      </div>
-      <br />
-      <div
-        className="sc-cmthru bKKzdz sc-iuJeZd hHelJB"
-      >
-        Requesting Appeal
       </div>
       <br />
       <div
@@ -247,6 +247,64 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
                   >
                     &lt;
                     AwaitingApprovalStatusLabel
+                  </span>
+                  <span />
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    /&gt;
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "paddingLeft": 33,
+                      "paddingRight": 3,
+                    }
+                  }
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    &lt;
+                    br
+                  </span>
+                  <span />
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    /&gt;
+                  </span>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "paddingLeft": 33,
+                      "paddingRight": 3,
+                    }
+                  }
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    &lt;
+                    AwaitingAppealRequestLabel
                   </span>
                   <span />
                   <span
@@ -536,64 +594,6 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
                     }
                   >
                     &lt;
-                    RequestingAppealStatusLabel
-                  </span>
-                  <span />
-                  <span
-                    style={
-                      Object {
-                        "color": "#444",
-                      }
-                    }
-                  >
-                    /&gt;
-                  </span>
-                </div>
-                <div
-                  style={
-                    Object {
-                      "paddingLeft": 33,
-                      "paddingRight": 3,
-                    }
-                  }
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#444",
-                      }
-                    }
-                  >
-                    &lt;
-                    br
-                  </span>
-                  <span />
-                  <span
-                    style={
-                      Object {
-                        "color": "#444",
-                      }
-                    }
-                  >
-                    /&gt;
-                  </span>
-                </div>
-                <div
-                  style={
-                    Object {
-                      "paddingLeft": 33,
-                      "paddingRight": 3,
-                    }
-                  }
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#444",
-                      }
-                    }
-                  >
-                    &lt;
                     ReadyToCompleteStatusLabel
                   </span>
                   <span />
@@ -691,6 +691,22 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
               }
             >
               "
+              AwaitingAppealRequestLabel
+              " Component
+            </h3>
+            <small>
+              No propTypes defined!
+            </small>
+          </div>
+          <div>
+            <h3
+              style={
+                Object {
+                  "margin": "20px 0 0 0",
+                }
+              }
+            >
+              "
               AwaitingApprovalStatusLabel
               " Component
             </h3>
@@ -756,22 +772,6 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
             >
               "
               ReadyToCompleteStatusLabel
-              " Component
-            </h3>
-            <small>
-              No propTypes defined!
-            </small>
-          </div>
-          <div>
-            <h3
-              style={
-                Object {
-                  "margin": "20px 0 0 0",
-                }
-              }
-            >
-              "
-              RequestingAppealStatusLabel
               " Component
             </h3>
             <small>


### PR DESCRIPTION
Issue #1216 

This update also DRYs up the rendering of these labels a bit, as well as adds the missing 'Awaiting Request to Appeal' label to the Listing Detail page header.