### PR TITLE
Create HelmetHelper component for easier og meta and fb/twitter cards

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,6 +76,7 @@
     "react-async-script": "^1.0.0",
     "react-docgen-typescript-loader": "^3.1.0",
     "react-dropzone": "^10.1.4",
+    "react-helmet": "^5.2.0",
     "react-router-dom": "^4.3.1",
     "react-rte": "^0.16.1",
     "rxjs": "^5.5.6",

--- a/packages/components/src/HelmetHelper.tsx
+++ b/packages/components/src/HelmetHelper.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { Helmet } from "react-helmet";
+
+export interface HelmetHelperProps {
+  title?: string;
+  description?: string;
+  image?: string;
+  meta?: { [key: string]: string };
+}
+
+export const HelmetHelper: React.FunctionComponent<HelmetHelperProps> = props => {
+  const meta: { [key: string]: string | undefined } = {
+    "og:title": props.title,
+    "twitter:title": props.title,
+    "og:description": props.description,
+    "twitter:description": props.description,
+    "og:image": props.image,
+    "twitter:image": props.image,
+    ...props.meta,
+  };
+
+  return (
+    <Helmet title={props.title}>
+      {Object.keys(meta).map(
+        metaName => meta[metaName] && <meta key={metaName} property={metaName} content={meta[metaName]} />,
+      )}
+    </Helmet>
+  );
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -68,3 +68,4 @@ export * from "./CurrencyConverter";
 export * from "./GasEstimate";
 export * from "./features";
 export * from "./CopyToClipboard";
+export * from "./HelmetHelper";

--- a/packages/components/src/types.d.ts
+++ b/packages/components/src/types.d.ts
@@ -2,6 +2,7 @@ declare module "@storybook/addon-storyshots";
 declare module "storybook-react-router";
 declare module "react-rte";
 declare module "react-add-to-calendar";
+declare module "react-helmet";
 declare module "*.png";
 declare module "*.svg";
 declare module "apollo-storybook-react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -18287,7 +18287,7 @@ style-loader@0.23.1, style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-styled-components@3.2.5, styled-components@^3.2.3, styled-components@^3.2.5:
+styled-components@^3.2.3, styled-components@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.2.5.tgz#b5d5d7d618ab240ff10602b5ca5886b8db3d0a0d"
   integrity sha1-tdXX1hirJA/xBgK1yliGuNs9Cg0=


### PR DESCRIPTION
Right now just using these for boosts, but would be good to update our use of `Helmet` elsewhere in the dapp at some point to add images and descriptions. Example invocation: https://github.com/joincivil/civil-sdk/blob/35ed473ced5c7de2d06a08d081d8b136130af19d/src/react/boosts/BoostCard.tsx#L42-L51