### PR TITLE
add logout route

### DIFF
--- a/packages/components/src/Tokens/buy/UniswapBuy.tsx
+++ b/packages/components/src/Tokens/buy/UniswapBuy.tsx
@@ -12,7 +12,7 @@ export interface UniswapBuyProps {
 }
 export class UniswapBuy extends React.Component<UniswapBuyProps, any> {
   public static contextType: React.Context<ICivilContext> = CivilContext;
-  private isMounted = true;
+  private isComponentMounted = true;
   constructor(props: UniswapBuyProps) {
     super(props);
     this.state = {};
@@ -27,7 +27,7 @@ export class UniswapBuy extends React.Component<UniswapBuyProps, any> {
   }
 
   public componentWillUnmount(): void {
-    this.isMounted = false;
+    this.isComponentMounted = false;
   }
 
   public render(): JSX.Element {
@@ -74,7 +74,7 @@ export class UniswapBuy extends React.Component<UniswapBuyProps, any> {
     const weiToSpend = uniswap.parseEther(this.props.ethToSpend.toString());
     const result = await uniswap.quoteETHToCVL(weiToSpend);
 
-    if (this.isMounted) {
+    if (this.isComponentMounted) {
       this.setState({ cvlToReceive: result });
     }
   }

--- a/packages/dapp/src/components/Auth/AuthLogout.tsx
+++ b/packages/dapp/src/components/Auth/AuthLogout.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Redirect } from "react-router";
+
+import { clearApolloSession } from "@joincivil/utils";
+
+export const AuthLogout = () => {
+  const [loggedOut, setLoggedOut] = React.useState(false);
+  React.useEffect(() => {
+    setTimeout(() => {
+      clearApolloSession();
+      setLoggedOut(true);
+    }, 500);
+  }, []);
+
+  return loggedOut ? <Redirect to="/" /> : <div>Logging out...</div>;
+};

--- a/packages/dapp/src/components/Auth/index.tsx
+++ b/packages/dapp/src/components/Auth/index.tsx
@@ -3,6 +3,7 @@ import { Route, Switch, RouteComponentProps } from "react-router-dom";
 import { AuthenticatedRoute } from "@joincivil/components";
 import { AuthEthConnected } from "./Eth";
 import { AuthLogin } from "./Login";
+import { AuthLogout } from "./AuthLogout";
 import { AuthSignup } from "./Signup";
 import { AuthCheckEmail } from "./CheckEmail";
 import { AuthVerifyToken } from "./VerifyToken";
@@ -43,6 +44,7 @@ export class AuthRouter extends React.Component<RouteComponentProps> {
         <Switch>
           {/* TODO(jorgelo): Add a 404 */}
           {/* Login Routes */}
+          <Route path={`/auth/logout`} exact component={AuthLogout} />
 
           {/* Add Wallet */}
           <AuthenticatedRoute


### PR DESCRIPTION
This isn't actually accessible except via URL, but can at least serve as a stop gap if people ask about it. That being said, we should do this properly in an upcoming sprint.


note: this also fixes an error I was seeing with the uniswap buy screen complaining that isMounted has no setter - I think react was setting this properly under the hood.