### PR TITLE
Additional update to fix broken Appeal Granted Statement URL

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeCommitVoteCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeCommitVoteCard.tsx
@@ -107,7 +107,7 @@ export class AppealChallengeCommitVoteCard extends React.Component<
 
               <AppealDecisionDetail
                 appealGranted={this.props.appealGranted}
-                appealGrantedStatementUri={this.props.appealGrantedStatementURI}
+                appealGrantedStatementURI={this.props.appealGrantedStatementURI}
               />
 
               <StyledListingDetailPhaseCardSection bgAccentColor="COMMIT_VOTE">

--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeResolveCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeResolveCard.tsx
@@ -71,7 +71,7 @@ export const AppealChallengeResolveCard: React.FunctionComponent<AppealChallenge
 
       <AppealDecisionDetail
         appealGranted={props.appealGranted}
-        appealGrantedStatementUri={props.appealGrantedStatementURI}
+        appealGrantedStatementURI={props.appealGrantedStatementURI}
       />
 
       {showAppealChallenge && (

--- a/packages/components/src/ListingDetailPhaseCard/AppealChallengeRevealVoteCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealChallengeRevealVoteCard.tsx
@@ -111,7 +111,7 @@ export class AppealChallengeRevealVoteCard extends React.Component<
 
               <AppealDecisionDetail
                 appealGranted={this.props.appealGranted}
-                appealGrantedStatementUri={this.props.appealGrantedStatementURI}
+                appealGrantedStatementURI={this.props.appealGrantedStatementURI}
               />
 
               <StyledListingDetailPhaseCardSection bgAccentColor="REVEAL_VOTE">

--- a/packages/components/src/ListingDetailPhaseCard/AppealDecisionCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealDecisionCard.tsx
@@ -90,7 +90,7 @@ export const AppealDecisionCard: React.FunctionComponent<
 
       <AppealDecisionDetail
         appealGranted={props.appealGranted}
-        appealGrantedStatementUri={props.appealGrantedStatementURI}
+        appealGrantedStatementURI={props.appealGrantedStatementURI}
       />
 
       <StyledListingDetailPhaseCardSection>

--- a/packages/components/src/ListingDetailPhaseCard/AppealDecisionDetail.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealDecisionDetail.tsx
@@ -12,7 +12,7 @@ export interface AppealDecisionDetailProps {
   appealGranted?: boolean;
   collapsable?: boolean;
   open?: boolean;
-  appealGrantedStatementUri?: string;
+  appealGrantedStatementURI?: string;
 }
 
 const StyledInner = styled.div`
@@ -29,7 +29,7 @@ const AppealDecisionDetailInner: React.FunctionComponent<AppealDecisionDetailPro
       </FormCopy>
 
       {props.appealGranted && (
-        <InvertedButton href={props.appealGrantedStatementUri} size={buttonSizes.MEDIUM_WIDE}>
+        <InvertedButton href={props.appealGrantedStatementURI} size={buttonSizes.MEDIUM_WIDE}>
           Read about this decision
         </InvertedButton>
       )}

--- a/packages/components/src/ListingDetailPhaseCard/AppealResolveCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/AppealResolveCard.tsx
@@ -48,7 +48,7 @@ export const AppealResolveCard: React.FunctionComponent<
 
       <AppealDecisionDetail
         appealGranted={props.appealGranted}
-        appealGrantedStatementUri={props.appealGrantedStatementURI}
+        appealGrantedStatementURI={props.appealGrantedStatementURI}
       />
 
       <StyledListingDetailPhaseCardSection>

--- a/packages/dapp/src/helpers/queryTransformations.ts
+++ b/packages/dapp/src/helpers/queryTransformations.ts
@@ -239,7 +239,7 @@ export function transformGraphQLDataIntoAppeal(queryAppealData: any): AppealData
       appealChallengeID: new BigNumber(queryAppealData.appealChallengeID),
       appealChallenge: transformGraphQLDataIntoAppealChallenge(queryAppealData.appealChallenge),
       appealStatementURI: queryAppealData.statement,
-      appealGrantedStatementURI: queryAppealData.appealGranted,
+      appealGrantedStatementURI: queryAppealData.appealGrantedStatementURI,
     };
   } else {
     return undefined;


### PR DESCRIPTION
- Fix case issue with `appealGrantedStatementURI` prop
- Fix issue where GraphQL response transform function was setting the wrong value for `appeealGrantedStatementUri`