### PR TITLE
Adds Boost to listings tab

### DIFF
--- a/packages/dapp/src/components/listing/ListingBoosts.tsx
+++ b/packages/dapp/src/components/listing/ListingBoosts.tsx
@@ -3,6 +3,8 @@ import { connect } from "react-redux";
 import { State } from "../../redux/reducers";
 import { ListingTabIntro } from "./styledComponents";
 import { BoostFeed } from "@joincivil/civil-sdk";
+import { FeatureFlag } from "@joincivil/components";
+import { ComingSoonText } from "../Boosts/BoostStyledComponents";
 
 export interface ListingBoostsProps {
   listingAddress: string;
@@ -13,7 +15,7 @@ class ListingBoosts extends React.Component<ListingBoostsProps> {
     const search = { postType: "boost", channelID: this.props.listingAddress };
 
     return (
-      <>
+      <FeatureFlag feature={"boosts-mvp"} replacement={<ComingSoonText />}>
         <ListingTabIntro>
           Boosts are mini-fundraisers. Newsrooms can use them to let their audience know about what they would like to
           do, and let their fans help them do it. The best boosts are smallish and short-term, with a concrete
@@ -21,7 +23,7 @@ class ListingBoosts extends React.Component<ListingBoostsProps> {
           be. Good reporting costs money, and the Civil community wants to help make it happen.
         </ListingTabIntro>
         <BoostFeed search={search} />
-      </>
+      </FeatureFlag>
     );
   }
 }

--- a/packages/dapp/src/components/listing/ListingBoosts.tsx
+++ b/packages/dapp/src/components/listing/ListingBoosts.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import { connect } from "react-redux";
-import { State } from "../../redux/reducers";
 import { ListingTabIntro } from "./styledComponents";
 import { BoostFeed } from "@joincivil/civil-sdk";
 import { FeatureFlag } from "@joincivil/components";
+import { urlConstants } from "@joincivil/utils";
 import { ComingSoonText } from "../Boosts/BoostStyledComponents";
 
 export interface ListingBoostsProps {
@@ -17,10 +16,13 @@ class ListingBoosts extends React.Component<ListingBoostsProps> {
     return (
       <FeatureFlag feature={"boosts-mvp"} replacement={<ComingSoonText />}>
         <ListingTabIntro>
-          Boosts are mini-fundraisers. Newsrooms can use them to let their audience know about what they would like to
-          do, and let their fans help them do it. The best boosts are smallish and short-term, with a concrete
-          description of what the newsroom wants to accomplish, what the costs are, and exactly what the outcome will
-          be. Good reporting costs money, and the Civil community wants to help make it happen.
+          Newsrooms around the world need your help to fund and start new projects. These Newsrooms are setting up
+          Boosts to help in get the word out with what they want to do and let their supporters and fans, like you, help
+          them do it. Support these newsrooms by funding their Boosts to help hit their goals. Good reporting costs
+          money, and the Civil community is making it happen.{" "}
+          <a href={urlConstants.FAQ_BOOSTS} target="_blank">
+            Learn More &gt;
+          </a>
         </ListingTabIntro>
         <BoostFeed search={search} />
       </FeatureFlag>
@@ -28,10 +30,4 @@ class ListingBoosts extends React.Component<ListingBoostsProps> {
   }
 }
 
-const mapToStateToProps = (state: State, ownProps: ListingBoostsProps) => {
-  return {
-    ...ownProps,
-  };
-};
-
-export default connect(mapToStateToProps)(ListingBoosts);
+export default ListingBoosts;

--- a/packages/dapp/src/components/listing/ListingBoosts.tsx
+++ b/packages/dapp/src/components/listing/ListingBoosts.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { connect } from "react-redux";
+import { State } from "../../redux/reducers";
+import { ListingTabIntro } from "./styledComponents";
+import { BoostFeed } from "@joincivil/civil-sdk";
+
+export interface ListingBoostsProps {
+  listingAddress: string;
+}
+
+class ListingBoosts extends React.Component<ListingBoostsProps> {
+  public render(): JSX.Element {
+    const search = { postType: "boost", channelID: this.props.listingAddress };
+
+    return (
+      <>
+        <ListingTabIntro>
+          Boosts are mini-fundraisers. Newsrooms can use them to let their audience know about what they would like to
+          do, and let their fans help them do it. The best boosts are smallish and short-term, with a concrete
+          description of what the newsroom wants to accomplish, what the costs are, and exactly what the outcome will
+          be. Good reporting costs money, and the Civil community wants to help make it happen.
+        </ListingTabIntro>
+        <BoostFeed search={search} />
+      </>
+    );
+  }
+}
+
+const mapToStateToProps = (state: State, ownProps: ListingBoostsProps) => {
+  return {
+    ...ownProps,
+  };
+};
+
+export default connect(mapToStateToProps)(ListingBoosts);

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -22,6 +22,7 @@ import EmailSignup from "./EmailSignup";
 import ListingOwnerActions from "./ListingOwnerActions";
 import ListingDiscourse from "./ListingDiscourse";
 import ListingHistory from "./ListingHistory";
+import ListingBoosts from "./ListingBoosts";
 import ListingHeader from "./ListingHeader";
 import ListingCharter from "./ListingCharter";
 import ListingPhaseActions from "./ListingPhaseActions";
@@ -169,6 +170,12 @@ class ListingPageComponent extends React.Component<
               <Tab title="History">
                 <ListingTabContent>
                   <ListingHistory listingAddress={this.props.listingAddress} />
+                </ListingTabContent>
+              </Tab>
+
+              <Tab title="Boosts">
+                <ListingTabContent>
+                  <ListingBoosts listingAddress={this.props.listingAddress} />
                 </ListingTabContent>
               </Tab>
 

--- a/packages/dapp/src/components/listing/styledComponents.tsx
+++ b/packages/dapp/src/components/listing/styledComponents.tsx
@@ -28,3 +28,10 @@ export const ListingTabContent = styled.div`
     line-height: inherit;
   }
 `;
+
+export const ListingTabIntro = styled.p`
+  font-size: 18px;
+  line-height: 33px;
+  margin: 0 0 40px;
+  width: 635px;
+`;

--- a/packages/dapp/src/components/listing/styledComponents.tsx
+++ b/packages/dapp/src/components/listing/styledComponents.tsx
@@ -33,5 +33,4 @@ export const ListingTabIntro = styled.p`
   font-size: 18px;
   line-height: 33px;
   margin: 0 0 40px;
-  width: 635px;
 `;


### PR DESCRIPTION
I added a feature flag to the boost but I can't add it to the tab without breaking tabs. If we don't want Boost in the tab with a coming soon message we can wait on this.