### PR TITLE
Fix issue where user w/ locked/not installed MetaMask sees incorrect UI based on user challenge data

### DIFF
--- a/packages/components/src/DAppMessageContent/styledComponents.tsx
+++ b/packages/components/src/DAppMessageContent/styledComponents.tsx
@@ -44,7 +44,7 @@ export const MetaMaskIcon = styled<MetaMaskIconProps>(MetaMaskSideIcon)`
   top: 3px;
 `;
 
-export const StyledLargeModalText = styled.p`
+export const StyledLargeModalText = styled.div`
   color: ${colors.accent.CIVIL_GRAY_0};
   font-size: 18px;
   line-height: 24px;

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -167,6 +167,10 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps> {
     };
 
     if (this.props.useGraphQL) {
+      if (!this.props.user) {
+        return this.renderAllStages(renderState, {});
+      }
+
       return (
         <Query
           query={USER_CHALLENGE_DATA_QUERY}
@@ -227,6 +231,8 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps> {
     const canShowRewardsForm = didUserCommit(userChallengeData) && this.props.challenge.resolved;
     const canShowAppealChallengeRewardsFrom =
       didUserCommit(userAppealChallengeData) && this.props.challenge.appeal!.appealChallenge!.resolved;
+
+    console.log(inCommitPhase, userChallengeData);
 
     return (
       <>

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -232,8 +232,6 @@ class ChallengeDetail extends React.Component<ChallengeDetailProps> {
     const canShowAppealChallengeRewardsFrom =
       didUserCommit(userAppealChallengeData) && this.props.challenge.appeal!.appealChallenge!.resolved;
 
-    console.log(inCommitPhase, userChallengeData);
-
     return (
       <>
         {inCommitPhase && this.renderCommitStage(userChallengeData)}


### PR DESCRIPTION
- Check if user's EthAddress is available before requesting user challenge data from GraphQL

- Fix nested `<p>` elements issue with DApp Error Message component