### PR TITLE
channel page

### DIFF
--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -4,7 +4,7 @@
   "homepage": "/",
   "private": false,
   "dependencies": {
-    "@joincivil/civil-sdk": "^1.16.10",
+    "@joincivil/civil-sdk": "^1.16.11",
     "@joincivil/components": "^1.9.7",
     "@joincivil/core": "^4.8.8",
     "@joincivil/ethapi": "^0.4.8",

--- a/packages/dapp/src/components/Dashboard/ChannelAdmin/ChannelAdminPage.tsx
+++ b/packages/dapp/src/components/Dashboard/ChannelAdmin/ChannelAdminPage.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { ManageNewsroom } from "./newsroom/ManageNewsroom";
+import styled from "styled-components";
+
+const ChannelAdminPage = (props: any) => {
+  const channelID = props.match.params.reference;
+  return (
+    <div>
+      <ManageNewsroom channelID={channelID} />
+    </div>
+  );
+};
+
+export default ChannelAdminPage;

--- a/packages/dapp/src/components/Dashboard/ChannelAdmin/newsroom/ManageNewsroom.tsx
+++ b/packages/dapp/src/components/Dashboard/ChannelAdmin/newsroom/ManageNewsroom.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import gql from "graphql-tag";
+import { Query } from "react-apollo";
+import { BoostForm } from "@joincivil/civil-sdk";
+import { Tabs, StyledTabLarge, StyledTabNav, Tab } from "@joincivil/components";
+
+const ManageQuery = gql`
+  query($id: String!) {
+    channelsGetByID(id: $id) {
+      id
+      newsroom {
+        contractAddress
+        multisigAddress
+        charter {
+          name
+          newsroomUrl
+          tagline
+          logoUrl
+        }
+      }
+    }
+  }
+`;
+
+export const ManageNewsroom = (props: any) => {
+  const variables = {
+    id: props.channelID,
+  };
+
+  return (
+    <Query query={ManageQuery} variables={variables}>
+      {({ loading, data, error }) => {
+        if (loading) {
+          return null;
+        }
+        if (error) {
+          return <div>error</div>;
+        }
+
+        const newsroom = data.channelsGetByID.newsroom;
+
+        const listingRoute = "#fixme";
+
+        const charter = data.channelsGetByID.newsroom.charter;
+
+        return (
+          <div>
+            <Tabs TabsNavComponent={StyledTabNav} TabComponent={StyledTabLarge}>
+              <Tab title={"Home"}>Home</Tab>
+              <Tab title={"Launch Boost"}>
+                <BoostForm
+                  channelID={data.channelsGetByID.id}
+                  newsroomData={{
+                    name: charter.name,
+                    url: charter && charter.newsroomUrl,
+                    owner: newsroom.multisigAddress,
+                  }}
+                  newsroomContractAddress={newsroom.contractAddress}
+                  newsroomAddress={newsroom.contractAddress}
+                  newsroomListingUrl={`${document.location.origin}${listingRoute}`}
+                  newsroomTagline={charter && charter.tagline}
+                  newsroomLogoUrl={charter && charter.logoUrl}
+                />
+              </Tab>
+            </Tabs>
+          </div>
+        );
+      }}
+    </Query>
+  );
+};

--- a/packages/dapp/src/components/Dashboard/ChannelAdminList/index.tsx
+++ b/packages/dapp/src/components/Dashboard/ChannelAdminList/index.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import { Query } from "react-apollo";
+import { colors, Button, buttonSizes } from "@joincivil/components";
+import gql from "graphql-tag";
+
+const channelMemberQuery = gql`
+  query {
+    currentUser {
+      uid
+      channels {
+        role
+        channel {
+          id
+          newsroom {
+            contractAddress
+            name
+            charter {
+              logoUrl
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ChannelListItem = styled.div`
+  padding: 5px 10px;
+  display: flex;
+  flex-direction: row;
+  a:first-child {
+    flex-grow: 1;
+    color: ${colors.accent.CIVIL_GRAY_1};
+    font-size: 16px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+  a > img {
+    height: 30px;
+    width: 30px;
+    margin: 4px;
+  }
+`;
+
+export const ChannelAdminList = (props: any) => {
+  if (props.channels && props.channels.length === 0) {
+    return null;
+  }
+  return (
+    <Query query={channelMemberQuery}>
+      {({ error, loading, data }) => {
+        if (error) {
+          return <div>error...</div>;
+        }
+        if (loading) {
+          return <></>;
+        }
+        return data.currentUser.channels.map((channelMember: any) => {
+          const link = `/admin/${channelMember.channel.id}`;
+          const newsroom = channelMember.channel.newsroom;
+          return (
+            <ChannelListItem key={channelMember.channel.id}>
+              <Link to={link}>
+                <img src={channelMember.channel.newsroom.charter.logoUrl} />
+                {newsroom.name}
+              </Link>
+              <Button to={link} size={buttonSizes.SMALL}>
+                Manage
+              </Button>
+            </ChannelListItem>
+          );
+        });
+      }}
+    </Query>
+  );
+};

--- a/packages/dapp/src/components/Dashboard/NewsroomsList.tsx
+++ b/packages/dapp/src/components/Dashboard/NewsroomsList.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Set, Map } from "immutable";
 import NewsroomsListItem from "./NewsroomsListItem";
+import { ChannelAdminList } from "./ChannelAdminList";
+import { FeatureFlag } from "@joincivil/components";
 
 export interface NewsroomsListOwnProps {
   listings?: Set<string>;
@@ -19,6 +21,9 @@ const NewsroomsList: React.FunctionComponent<NewsroomsListOwnProps> = props => {
           }
           return <NewsroomsListItem key={l} listingAddress={l!} applicationProgressData={applicationProgressData} />;
         })}
+      <FeatureFlag feature="newsroom-channels">
+        <ChannelAdminList />
+      </FeatureFlag>
     </>
   );
 };

--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -46,6 +46,7 @@ const DashboardPage = React.lazy(async () => import("./Dashboard/DashboardPage")
 const BoostPage = React.lazy(async () => import("./Boosts/Boost"));
 const BoostCreatePage = React.lazy(async () => import("./Boosts/BoostCreate"));
 const BoostFeedPage = React.lazy(async () => import("./Boosts/BoostFeed"));
+const ChannelAdminPage = React.lazy(async () => import("./Dashboard/ChannelAdmin/ChannelAdminPage"));
 
 function AsyncComponent(Component: React.LazyExoticComponent<any>, extraProps?: any): any {
   return (props: any) => (
@@ -186,6 +187,7 @@ class Main extends React.Component<MainReduxProps & DispatchProp<any> & RouteCom
               })}
             />
             <Route path={routes.DASHBOARD} component={AsyncComponent(DashboardPage)} />
+            <Route path={routes.CHANNEL_ADMIN} component={AsyncComponent(ChannelAdminPage)} />
             <Route path={routes.AUTH} component={AuthRouter} />>
             <Route path={routes.TOKEN_STOREFRONT} component={AsyncComponent(StorefrontPage)} />
             <Route path={routes.BOOST_EDIT} component={AsyncComponent(BoostPage, { editMode: true })} />

--- a/packages/dapp/src/constants.ts
+++ b/packages/dapp/src/constants.ts
@@ -25,6 +25,7 @@ export enum routes {
   BOOST = "/boosts/:boostId",
   BOOST_EDIT = "/boosts/:boostId/edit",
   BOOST_PAYMENT = "/boosts/:boostId/payment",
+  CHANNEL_ADMIN = "/admin/:reference",
 }
 
 export enum registryListingTypes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,9 +1766,10 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@joincivil/civil-sdk@^1.16.10":
-  version "1.16.10"
-  resolved "https://registry.yarnpkg.com/@joincivil/civil-sdk/-/civil-sdk-1.16.10.tgz#bf412413ccdf6184215bd5bedf5f0b202bd807fd"
+"@joincivil/civil-sdk@^1.16.11":
+  version "1.16.11"
+  resolved "https://registry.yarnpkg.com/@joincivil/civil-sdk/-/civil-sdk-1.16.11.tgz#d33cc0613c47effda432adf4b6a49818faf65f97"
+  integrity sha512-IWljec/3C79SQd1F9L3DhzRU103+OsBA5wClPpKugf/hYnW1stWnU2gXDC+2zq0jc0Kiik5k9eXzgLIM7iLHEQ==
   dependencies:
     "@babel/core" "7.2.2"
     "@commitlint/cli" "^7.5.2"


### PR DESCRIPTION
the UI for this can more or less be ignored, this is to just make every we have everything we need in graphql to create a boost from a channel that was created via fast-pass. Toby and I will work together to get this page fleshed out before we turn the feature flag on. 