### PR TITLE
exit listing improvements

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/WithdrawnCard.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/WithdrawnCard.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { getLocalDateTimeStrings } from "@joincivil/utils";
+import { ListingDetailPhaseCardComponentProps } from "./types";
+import {
+  StyledListingDetailPhaseCardContainer,
+  StyledListingDetailPhaseCardSection,
+  StyledPhaseDisplayName,
+  MetaItemValue,
+  MetaItemLabel,
+} from "./styledComponents";
+import { WithdrawnNewroomDisplayNameText, WithdrawnNewsroomsToolTipText } from "./textComponents";
+import { QuestionToolTip } from "../QuestionToolTip";
+
+export interface WithdrawnCardProps {
+  listingRemovedTimestamp?: number;
+}
+
+export type WithdrawnCardAllProps = ListingDetailPhaseCardComponentProps & WithdrawnCardProps;
+
+export const WithdrawnCard: React.FunctionComponent<WithdrawnCardAllProps> = props => {
+  let displayDateTime;
+  if (props.listingRemovedTimestamp) {
+    const listingRemovedDateTime = getLocalDateTimeStrings(props.listingRemovedTimestamp);
+    displayDateTime = `${listingRemovedDateTime[0]} ${listingRemovedDateTime[1]}`;
+  }
+
+  return (
+    <StyledListingDetailPhaseCardContainer>
+      <StyledListingDetailPhaseCardSection>
+        <StyledPhaseDisplayName>
+          <WithdrawnNewroomDisplayNameText />
+          <QuestionToolTip explainerText={<WithdrawnNewsroomsToolTipText />} positionBottom={true} />
+        </StyledPhaseDisplayName>
+        <MetaItemLabel>Withdrawn date</MetaItemLabel>
+        <MetaItemValue>{displayDateTime}</MetaItemValue>
+      </StyledListingDetailPhaseCardSection>
+    </StyledListingDetailPhaseCardContainer>
+  );
+};

--- a/packages/components/src/ListingDetailPhaseCard/index.ts
+++ b/packages/components/src/ListingDetailPhaseCard/index.ts
@@ -12,5 +12,6 @@ export * from "./AppealChallengeRevealVoteCard";
 export * from "./AppealChallengeResolveCard";
 export * from "./WhitelistedCard";
 export * from "./RejectedCard";
+export * from "./WithdrawnCard";
 export * from "./CompleteChallengeResults";
 export * from "./types";

--- a/packages/components/src/ListingDetailPhaseCard/textComponents.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/textComponents.tsx
@@ -143,6 +143,8 @@ export const NewApplicationDisplayNameText: React.FunctionComponent = props => <
 
 export const RejectedNewroomDisplayNameText: React.FunctionComponent = props => <>Rejected Newsroom</>;
 
+export const WithdrawnNewroomDisplayNameText: React.FunctionComponent = props => <>Withdrawn Newsroom</>;
+
 export const WhitelistedNewroomsDisplayNameText: React.FunctionComponent = props => <>Approved Newsroom</>;
 
 // Tooltips
@@ -208,6 +210,15 @@ export const RejectedNewsroomsToolTipText: React.FunctionComponent = props => {
         Constitution.
       </p>
       <p>Rejected Newsrooms may reapply to the Civil Registry at any time.</p>
+    </>
+  );
+};
+
+export const WithdrawnNewsroomsToolTipText: React.FunctionComponent = props => {
+  return (
+    <>
+      <p>This Newsroom has been withdrawn from the registry by its owner.</p>
+      <p>Withdrawn Newsrooms may reapply to the Civil Registry at any time.</p>
     </>
   );
 };

--- a/packages/components/src/ListingHistoryEvent/constants.ts
+++ b/packages/components/src/ListingHistoryEvent/constants.ts
@@ -5,11 +5,11 @@ export enum ListingEventTitles {
   CHALLENGE = "Newsroom Challenged",
   CHALLENGE_FAILED = "Challenge Failed",
   CHALLENGE_SUCCEEDED = "Challenge Succeeded",
-  REJECTED = "Newsroom Rejected from Civil Registry",
+  REJECTED = "Newsroom Removed from Civil Registry",
   WHITELISTED = "Newsroom Whitelisted to Civil Registry",
   DEPOSIT = "Newsroom Deposited CVL to Listing",
   WITHDRAWAL = "Newsroom Withdrew CVL from Listing",
-  LISTING_WITHDRAWN = "Listing Withdrawn from Civil Registry",
+  LISTING_WITHDRAWN = "Listing Withdrawn from Civil Registry by owner",
   TOUCH_AND_REMOVED = "Listing Removed from Civil Registry",
   GRANTED_APPEAL_CHALLENGED = "The Appeal Granted by the Council has been Challenged",
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -149,6 +149,8 @@ export interface ListingData {
   prevChallengeID?: BigNumber;
   prevChallenge?: ChallengeData;
   approvalDate?: BigNumber;
+  lastGovState?: string;
+  lastUpdatedDate?: BigNumber;
 }
 
 export interface PollData {

--- a/packages/dapp/src/components/listing/ListingOwnerActions.tsx
+++ b/packages/dapp/src/components/listing/ListingOwnerActions.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { EthAddress, ListingWrapper, TwoStepEthTransaction, TxHash } from "@joincivil/core";
-import { TransactionButton, CommitVoteSuccessIcon, ModalUnorderedList, ModalListItem } from "@joincivil/components";
+import { TransactionButton } from "@joincivil/components";
 import { exitListing, withdrawTokensFromMultisig } from "../../apis/civilTCR";
 import { ViewModuleHeader } from "../utility/ViewModules";
 import { hasTransactionStatusModals, InjectedTransactionStatusModalProps } from "../utility/TransactionStatusModalsHOC";

--- a/packages/dapp/src/components/listing/ListingOwnerActions.tsx
+++ b/packages/dapp/src/components/listing/ListingOwnerActions.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
-import { EthAddress, ListingWrapper, TwoStepEthTransaction } from "@joincivil/core";
-import { TransactionButton } from "@joincivil/components";
+import { EthAddress, ListingWrapper, TwoStepEthTransaction, TxHash } from "@joincivil/core";
+import { TransactionButton, CommitVoteSuccessIcon, ModalUnorderedList, ModalListItem } from "@joincivil/components";
 import { exitListing, withdrawTokensFromMultisig } from "../../apis/civilTCR";
 import { ViewModuleHeader } from "../utility/ViewModules";
+import { hasTransactionStatusModals, InjectedTransactionStatusModalProps } from "../utility/TransactionStatusModalsHOC";
+import { ModalContent } from "@joincivil/components/build/ReviewVote/styledComponents";
+import { compose } from "redux";
 
 export interface ListingOwnerActionsProps {
   listing: ListingWrapper;
@@ -13,7 +16,74 @@ export interface OwnerListingViewProps {
   listing: ListingWrapper;
 }
 
-class ExitListing extends React.Component<OwnerListingViewProps> {
+enum TransactionTypes {
+  EXIT_LISTING = "EXIT_LISTING",
+  WITHDRAW_TOKENS = "WITHDRAW_TOKENS",
+}
+
+const transactionLabels = {
+  [TransactionTypes.EXIT_LISTING]: "Withdraw from Registry",
+  [TransactionTypes.WITHDRAW_TOKENS]: "Withdraw CVL from Newsroom Wallet",
+};
+
+const multiStepTransactionLabels = {
+  [TransactionTypes.EXIT_LISTING]: "1 of 2",
+  [TransactionTypes.WITHDRAW_TOKENS]: "2 of 2",
+};
+
+const transactionSuccessContent = {
+  [TransactionTypes.EXIT_LISTING]: [undefined, undefined],
+  [TransactionTypes.WITHDRAW_TOKENS]: [
+    <>
+      <div>Your newsroom has exited the registry</div>
+    </>,
+    <>
+      <ModalContent>
+        Your newsroom has exited from the registry and your CVL tokens have been withdrawn to your personal wallet.
+      </ModalContent>
+    </>,
+  ],
+};
+
+const transactionRejectionContent = {
+  [TransactionTypes.EXIT_LISTING]: [
+    "Your newsroom has not exited the registry",
+    "To exit the registry, you need to confirm the transaction in your MetaMask wallet",
+  ],
+  [TransactionTypes.WITHDRAW_TOKENS]: [
+    "Your tokens have not been withdrawn",
+    "To withdraw your tokens, you need to confirm the transaction in your MetaMask wallet.",
+  ],
+};
+
+const transactionErrorContent = {
+  [TransactionTypes.EXIT_LISTING]: [
+    "The was an problem with exiting the registry",
+    <>
+      <ModalContent>
+        Please retry your transaction. You can contact Customer Support if you continue to have issues.
+      </ModalContent>
+    </>,
+  ],
+  [TransactionTypes.WITHDRAW_TOKENS]: [
+    "The was an problem with withdrawing your tokens",
+    <>
+      <ModalContent>
+        Please retry your transaction. You can contact Customer Support if you continue to have issues.
+      </ModalContent>
+    </>,
+  ],
+};
+
+const transactionStatusModalConfig = {
+  transactionLabels,
+  multiStepTransactionLabels,
+  transactionSuccessContent,
+  transactionRejectionContent,
+  transactionErrorContent,
+};
+
+class ExitListing extends React.Component<OwnerListingViewProps & InjectedTransactionStatusModalProps> {
   constructor(props: any) {
     super(props);
   }
@@ -21,7 +91,51 @@ class ExitListing extends React.Component<OwnerListingViewProps> {
   public render(): JSX.Element {
     return (
       <TransactionButton
-        transactions={[{ transaction: this.exitListing }, { transaction: this.withdrawTokensFromMultisig }]}
+        transactions={[
+          {
+            transaction: async () => {
+              this.props.updateTransactionStatusModalsState({
+                isWaitingTransactionModalOpen: true,
+                isTransactionProgressModalOpen: false,
+                isTransactionSuccessModalOpen: false,
+                transactionType: TransactionTypes.EXIT_LISTING,
+              });
+              return this.exitListing();
+            },
+            handleTransactionHash: (txHash: TxHash) => {
+              this.props.updateTransactionStatusModalsState({
+                isWaitingTransactionModalOpen: false,
+                isTransactionProgressModalOpen: true,
+              });
+            },
+            handleTransactionError: this.props.handleTransactionError,
+          },
+          {
+            transaction: async () => {
+              this.props.updateTransactionStatusModalsState({
+                isWaitingTransactionModalOpen: true,
+                isTransactionProgressModalOpen: false,
+                isTransactionSuccessModalOpen: false,
+                transactionType: TransactionTypes.WITHDRAW_TOKENS,
+              });
+              return this.withdrawTokensFromMultisig();
+            },
+            handleTransactionHash: (txHash: TxHash) => {
+              this.props.updateTransactionStatusModalsState({
+                isWaitingTransactionModalOpen: false,
+                isTransactionProgressModalOpen: true,
+              });
+            },
+            postTransaction: () => {
+              this.props.updateTransactionStatusModalsState({
+                isWaitingTransactionModalOpen: false,
+                isTransactionProgressModalOpen: false,
+                isTransactionSuccessModalOpen: true,
+              });
+            },
+            handleTransactionError: this.props.handleTransactionError,
+          },
+        ]}
       >
         Exit Listing
       </TransactionButton>
@@ -37,7 +151,7 @@ class ExitListing extends React.Component<OwnerListingViewProps> {
   };
 }
 
-export default class ListingOwnerActions extends React.Component<ListingOwnerActionsProps> {
+class ListingOwnerActions extends React.Component<ListingOwnerActionsProps & InjectedTransactionStatusModalProps> {
   public render(): JSX.Element {
     const canExitListing = this.props.listing.data.isWhitelisted && !this.props.listing.data.challenge;
     return (
@@ -51,10 +165,14 @@ export default class ListingOwnerActions extends React.Component<ListingOwnerAct
               below. If you choose to rejoin the registry, you will have to re-apply. There will be 2 transactions to
               complete this action.{" "}
             </p>
-            <ExitListing listingAddress={this.props.listing.address} listing={this.props.listing} />
+            <ExitListing listingAddress={this.props.listing.address} {...this.props} />
           </>
         )}
       </>
     );
   }
 }
+
+export default compose<React.ComponentClass<ListingOwnerActionsProps>>(
+  hasTransactionStatusModals(transactionStatusModalConfig),
+)(ListingOwnerActions);

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -129,6 +129,7 @@ class ListingPageComponent extends React.Component<
               newsroom={this.props.newsroom!}
               expiry={this.props.expiry}
               listingPhaseState={this.props.listingPhaseState}
+              listingLastGovState={this.props.listing!.data.lastGovState}
               parameters={this.props.parameters}
               govtParameters={this.props.govtParameters}
               constitutionURI={links.CONSTITUTION}

--- a/packages/dapp/src/helpers/queryTransformations.ts
+++ b/packages/dapp/src/helpers/queryTransformations.ts
@@ -70,6 +70,7 @@ export const LISTING_FRAGMENT = gql`
     contractAddress
     whitelisted
     lastGovState
+    lastUpdatedDate
     charter {
       uri
       contentID
@@ -218,6 +219,8 @@ export function transformGraphQLDataIntoListing(listing: any, listingAddress: st
       prevChallengeID: transformGraphQLDataIntoPrevChallengeID(listing.prevChallenge),
       prevChallenge: transformGraphQLDataIntoChallenge(listing.prevChallenge),
       approvalDate: listing.approvalDate ? new BigNumber(listing.approvalDate) : new BigNumber(0),
+      lastGovState: listing.lastGovState,
+      lastUpdatedDate: listing.lastUpdatedDate ? new BigNumber(listing.lastUpdatedDate) : new BigNumber(0),
     },
   };
 }


### PR DESCRIPTION
- better transaction modals
- better rendering of withdrawn listing
part of this is kind of hacky because of handling both graphql and web3 loading. I decided to just only care about rendering it correctly with graphql since we're trying to deprecate web3 loading anyways and it would've been too complicated