### PR TITLE
Fix buggy logic for when to skip grant step [CIVIL-751]

### DIFF
--- a/packages/newsroom-signup/src/NewsroomProfile/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/index.tsx
@@ -18,6 +18,7 @@ export interface NewsroomProfileProps {
   charter: Partial<CharterData>;
   grantRequested?: boolean;
   waitingOnGrant?: boolean;
+  completedGrantFlow?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
   navigate(go: 1 | -1): void;
 }
@@ -61,7 +62,7 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
         return false;
       },
       () => {
-        return this.props.waitingOnGrant || typeof this.props.grantRequested !== "boolean";
+        return !this.props.completedGrantFlow;
       },
     ];
 


### PR DESCRIPTION
Buggy logic was "skip the grant step if the user is not waiting for grant approval", but new users who haven't even selected whether they
want to apply for grant approval or not are of course "not waiting for grant approval" so we erroneously skipped that step for them.

Similar logic is (correctly) used elsewhere so I've codified this into a dedicated variable `completedGrantFlow` to make it clearer.