### PR TITLE
Various Appeal related UI fixes for the DApp

### DIFF
--- a/packages/components/src/ApplicationPhaseStatusLabels.tsx
+++ b/packages/components/src/ApplicationPhaseStatusLabels.tsx
@@ -47,7 +47,7 @@ export const AwaitingAppealRequestLabel: React.FunctionComponent = props => {
 };
 
 export const AwaitingDecisionStatusLabel: React.FunctionComponent = props => {
-  return <StyledAwaitingStatuslabel>Awaiting Decision</StyledAwaitingStatuslabel>;
+  return <StyledAwaitingStatuslabel>Awaiting Council Decision</StyledAwaitingStatuslabel>;
 };
 
 export const AwaitingAppealChallengeStatusLabel: React.FunctionComponent = props => {

--- a/packages/components/src/ListingSummary/AppealJudgementBanner.tsx
+++ b/packages/components/src/ListingSummary/AppealJudgementBanner.tsx
@@ -8,35 +8,49 @@ import {
 } from "./styledComponents";
 
 const AppealDecisionBanner: React.FunctionComponent<ListingSummaryComponentProps> = props => {
-  const { appeal, appealRequested, appealGranted, didChallengeOriginallySucceed } = props;
-  if (!appeal && !appealRequested) {
+  const {
+    appeal,
+    appealGranted,
+    doesChallengeHaveAppeal,
+    isAwaitingAppealJudgement,
+    didChallengeOriginallySucceed,
+  } = props;
+  if (!doesChallengeHaveAppeal && !isAwaitingAppealJudgement) {
     return <></>;
   }
 
-  let decisionText;
-  if ((appeal && appeal.appealGranted) || appealGranted) {
-    if (didChallengeOriginallySucceed) {
-      // Challenge succeeded (newsroom rejected) and appeal was granted, so newsroom is accepted
-      decisionText = (
-        <StyledBaseResultsBanner>
-          <HollowGreenCheck /> Appeal granted to accept Newsroom
-        </StyledBaseResultsBanner>
-      );
-      // Challenge failed (newsroom accepted) and appeal was granted, so newsroom is rejected
-      //
-    } else {
-      decisionText = (
-        <StyledRejectedResultsBanner>
-          <HollowRedNoGood /> Appeal granted to reject Newsroom
-        </StyledRejectedResultsBanner>
-      );
-    }
-  } else {
+  let decisionText = <></>;
+  if (isAwaitingAppealJudgement) {
     decisionText = (
       <StyledNotGrantedResultsBanner>
-        <HollowGrayNotGranted /> Appeal requested but not granted
+        <HollowGrayNotGranted /> Appeal requested
       </StyledNotGrantedResultsBanner>
     );
+  } else if (appeal) {
+    if (appeal.appealGranted || appealGranted) {
+      if (didChallengeOriginallySucceed) {
+        // Challenge succeeded (newsroom rejected) and appeal was granted, so newsroom is accepted
+        decisionText = (
+          <StyledBaseResultsBanner>
+            <HollowGreenCheck /> Appeal granted to accept Newsroom
+          </StyledBaseResultsBanner>
+        );
+        // Challenge failed (newsroom accepted) and appeal was granted, so newsroom is rejected
+        //
+      } else {
+        decisionText = (
+          <StyledRejectedResultsBanner>
+            <HollowRedNoGood /> Appeal granted to reject Newsroom
+          </StyledRejectedResultsBanner>
+        );
+      }
+    } else {
+      decisionText = (
+        <StyledNotGrantedResultsBanner>
+          <HollowGrayNotGranted /> Appeal requested but not granted
+        </StyledNotGrantedResultsBanner>
+      );
+    }
   }
 
   return decisionText;

--- a/packages/components/src/ListingSummary/ListingSummaryRejected.tsx
+++ b/packages/components/src/ListingSummary/ListingSummaryRejected.tsx
@@ -11,9 +11,9 @@ import AppealJudgementBanner from "./AppealJudgementBanner";
 export const ListingSummaryRejectedComponent: React.FunctionComponent<
   ListingSummaryComponentProps & ChallengeResultsProps
 > = props => {
-  const { appeal, appealRequested } = props;
+  const { doesChallengeHaveAppeal, isAwaitingAppealJudgement } = props;
 
-  const hasTopPadding = !appeal && !appealRequested;
+  const hasTopPadding = !doesChallengeHaveAppeal && !isAwaitingAppealJudgement;
   return (
     <ListingSummaryBase {...props}>
       <StyledListingSummary hasTopPadding={hasTopPadding}>

--- a/packages/components/src/ListingSummary/ListingSummaryUnderChallenge.tsx
+++ b/packages/components/src/ListingSummary/ListingSummaryUnderChallenge.tsx
@@ -20,9 +20,9 @@ export interface ListingSummaryUnderChallengeComponentProps
 export const ListingSummaryUnderChallengeComponent: React.FunctionComponent<
   ListingSummaryUnderChallengeComponentProps
 > = props => {
-  const { appeal, appealRequested } = props;
+  const { doesChallengeHaveAppeal, isAwaitingAppealJudgement } = props;
 
-  const hasTopPadding = !appeal && !appealRequested;
+  const hasTopPadding = !doesChallengeHaveAppeal && !isAwaitingAppealJudgement;
 
   return (
     <ListingSummaryBase {...props}>

--- a/packages/components/src/ListingSummary/types.ts
+++ b/packages/components/src/ListingSummary/types.ts
@@ -10,6 +10,7 @@ export interface ListingChallengeStatusProps {
   didChallengeSucceed?: boolean;
   didChallengeOriginallySucceed?: boolean;
   canResolveChallenge?: boolean;
+  doesChallengeHaveAppeal?: boolean;
   isAwaitingAppealJudgement?: boolean;
   isAwaitingAppealChallenge?: boolean;
   canListingAppealBeResolved?: boolean;

--- a/packages/components/src/__snapshots__/ApplicationPhaseStatusLabels.stories.storyshot
+++ b/packages/components/src/__snapshots__/ApplicationPhaseStatusLabels.stories.storyshot
@@ -28,7 +28,7 @@ exports[`Storyshots Registry / Application Status Labels Labels 1`] = `
       <div
         className="sc-hMFtBS ggAFsy sc-cmthru kMUvlH"
       >
-        Awaiting Decision
+        Awaiting Council Decision
       </div>
       <br />
       <div

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -156,6 +156,7 @@ const RejectedListing: React.FunctionComponent<ListingListItemOwnProps & Listing
     const ListingSummaryRejected = compose<React.ComponentClass<ListingContainerProps & {}>>(
       connectLatestChallengeSucceededResults,
     )(ListingSummaryRejectedComponent);
+    // console.log(listingViewProps, props);
     return <ListingSummaryRejected {...listingViewProps} />;
   } else {
     const challengeResultsProps = getChallengeResultsProps(data.prevChallenge!);

--- a/packages/dapp/src/components/listinglist/ListingListItem.tsx
+++ b/packages/dapp/src/components/listinglist/ListingListItem.tsx
@@ -156,7 +156,6 @@ const RejectedListing: React.FunctionComponent<ListingListItemOwnProps & Listing
     const ListingSummaryRejected = compose<React.ComponentClass<ListingContainerProps & {}>>(
       connectLatestChallengeSucceededResults,
     )(ListingSummaryRejectedComponent);
-    // console.log(listingViewProps, props);
     return <ListingSummaryRejected {...listingViewProps} />;
   } else {
     const challengeResultsProps = getChallengeResultsProps(data.prevChallenge!);

--- a/packages/dapp/src/helpers/transforms.ts
+++ b/packages/dapp/src/helpers/transforms.ts
@@ -5,6 +5,8 @@ import {
   didChallengeSucceed as getDidChallengeSucceed,
   didAppealChallengeSucceed as getDidAppealChallengeSucceed,
   didChallengeOriginallySucceed as getDidChallengeOriginallySucceed,
+  doesChallengeHaveAppeal as getDoesChallengeHaveAppeal,
+  isAppealAwaitingJudgment,
 } from "@joincivil/core";
 import { ChallengeResultsProps } from "@joincivil/components";
 
@@ -46,11 +48,15 @@ export const getChallengeResultsProps = (challengeData: ChallengeData): Challeng
   const baseChallengeResults = getBaseChallengeResults(challengeData);
   const didChallengeSucceed = getDidChallengeSucceed(challengeData);
   const didChallengeOriginallySucceed = getDidChallengeOriginallySucceed(challengeData);
+  const doesChallengeHaveAppeal = getDoesChallengeHaveAppeal(challengeData);
+  const isAwaitingAppealJudgement = challengeData.appeal && isAppealAwaitingJudgment(challengeData.appeal);
 
   return {
     ...(baseChallengeResults as ChallengeResultsProps),
     didChallengeSucceed,
     didChallengeOriginallySucceed,
+    doesChallengeHaveAppeal,
+    isAwaitingAppealJudgement,
   };
 };
 

--- a/packages/dapp/src/selectors/index.ts
+++ b/packages/dapp/src/selectors/index.ts
@@ -868,6 +868,7 @@ export const getChallengeState = (challengeData: WrappedChallengeData) => {
   const inRevealPhase = challenge && isChallengeInRevealStage(challenge);
   const canResolveChallenge = challenge && getCanResolveChallenge(challenge);
   const canRequestAppeal = challenge && getCanRequestAppeal(challenge);
+  const doesChallengeHaveAppeal = challenge && getDoesChallengeHaveAppeal(challenge);
   const isAwaitingAppealJudgement = challenge && challenge.appeal && isAppealAwaitingJudgment(challenge.appeal);
   const canAppealBeResolved = challenge && challenge.appeal && getCanAppealBeResolved(challenge.appeal);
   const isAwaitingAppealChallenge = challenge && challenge.appeal && getIsAwaitingAppealChallenge(challenge.appeal);
@@ -890,6 +891,7 @@ export const getChallengeState = (challengeData: WrappedChallengeData) => {
     canAppealBeResolved,
     didChallengeSucceed,
     didChallengeOriginallySucceed,
+    doesChallengeHaveAppeal,
     isAppealChallengeInCommitStage,
     isAppealChallengeInRevealStage,
   };


### PR DESCRIPTION
- Fix issue where in commit/reveal phase displayed "Appeal Requested" banner on Registry Homepage when Web3 is enabled
- Fix appeal banner on summary cards on Registry Homepage to properly support
awaiting appeal judgement status
- Update text for awaiting appeal judgement status banner on summary
cards and application status label