### PR TITLE
Standalone create boost page [CIVIL-793]

### DIFF
--- a/packages/components/src/imageUrls.ts
+++ b/packages/components/src/imageUrls.ts
@@ -7,6 +7,7 @@ import * as metaMaskSignImgUrl from "./images/img-metamask-sign@2x.png";
 import * as applicationSavedImgUrl from "./images/img-application-saved@2x.png";
 import * as applicationSubmittedImgUrl from "./images/img-application-submitted@2x.png";
 import * as grantSubmittedImgUrl from "./images/img-grant-submitted@2x.png";
+import * as defaultNewsroomImgUrl from "./images/img-default-newsroom@2x.png";
 
 export {
   metaMaskNetworkSwitchImgUrl,
@@ -17,4 +18,5 @@ export {
   applicationSavedImgUrl,
   applicationSubmittedImgUrl,
   grantSubmittedImgUrl,
+  defaultNewsroomImgUrl,
 };

--- a/packages/components/src/styleConstants.ts
+++ b/packages/components/src/styleConstants.ts
@@ -30,6 +30,7 @@ export const colors = {
     CIVIL_ORANGE: "#FFA716",
     CIVIL_GREEN: "#0D9D33",
     CIVIL_GREEN_1: "#29cb42",
+    CIVIL_PURPLE: "#9013FE",
   },
   basic: {
     WHITE: "#FFFFFF",

--- a/packages/dapp/src/components/Boosts/BoostCreate.tsx
+++ b/packages/dapp/src/components/Boosts/BoostCreate.tsx
@@ -1,0 +1,151 @@
+import * as React from "react";
+import { connect, DispatchProp } from "react-redux";
+import { formatRoute } from "react-router-named-routes";
+import { compose, withApollo, WithApolloClient } from "react-apollo";
+import { Helmet } from "react-helmet";
+import gql from "graphql-tag";
+import { Set } from "immutable";
+
+import { NewsroomState } from "@joincivil/newsroom-signup";
+import { CharterData, EthAddress } from "@joincivil/core";
+import { BoostForm } from "@joincivil/civil-sdk";
+import { FeatureFlag } from "@joincivil/components";
+
+import { routes } from "../../constants";
+import { State } from "../../redux/reducers";
+import ScrollToTopOnMount from "../utility/ScrollToTop";
+import LoadingMsg from "../utility/LoadingMsg";
+import ErrorLoadingDataMsg from "../utility/ErrorLoadingData";
+import { addUserNewsroom, getContent } from "../../redux/actionCreators/newsrooms";
+import { fetchAndAddListingData } from "../../redux/actionCreators/listings";
+import { ComingSoonText } from "./BoostStyledComponents";
+
+const NEWSROOMS_QUERY = gql`
+  query {
+    nrsignupNewsroom {
+      newsroomAddress
+    }
+  }
+`;
+
+export interface BoostCreatePageProps {
+  currentUserNewsrooms: Set<string>;
+  useGraphQL: boolean;
+  newsroom?: NewsroomState;
+  charter?: CharterData;
+}
+
+export interface BoostCreatePageState {
+  newsroomAddress?: EthAddress;
+  gqlLoading?: boolean;
+  gqlError?: any;
+}
+
+class BoostCreatePage extends React.Component<
+  WithApolloClient<BoostCreatePageProps & DispatchProp<any>>,
+  BoostCreatePageState
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = {};
+  }
+
+  public async componentDidUpdate(): Promise<void> {
+    await this.fetchNewsroomData();
+  }
+
+  public async componentDidMount(): Promise<void> {
+    await this.fetchNewsroomAddress();
+    await this.fetchNewsroomData();
+  }
+
+  public render(): JSX.Element {
+    return (
+      <>
+        <Helmet title="Launch Boost - The Civil Registry" />
+        <ScrollToTopOnMount />
+        <FeatureFlag feature={"boosts-mvp"} replacement={<ComingSoonText />}>
+          {this.renderCreateBoost()}
+        </FeatureFlag>
+      </>
+    );
+  }
+
+  private renderCreateBoost(): JSX.Element {
+    if (this.state.gqlLoading || !this.props.newsroom || !this.props.charter) {
+      return <LoadingMsg />;
+    }
+    if (this.state.gqlError) {
+      return <ErrorLoadingDataMsg />;
+    }
+
+    const { newsroom, charter } = this.props;
+    const listingRoute = formatRoute(routes.LISTING, { listingAddress: newsroom.address });
+    return (
+      <BoostForm
+        newsroomAddress={newsroom.address}
+        newsroomName={charter.name}
+        newsroomListingUrl={`${document.location.origin}${listingRoute}`}
+        newsroomWallet={newsroom.wrapper.data.owners[0]}
+        newsroomUrl={charter && charter.newsroomUrl}
+        newsroomTagline={charter && charter.tagline}
+        newsroomLogoUrl={charter && charter.logoUrl}
+      />
+    );
+  }
+
+  private async fetchNewsroomAddress(): Promise<void> {
+    if (this.props.useGraphQL && this.props.currentUserNewsrooms.isEmpty()) {
+      this.setState({
+        gqlLoading: true,
+      });
+      try {
+        const result = (await this.props.client.query({
+          query: NEWSROOMS_QUERY,
+        })) as any;
+        if (!result || !result.data || !result.data.nrsignupNewsroom || !result.data.nrsignupNewsroom.newsroomAddress) {
+          // @TODO/tobek No newsroom: tell user to make one
+        }
+        this.setState({
+          gqlLoading: false,
+          newsroomAddress: result.data.nrsignupNewsroom.newsroomAddress,
+        });
+        this.props.dispatch!(addUserNewsroom(result.data.nrsignupNewsroom.newsroomAddress));
+      } catch (e) {
+        this.setState({
+          gqlError: e,
+        });
+      }
+    }
+  }
+
+  private async fetchNewsroomData(): Promise<void> {
+    if (!this.props.newsroom && this.props.currentUserNewsrooms.first()) {
+      this.props.dispatch!(fetchAndAddListingData(this.props.currentUserNewsrooms.first()));
+    }
+    if (this.props.newsroom && !this.props.charter) {
+      this.props.dispatch!(await getContent(this.props.newsroom.wrapper.data.charterHeader!));
+    }
+  }
+}
+
+const mapStateToProps = (state: State, ownProps: BoostCreatePageProps): BoostCreatePageProps => {
+  const { currentUserNewsrooms, content } = state.networkDependent;
+  const { useGraphQL, newsrooms } = state;
+  const newsroom = currentUserNewsrooms.first() ? newsrooms.get(currentUserNewsrooms.first()) : undefined;
+  let charter;
+  if (newsroom && newsroom.wrapper.data.charterHeader) {
+    charter = content.get(newsroom.wrapper.data.charterHeader.uri) as CharterData;
+  }
+
+  // @TODO/tobek Also load listing data so we can check if newsroom is whitelisted
+  return {
+    ...ownProps,
+    useGraphQL,
+    currentUserNewsrooms,
+    newsroom,
+    charter,
+  };
+};
+
+export default compose(withApollo, connect(mapStateToProps))(BoostCreatePage);

--- a/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
@@ -136,7 +136,7 @@ class ActivityListItemComponent extends React.Component<
             <p>Accepted into Registry</p>
           </>
         );
-      } else if (!isRejected && !isInApplication && !isUnderChallenge) {
+      } else if (isRejected && !isInApplication && !isUnderChallenge) {
         return (
           <>
             <p>Rejected from Registry</p>

--- a/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
@@ -3,7 +3,6 @@ import { connect, DispatchProp } from "react-redux";
 import { Link } from "react-router-dom";
 import { formatRoute } from "react-router-named-routes";
 import BigNumber from "bignumber.js";
-import { BoostForm } from "@joincivil/civil-sdk";
 import { ListingWrapper, WrappedChallengeData, UserChallengeData, CharterData } from "@joincivil/core";
 import { NewsroomState } from "@joincivil/newsroom-signup";
 import { DashboardActivityItem, PHASE_TYPE_NAMES, FeatureFlag } from "@joincivil/components";
@@ -75,7 +74,7 @@ class ActivityListItemComponent extends React.Component<
   }
 
   public render(): JSX.Element {
-    const { listingAddress: address, listing, newsroom, listingPhaseState, charter } = this.props;
+    const { listingAddress: address, listing, newsroom, listingPhaseState, charter, userChallengeData } = this.props;
     if (listing && listing.data && newsroom && listingPhaseState) {
       const newsroomData = newsroom.wrapper.data;
       let listingDetailURL = `/listing/${address}`;
@@ -90,7 +89,7 @@ class ActivityListItemComponent extends React.Component<
         buttonText: buttonTextTuple[0],
         buttonHelperText: buttonTextTuple[1],
         challengeID: this.props.challengeID,
-        salt: this.props.userChallengeData && this.props.userChallengeData.salt,
+        salt: userChallengeData && userChallengeData.salt,
         toggleSelect: this.props.toggleSelect,
       };
 
@@ -98,18 +97,12 @@ class ActivityListItemComponent extends React.Component<
         <DashboardActivityItem {...props}>
           {this.renderActivityDetails()}
 
-          <FeatureFlag feature="boosts-mvp">
-            {/*@TODO/tobek Only show if user is owner of newsroom, only show if newsroom is on registry, etc.*/}
-            <BoostForm
-              loading={!charter}
-              newsroomAddress={newsroom.address}
-              newsroomName={newsroomData.name}
-              newsroomListingUrl={`${document.location.origin}/listing/${newsroom.address}`}
-              newsroomWallet={newsroom.wrapper.data.owners[0]}
-              newsroomUrl={charter && charter.newsroomUrl}
-              newsroomTagline={charter && charter.tagline}
-            />
-          </FeatureFlag>
+          {!userChallengeData &&
+            address && (
+              <FeatureFlag feature="boosts-mvp">
+                <Link to={routes.BOOST_CREATE}>Launch Boost</Link>
+              </FeatureFlag>
+            )}
         </DashboardActivityItem>
       );
     } else {

--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -44,6 +44,7 @@ const SignUpNewsroom = React.lazy(async () => import("./SignUpNewsroom"));
 const StorefrontPage = React.lazy(async () => import("./Tokens/StorefrontPage"));
 const DashboardPage = React.lazy(async () => import("./Dashboard/DashboardPage"));
 const BoostPage = React.lazy(async () => import("./Boosts/Boost"));
+const BoostCreatePage = React.lazy(async () => import("./Boosts/BoostCreate"));
 const BoostFeedPage = React.lazy(async () => import("./Boosts/BoostFeed"));
 
 function AsyncComponent(Component: React.LazyExoticComponent<any>): any {
@@ -188,6 +189,7 @@ class Main extends React.Component<MainReduxProps & DispatchProp<any> & RouteCom
             <Route path={routes.AUTH} component={AuthRouter} />>
             <Route path={routes.TOKEN_STOREFRONT} component={AsyncComponent(StorefrontPage)} />
             <Route path={routes.BOOST} component={AsyncComponent(BoostPage)} />
+            <Route path={routes.BOOST_CREATE} component={AsyncComponent(BoostCreatePage)} />
             <Route path={routes.BOOST_FEED} component={AsyncComponent(BoostFeedPage)} />
             {/* TODO(jorgelo): Better 404 */}
             <Route path="*" render={() => <h1>404</h1>} />

--- a/packages/dapp/src/constants.ts
+++ b/packages/dapp/src/constants.ts
@@ -19,6 +19,7 @@ export enum routes {
   AUTH = "/auth",
   TOKEN_STOREFRONT = "/tokens",
   BOOST_FEED = "/boosts",
+  BOOST_CREATE = "/launch-boost",
   BOOST = "/boosts/:boostId",
 }
 


### PR DESCRIPTION
A lot of boilerplate here to get user's newsroom and newsroom data and charter data but I don't think there's any more concise way to do it without abstracting some HOC or something.

@sruddy not sure if you've worked on fetching newsroom data for standalone boost page but it'll probably look something like this but getting newsroom address from channel ID instead of `currentUserNewsrooms`.