### PR TITLE
exit listing

### DIFF
--- a/packages/core/src/civil.ts
+++ b/packages/core/src/civil.ts
@@ -23,6 +23,7 @@ import { CivilTCR } from "./contracts/tcr/civilTCR";
 import { Council } from "./contracts/tcr/council";
 import { ContentData, StorageHeader } from "./types";
 import { createTwoStepSimple } from "./contracts/utils/contracts";
+import { CVLToken } from "./contracts/tcr/cvltoken";
 
 // See debug in npm, you can use `localStorage.debug = "civil:*" to enable logging
 const debug = Debug("civil:main");
@@ -210,6 +211,10 @@ export class Civil {
 
   public async councilSingletonTrusted(): Promise<Council> {
     return Council.singleton(this.ethApi);
+  }
+
+  public async cvlTokenSingletonTrusted(multisigAddress?: EthAddress): Promise<CVLToken> {
+    return CVLToken.singletonTrusted(this.ethApi, multisigAddress);
   }
 
   /**

--- a/packages/dapp/src/apis/civilTCR.ts
+++ b/packages/dapp/src/apis/civilTCR.ts
@@ -161,6 +161,12 @@ export async function exitListing(address: EthAddress, multisigAddress?: EthAddr
   return tcr.exitListing(address);
 }
 
+export async function withdrawTokensFromMultisig(multisigAddress?: EthAddress): Promise<TwoStepEthTransaction> {
+  const civil = getCivil();
+  const token = await civil.cvlTokenSingletonTrusted(multisigAddress);
+  return token.transferToSelf(ensureWeb3BigNumber(await token.getBalance(multisigAddress)));
+}
+
 export async function updateStatus(address: EthAddress): Promise<TwoStepEthTransaction> {
   const civil = getCivil();
   const tcr = await civil.tcrSingletonTrusted();


### PR DESCRIPTION
- update listing owner actions so exit listing also withdraws tokens to user wallet after exiting listing transaction
- updates needed to `ownerAddresses` in graphql newsroom query (otherwise need to disable graphql to see owner actions)