### PR TITLE
Fix missing Appeal Granted URL on Submit Appeal Challenge ballot card

### DIFF
--- a/packages/dapp/src/components/listing/AppealResolve.tsx
+++ b/packages/dapp/src/components/listing/AppealResolve.tsx
@@ -67,15 +67,17 @@ const transactionStatusModalConfig = {
 class AppealResolve extends React.Component<AppealDetailProps & InjectedTransactionStatusModalProps> {
   public render(): JSX.Element {
     const transactions = this.getTransactions();
-    const appealGranted = this.props.appeal.appealGranted;
+    const { appeal, challengeID, onMobileTransactionClick } = this.props;
+    const appealGranted = appeal.appealGranted;
+    const appealGrantedStatementURI = appeal.appealGrantedStatementURI;
     return (
       <>
         <AppealResolveCard
-          challengeID={this.props.challengeID.toString()}
+          challengeID={challengeID.toString()}
           appealGranted={appealGranted}
-          appealGrantedStatementURI={this.props.appeal.appealGrantedStatementURI}
+          appealGrantedStatementURI={appealGrantedStatementURI}
           transactions={transactions}
-          onMobileTransactionClick={this.props.onMobileTransactionClick}
+          onMobileTransactionClick={onMobileTransactionClick}
           faqURL={links.FAQ_HOW_TO_UPDATE_NEWSROOM_STATUS}
         />
       </>

--- a/packages/dapp/src/components/listing/AppealSubmitChallenge.tsx
+++ b/packages/dapp/src/components/listing/AppealSubmitChallenge.tsx
@@ -35,6 +35,7 @@ class AppealSubmitChallenge extends React.Component<AppealDetailProps> {
     const appealGranted = appeal.appealGranted;
     const endTime = appeal.appealOpenToChallengeExpiry.toNumber();
     const phaseLength = this.props.parameters.challengeAppealLen;
+    const appealGrantedStatementURI = appeal.appealGrantedStatementURI;
 
     const submitAppealChallengeURI = formatRoute(routes.SUBMIT_APPEAL_CHALLENGE, {
       listingAddress: this.props.listingAddress,
@@ -45,6 +46,7 @@ class AppealSubmitChallenge extends React.Component<AppealDetailProps> {
         endTime={endTime}
         phaseLength={phaseLength}
         challengeID={this.props.challengeID.toString()}
+        appealGrantedStatementURI={appealGrantedStatementURI}
         appealGranted={appealGranted}
         submitAppealChallengeURI={submitAppealChallengeURI}
         faqURL={links.FAQ_COMMUNITY_VETTING_PROCESS}


### PR DESCRIPTION
- Add missing `appealGrantedStatementURI` prop to Submit Appeal Challenge card
- Minor code cleanup