### PR TITLE
fix withdraw tokens owner action

### DIFF
--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -283,10 +283,12 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
    */
   public async getNewsroomData(): Promise<NewsroomData> {
     const name = await this.getName();
+    const owner = await this.instance.owner.callAsync();
     const owners = await this.owners();
     const charterHeader = await this.getCharterHeader();
     return {
       name,
+      owner,
       owners,
       charterHeader,
     };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,6 +127,7 @@ export interface NewsroomWrapper {
 
 export interface NewsroomData {
   name: string;
+  owner: EthAddress;
   owners: EthAddress[];
   charterHeader?: EthContentHeader;
 }

--- a/packages/dapp/src/components/listing/ListingPhaseActions.tsx
+++ b/packages/dapp/src/components/listing/ListingPhaseActions.tsx
@@ -23,6 +23,7 @@ import { routes } from "../../constants";
 import { ListingContainerProps, connectLatestChallengeSucceededResults } from "../utility/HigherOrderComponents";
 import ApplicationUpdateStatus from "./ApplicationUpdateStatus";
 import WhitelistedDetail from "./WhitelistedDetail";
+import BigNumber from "bignumber.js";
 
 const StyledContainer = styled.div`
   margin: 0 0 80px;
@@ -130,19 +131,21 @@ class ListingPhaseActions extends React.Component<ListingPhaseActionsProps, List
   }
 
   private renderWithdrawn(): JSX.Element {
-    const lastUpdatedDate = new Date(this.props.listing.data.lastUpdatedDate.mul(1000).toNumber());
-    return <WithdrawnCard listingRemovedTimestamp={lastUpdatedDate} />;
+    const lastUpdatedDate = this.props.listing.data.lastUpdatedDate;
+    const lastUpdatedDateAsDate = lastUpdatedDate ? new Date(lastUpdatedDate.mul(1000).toNumber()) : new BigNumber(0);
+    return <WithdrawnCard listingRemovedTimestamp={lastUpdatedDateAsDate} />;
   }
 
   private renderRejected(): JSX.Element {
     const data = this.props.listing.data;
-    const lastUpdatedDate = new Date(this.props.listing.data.lastUpdatedDate.mul(1000).toNumber());
+    const lastUpdatedDate = this.props.listing.data.lastUpdatedDate;
+    const lastUpdatedDateAsDate = lastUpdatedDate ? new Date(lastUpdatedDate.mul(1000).toNumber()) : new BigNumber(0);
     if (!data.prevChallenge) {
       const RejectedCard = compose<React.ComponentClass<ListingContainerProps & {}>>(
         connectLatestChallengeSucceededResults,
       )(RejectedCardComponent);
 
-      return <RejectedCard listingAddress={this.props.listing.address} listingRemovedDate={lastUpdatedDate} />;
+      return <RejectedCard listingAddress={this.props.listing.address} listingRemovedDate={lastUpdatedDateAsDate} />;
     } else {
       const challengeResultsProps = getChallengeResultsProps(data.prevChallenge!) as ChallengeResultsProps;
       let appealChallengeResultsProps;
@@ -172,7 +175,7 @@ class ListingPhaseActions extends React.Component<ListingPhaseActionsProps, List
           {...appealProps}
           {...appealChallengeResultsProps}
           {...appealChallengePhaseProps}
-          listingRemovedDate={lastUpdatedDate}
+          listingRemovedDate={lastUpdatedDateAsDate}
         />
       );
     }

--- a/packages/dapp/src/components/listing/ListingRedux.tsx
+++ b/packages/dapp/src/components/listing/ListingRedux.tsx
@@ -184,7 +184,7 @@ class ListingPageComponent extends React.Component<
                 this.props.listing && (
                   <Tab title="Owner Actions">
                     <ListingTabContent>
-                      <ListingOwnerActions listing={this.props.listing} />
+                      <ListingOwnerActions listing={this.props.listing} newsroom={this.props.newsroom!} />
                     </ListingTabContent>
                   </Tab>
                 )) || <></>}


### PR DESCRIPTION
Separate exit listing & withdraw into 2 buttons. fix withdraw transaction to use newsroom owner instead of listing owner since listing owner is zeroed out once first transaction completes