### PR TITLE
Newsroom Manager update charter UI [CIVIL-994]

### DIFF
--- a/packages/components/src/LoadingIndicator.tsx
+++ b/packages/components/src/LoadingIndicator.tsx
@@ -3,6 +3,7 @@ import { colors } from "./styleConstants";
 
 export interface LoadingIndicatorProps {
   className?: string;
+  inline?: boolean;
   height?: string | number;
   width?: string | number;
 }
@@ -45,6 +46,7 @@ export const LoadingIndicator: React.FunctionComponent<LoadingIndicatorProps> = 
       height={height}
       fill={colors.accent.CIVIL_TEAL}
       className={props.className}
+      style={{ verticalAlign: props.inline ? "middle" : undefined }}
     >
       <circle transform={getCircleTranslate(0)} cx="0" cy={getCenterY()} r="0">
         <animate

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -14,6 +14,8 @@ export interface TabsProps {
   TabsNavComponent?: any;
   TabsNavBefore?: React.ReactElement;
   TabsNavAfter?: React.ReactElement;
+  /** Set to `true` to prevent tab change silently. If set to a string, on tab change attempt string will be passed to `window.confirm`: if user hits "cancel" tab change will be prevented. */
+  preventTabChange?: boolean | string;
   onActiveTabChange?(activeIndex: number): void;
 }
 
@@ -87,6 +89,13 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   }
 
   private handleClick = (index: number) => {
+    if (
+      this.props.preventTabChange &&
+      (this.props.preventTabChange === true || !window.confirm(this.props.preventTabChange))
+    ) {
+      return;
+    }
+
     this.setState({ activeIndex: index });
     if (this.props.onActiveTabChange) {
       this.props.onActiveTabChange(index);

--- a/packages/components/src/__snapshots__/LoadingIndicator.stories.storyshot
+++ b/packages/components/src/__snapshots__/LoadingIndicator.stories.storyshot
@@ -17,6 +17,11 @@ exports[`Storyshots Pattern Library / Loading / Loading Indicator Default Size (
         <svg
           fill="#30E8BD"
           height="32"
+          style={
+            Object {
+              "verticalAlign": undefined,
+            }
+          }
           viewBox="0 0 32 32"
           width="32"
           xmlns="http://www.w3.org/2000/svg"
@@ -394,6 +399,11 @@ exports[`Storyshots Pattern Library / Loading / Loading Indicator Prop-defined s
         <svg
           fill="#30E8BD"
           height="100"
+          style={
+            Object {
+              "verticalAlign": undefined,
+            }
+          }
           viewBox="0 0 100 100"
           width="100"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/src/__snapshots__/LoadingMessage.stories.storyshot
+++ b/packages/components/src/__snapshots__/LoadingMessage.stories.storyshot
@@ -19,6 +19,11 @@ exports[`Storyshots Pattern Library / Loading / Loading Message Default size (32
         <svg
           fill="#30E8BD"
           height="32"
+          style={
+            Object {
+              "verticalAlign": undefined,
+            }
+          }
           viewBox="0 0 32 32"
           width="32"
           xmlns="http://www.w3.org/2000/svg"
@@ -443,6 +448,11 @@ exports[`Storyshots Pattern Library / Loading / Loading Message Default size (32
         <svg
           fill="#30E8BD"
           height="32"
+          style={
+            Object {
+              "verticalAlign": undefined,
+            }
+          }
           viewBox="0 0 32 32"
           width="32"
           xmlns="http://www.w3.org/2000/svg"
@@ -827,6 +837,11 @@ exports[`Storyshots Pattern Library / Loading / Loading Message Prop-defined siz
         <svg
           fill="#30E8BD"
           height="100"
+          style={
+            Object {
+              "verticalAlign": undefined,
+            }
+          }
           viewBox="0 0 100 100"
           width="100"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/components/src/input/ImageFileToDataUri.tsx
+++ b/packages/components/src/input/ImageFileToDataUri.tsx
@@ -11,6 +11,7 @@ export interface ImageFileToDataUriState {
 
 export interface ImageFileToDataUriProps {
   onChange(dataUri: string): void;
+  buttonText?: string;
 }
 
 const DropArea = styled.div`
@@ -73,7 +74,7 @@ export class ImageFileToDataUri extends React.Component<ImageFileToDataUriProps,
       <>
         <InvertedButton size={buttonSizes.SMALL} onClick={() => this.setState({ modalOpen: true })}>
           {" "}
-          Add Image{" "}
+          {this.props.buttonText || "Add Image"}{" "}
         </InvertedButton>
         {this.renderModal()}
       </>

--- a/packages/components/src/input/ImageFileToDataUri.tsx
+++ b/packages/components/src/input/ImageFileToDataUri.tsx
@@ -10,8 +10,8 @@ export interface ImageFileToDataUriState {
 }
 
 export interface ImageFileToDataUriProps {
-  onChange(dataUri: string): void;
   buttonText?: string;
+  onChange(dataUri: string): void;
 }
 
 const DropArea = styled.div`

--- a/packages/dapp/.env
+++ b/packages/dapp/.env
@@ -8,5 +8,5 @@ REACT_APP_SENDGRID_REGISTRY_LIST_ID="5353193"
 REACT_APP_STRIPE_CLIENT_ID="ca_BzqgUsw7tnnCpVaoQ157mrxtuCdN7h2q"
 REACT_APP_STRIPE_API_KEY="pk_test_3a5qmy1MuBEcooDr5wL8bRz9"
 REACT_APP_INFURA_APP_KEY=""
-REACT_APP_FEATURE_FLAGS="uniswap,boosts-mvp,stripe-admin,boost-stripe"
+REACT_APP_FEATURE_FLAGS="uniswap,boosts-mvp,stripe-admin,boost-stripe,newsroom-channels"
 SKIP_PREFLIGHT_CHECK=true

--- a/packages/dapp/src/components/Boosts/BoostFeed.tsx
+++ b/packages/dapp/src/components/Boosts/BoostFeed.tsx
@@ -25,9 +25,9 @@ class BoostFeedPage extends React.Component {
               <h1>Boosts: support the work that journalists do.</h1>
               <BoostIntro>
                 Newsrooms around the world need your help to fund and start new projects. These Newsrooms are setting up
-                Boosts to help in get the word out with what they want to do and let their supporters and fans, like
-                you, help them do it. Support these newsrooms by funding their Boosts to help hit their goals. Good
-                reporting costs money, and the Civil community is making it happen.
+                Boosts to help get the word out about what they want to do and let their supporters and fans, like you,
+                help them do it. Support these newsrooms by funding their Boosts to help hit their goals. Good reporting
+                costs money, and the Civil community is making it happen.
                 <BoostLearnMore href={urlConstants.FAQ_BOOSTS} target="_blank">
                   Learn More &gt;
                 </BoostLearnMore>

--- a/packages/dapp/src/components/Dashboard/ChannelAdmin/newsroom/ManageNewsroom.tsx
+++ b/packages/dapp/src/components/Dashboard/ChannelAdmin/newsroom/ManageNewsroom.tsx
@@ -65,6 +65,8 @@ export const ManageNewsroom = (props: any) => {
     id: props.channelID,
   };
 
+  const [preventNav, setPreventNav] = React.useState<boolean | string>(false);
+
   return (
     <Query<ManageQueryData, ManageQueryVariables> query={ManageQuery} variables={variables}>
       {({ loading, data, error }) => {
@@ -90,9 +92,9 @@ export const ManageNewsroom = (props: any) => {
 
         return (
           <div>
-            <Tabs TabsNavComponent={StyledTabNav} TabComponent={StyledTabLarge}>
+            <Tabs TabsNavComponent={StyledTabNav} TabComponent={StyledTabLarge} preventTabChange={preventNav} onActiveTabChange={() => setPreventNav(false)}>
               <Tab title={"Home"}>
-                <NewsroomManager newsroomAddress={newsroom.contractAddress} publishedCharter={charter} />
+                <NewsroomManager newsroomAddress={newsroom.contractAddress} publishedCharter={charter} setPreventNav={setPreventNav} />
               </Tab>
               <Tab title={"Launch Boost"}>
                 <BoostForm

--- a/packages/dapp/src/components/Dashboard/ChannelAdmin/newsroom/ManageNewsroom.tsx
+++ b/packages/dapp/src/components/Dashboard/ChannelAdmin/newsroom/ManageNewsroom.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
 import { BoostForm } from "@joincivil/civil-sdk";
-import { Tabs, StyledTabLarge, StyledTabNav, Tab } from "@joincivil/components";
+import { EthAddress, CharterData } from "@joincivil/core";
+import { Tabs, StyledTabLarge, StyledTabNav, Tab, LoadingMessage } from "@joincivil/components";
+import { NewsroomManager } from "@joincivil/newsroom-signup";
 
 const ManageQuery = gql`
   query($id: String!) {
@@ -14,13 +16,49 @@ const ManageQuery = gql`
         charter {
           name
           newsroomUrl
-          tagline
           logoUrl
+          tagline
+          mission {
+            purpose
+            structure
+            revenue
+            encumbrances
+            miscellaneous
+          }
+          socialUrls {
+            twitter
+            facebook
+          }
+          roster {
+            name
+            role
+            bio
+            ethAddress
+            avatarUrl
+            signature
+            socialUrls {
+              twitter
+              facebook
+            }
+          }
         }
       }
     }
   }
 `;
+interface ManageQueryData {
+  channelsGetByID: {
+    id: string;
+    newsroom: {
+      contractAddress: EthAddress;
+      multisigAddress: EthAddress;
+      charter: Partial<CharterData>;
+    };
+  };
+}
+interface ManageQueryVariables {
+  id: string;
+}
 
 export const ManageNewsroom = (props: any) => {
   const variables = {
@@ -28,13 +66,20 @@ export const ManageNewsroom = (props: any) => {
   };
 
   return (
-    <Query query={ManageQuery} variables={variables}>
+    <Query<ManageQueryData, ManageQueryVariables> query={ManageQuery} variables={variables}>
       {({ loading, data, error }) => {
         if (loading) {
-          return null;
-        }
-        if (error) {
-          return <div>error</div>;
+          return <LoadingMessage>Loading your Newsroom</LoadingMessage>;
+        } else if (error) {
+          console.error("error querying channelsGetByID:", error);
+          return (
+            <div>
+              Error loading newsroom: <code>{error.message || JSON.stringify(error)}</code>
+            </div>
+          );
+        } else if (!data) {
+          console.error("error querying channelsGetByID: no data returned");
+          return <div>Error loading newsroom: no newsroom data returned</div>;
         }
 
         const newsroom = data.channelsGetByID.newsroom;
@@ -46,7 +91,9 @@ export const ManageNewsroom = (props: any) => {
         return (
           <div>
             <Tabs TabsNavComponent={StyledTabNav} TabComponent={StyledTabLarge}>
-              <Tab title={"Home"}>Home</Tab>
+              <Tab title={"Home"}>
+                <NewsroomManager newsroomAddress={newsroom.contractAddress} publishedCharter={charter} />
+              </Tab>
               <Tab title={"Launch Boost"}>
                 <BoostForm
                   channelID={data.channelsGetByID.id}

--- a/packages/newsroom-signup/src/ApplyToTCR/index.tsx
+++ b/packages/newsroom-signup/src/ApplyToTCR/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
 import { BigNumber } from "bignumber.js";
-import { Civil, EthAddress, ListingWrapper, isInApplicationPhase } from "@joincivil/core";
+import { Civil, EthAddress, ListingWrapper, isInApplicationPhase, NewsroomInstance } from "@joincivil/core";
 import { Parameters, getFormattedParameterValue } from "@joincivil/utils";
 import { NextBack } from "../styledComponents";
 import { getListing, getNewsroomMultisigBalance } from "../actionCreators";
@@ -10,7 +10,7 @@ import ApplyToTCRSuccess from "./ApplyToTCRSuccess";
 
 export interface ApplyToTCRStepOwnProps {
   address?: EthAddress;
-  newsroom: any;
+  newsroom: NewsroomInstance;
   civil?: Civil;
   navigate(go: 1 | -1): void;
 }
@@ -69,7 +69,9 @@ class ApplyToTCRStepComponent extends React.Component<TApplyToTCRStepProps & Dis
   private hydrateNewsroomMultisigBalance = async (): Promise<void> => {
     if (this.props.address && this.props.newsroom && this.props.civil) {
       const multisigAddress = await this.props.newsroom.getMultisigAddress();
-      await this.props.dispatch!(getNewsroomMultisigBalance(this.props.address, multisigAddress, this.props.civil));
+      if (multisigAddress) {
+        await this.props.dispatch!(getNewsroomMultisigBalance(this.props.address, multisigAddress, this.props.civil));
+      }
     }
   };
 

--- a/packages/newsroom-signup/src/Newsroom.tsx
+++ b/packages/newsroom-signup/src/Newsroom.tsx
@@ -8,10 +8,8 @@ import {
   StepNoButtons,
   WalletOnboardingV2,
   AuthApplicationEnum,
-  DEFAULT_BUTTON_THEME,
-  DEFAULT_CHECKBOX_THEME,
 } from "@joincivil/components";
-import { Civil, EthAddress, CharterData } from "@joincivil/core";
+import { Civil, EthAddress, CharterData, NewsroomInstance } from "@joincivil/core";
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
 import { debounce } from "lodash";
@@ -42,6 +40,7 @@ import { RepublishCharterNotice } from "./RepublishCharterNotice";
 import { ApplyToTCRStep as ApplyToTCR } from "./ApplyToTCR/index";
 import { StateWithNewsroom } from "./reducers";
 import { CmsUserData } from "./types";
+import { Wrapper, DEFAULT_THEME } from "./styledComponents";
 import { MutationFunc } from "react-apollo";
 
 enum SECTION {
@@ -128,7 +127,7 @@ export interface NewsroomExternalProps {
 export interface NewsroomReduxProps extends NewsroomExternalProps {
   charter: Partial<CharterData>;
   name?: string;
-  newsroom?: any;
+  newsroom?: NewsroomInstance;
   userIsOwner?: boolean;
   userIsEditor?: boolean;
   userNotOnContract?: boolean;
@@ -159,25 +158,13 @@ export const NoteSection: StyledComponentClass<any, "p"> = styled.p`
   color: ${(props: { disabled: boolean }) => (props.disabled ? "#dcdcdc" : colors.accent.CIVIL_GRAY_3)};
 `;
 
-export const Wrapper: StyledComponentClass<any, "div"> = styled.div`
-  max-width: 720px;
-  margin: auto;
-  font-size: 14px;
-`;
-
 const ErrorP = styled.p`
   color: ${colors.accent.CIVIL_RED};
 `;
 
 class NewsroomComponent extends React.Component<NewsroomProps, NewsroomComponentState> {
   public static defaultProps = {
-    theme: {
-      ...DEFAULT_BUTTON_THEME,
-      ...DEFAULT_CHECKBOX_THEME,
-      primaryButtonTextTransform: "none",
-      primaryButtonFontWeight: "bold",
-      borderlessButtonSize: "14px",
-    },
+    theme: DEFAULT_THEME,
   };
 
   public static getDerivedStateFromProps(
@@ -322,6 +309,7 @@ class NewsroomComponent extends React.Component<NewsroomProps, NewsroomComponent
         <NewsroomProfile
           profileWalletAddress={this.props.profileWalletAddress}
           currentStep={this.state.currentStep - SECTION_STARTS[SECTION.PROFILE]}
+          furthestStep={this.props.furthestStep}
           navigate={this.navigate}
           grantRequested={this.props.grantRequested}
           waitingOnGrant={this.props.waitingOnGrant}
@@ -352,7 +340,7 @@ class NewsroomComponent extends React.Component<NewsroomProps, NewsroomComponent
       <StepNoButtons title={"Apply to Registry"} disabled={this.getDisabled(SECTION.APPLY)()} key="atr">
         <ApplyToTCR
           navigate={this.navigate}
-          newsroom={this.props.newsroom}
+          newsroom={this.props.newsroom!}
           address={this.props.newsroomAddress}
           civil={this.props.civil}
         />
@@ -436,7 +424,7 @@ class NewsroomComponent extends React.Component<NewsroomProps, NewsroomComponent
     }
 
     return (
-      <RepublishCharterNotice civil={this.props.civil!} charter={this.props.charter} newsroom={this.props.newsroom} />
+      <RepublishCharterNotice civil={this.props.civil!} charter={this.props.charter} newsroom={this.props.newsroom!} />
     );
   }
 

--- a/packages/newsroom-signup/src/NewsroomManager/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomManager/index.tsx
@@ -46,6 +46,7 @@ export interface NewsroomManagerReduxProps {
 export type NewsroomManagerProps = NewsroomManagerExternalProps & NewsroomManagerReduxProps & DispatchProp<any>;
 
 export interface NewsroomManagerState {
+  web3Enabled: boolean; // @TODO This state logic should be lifted to something dapp-wide
   editMode?: boolean;
   dirty?: boolean;
   saving?: boolean;
@@ -89,7 +90,7 @@ class NewsroomManagerComponent extends React.Component<NewsroomManagerProps, New
 
   constructor(props: NewsroomManagerProps) {
     super(props);
-    this.state = {};
+    this.state = { web3Enabled: false };
   }
 
   public async componentDidMount(): Promise<void> {
@@ -101,6 +102,8 @@ class NewsroomManagerComponent extends React.Component<NewsroomManagerProps, New
       // Pretty certain this will have been instantiated by the time this component is mounted, but if that's ever not the case I want to catch it!
       throw Error("NewsroomManagerComponent: civil instance not yet instantiated in context");
     }
+
+    this.context.civil.currentProviderEnable().then(() => this.setState({ web3Enabled: true }));
     await this.props.dispatch!(
       getNewsroom(this.props.newsroomAddress, this.context.civil!, this.props.publishedCharter),
     );
@@ -109,6 +112,17 @@ class NewsroomManagerComponent extends React.Component<NewsroomManagerProps, New
   public render(): JSX.Element {
     if (!this.props.charter) {
       return <LoadingMessage>Loading charter</LoadingMessage>;
+    }
+    if (!this.state.web3Enabled) {
+      // @TODO This logic should be lifted to something dapp-wide, and with a less hacky UI of course
+      return (
+        <LoadingMessage>
+          Please connect your Ethereum wallet.
+          <div>
+            <img src={metaMaskLoginImgUrl} style={{ width: 255, marginTop: 8 }} />
+          </div>
+        </LoadingMessage>
+      );
     }
     return (
       <ThemeProvider theme={this.props.theme}>

--- a/packages/newsroom-signup/src/NewsroomManager/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomManager/index.tsx
@@ -1,0 +1,152 @@
+import * as React from "react";
+import { connect, DispatchProp } from "react-redux";
+import styled, { ThemeProvider } from "styled-components";
+
+import { EthAddress, CharterData, NewsroomInstance } from "@joincivil/core";
+import { ButtonTheme, CivilContext, ICivilContext, OBSectionHeader, colors } from "@joincivil/components";
+
+import { StateWithNewsroom } from "../reducers";
+import {
+  getNewsroom,
+  updateCharter,
+  // analyticsEvent,
+} from "../actionCreators";
+import { Wrapper, DEFAULT_THEME } from "../styledComponents";
+import { RepublishCharterNotice } from "../RepublishCharterNotice";
+import { NewsroomBio } from "../NewsroomProfile/NewsroomBio";
+import { AddRosterMember } from "../NewsroomProfile/AddRosterMembers";
+import { CharterQuestions } from "../NewsroomProfile/CharterQuestions";
+import { ApplicationSoFarPage } from "../NewsroomProfile/ApplicationSoFarPage";
+
+export interface NewsroomManagerExternalProps {
+  newsroomAddress: EthAddress;
+  publishedCharter: Partial<CharterData>;
+  theme?: ButtonTheme;
+}
+
+export interface NewsroomManagerReduxProps {
+  charter?: Partial<CharterData>;
+  newsroom?: NewsroomInstance;
+  // userIsOwner?: boolean;
+  // userIsEditor?: boolean;
+  // userNotOnContract?: boolean;
+  // @TODO/tobek Ensure whitelisted or else send to apply to registry
+}
+
+export type NewsroomManagerProps = NewsroomManagerExternalProps & NewsroomManagerReduxProps & DispatchProp<any>;
+
+export interface NewsroomManagerState {
+  editMode?: boolean;
+  dirty?: boolean;
+}
+
+const StyledHeader = styled(OBSectionHeader)`
+  border-top: 1px solid ${colors.accent.CIVIL_GRAY_4};
+  font-size: 20px;
+  padding-top: 24px;
+  margin-top: 25px;
+  text-align: left;
+`;
+
+class NewsroomManagerComponent extends React.Component<NewsroomManagerProps, NewsroomManagerState> {
+  public static contextType: React.Context<ICivilContext> = CivilContext;
+  public static defaultProps: Partial<NewsroomManagerProps> = {
+    theme: DEFAULT_THEME,
+  };
+
+  public context!: React.ContextType<typeof CivilContext>;
+
+  constructor(props: NewsroomManagerProps) {
+    super(props);
+    this.state = {};
+  }
+
+  public async componentDidMount(): Promise<void> {
+    if (!this.props.newsroomAddress || !this.props.publishedCharter) {
+      // Type safety should ensure this doesn't happen, but I don't trust everything to be lined up all the way up component tree, and if undefined this page will be borked with blank charter, user might try to add stuff back in, republish... so just in case:
+      throw Error("NewsroomManagerComponent: newsroomAddress and/or publishedCharter props missing");
+    }
+    if (!this.context.civil) {
+      // Pretty certain this will have been instantiated by the time this component is mounted, but if that's ever not the case I want to catch it!
+      throw Error("NewsroomManagerComponent: civil instance not yet instantiated in context");
+    }
+    await this.props.dispatch!(
+      getNewsroom(this.props.newsroomAddress, this.context.civil!, this.props.publishedCharter),
+    );
+  }
+
+  public render(): JSX.Element {
+    if (!this.props.charter) {
+      return <>Loading charter...</>;
+    }
+    return (
+      <ThemeProvider theme={this.props.theme}>
+        <Wrapper>
+          <p>
+            <a
+              href="javascript:void 0"
+              onClick={() => {
+                this.setState({ editMode: !this.state.editMode, dirty: false });
+              }}
+            >
+              {this.state.editMode ? "Discard Changes" : "Edit >>"}
+            </a>
+          </p>
+
+          {this.state.dirty && this.props.newsroom && (
+            <RepublishCharterNotice
+              civil={this.context.civil!}
+              charter={this.props.charter}
+              newsroom={this.props.newsroom}
+            />
+          )}
+
+          {this.state.editMode ? (
+            <>
+              <StyledHeader>Newsroom Details</StyledHeader>
+              <NewsroomBio editMode={true} charter={this.props.charter} updateCharter={this.updateCharter} />
+              <StyledHeader>Roster</StyledHeader>
+              <AddRosterMember
+                editMode={true}
+                charter={this.props.charter}
+                updateCharter={this.updateCharter}
+                profileWalletAddress={"@TODO/tobek"}
+              />
+              <StyledHeader>Charter</StyledHeader>
+              <CharterQuestions editMode={true} charter={this.props.charter} updateCharter={this.updateCharter} />
+            </>
+          ) : (
+            <ApplicationSoFarPage editMode={true} charter={this.props.charter} />
+          )}
+        </Wrapper>
+      </ThemeProvider>
+    );
+  }
+
+  private updateCharter = (charter: Partial<CharterData>) => {
+    if (!this.state.dirty) {
+      this.setState({ dirty: true });
+    }
+    this.props.dispatch!(updateCharter(this.props.newsroomAddress || "", charter, true));
+  };
+}
+
+const mapStateToProps = (
+  state: StateWithNewsroom,
+  ownProps: NewsroomManagerExternalProps,
+): NewsroomManagerReduxProps => {
+  const { newsroomAddress } = ownProps;
+  const newsroom = state.newsrooms.get(newsroomAddress);
+  const { user } = (state as any).networkDependent; // @TODO Should refactor to use a context here and elsewhere in this package that we pull this state from parent context
+
+  console.log("newsroom", newsroom);
+  console.log("user", user);
+
+  return {
+    ...ownProps,
+    charter: newsroom && newsroom.charter,
+    newsroom: newsroom && newsroom.newsroom,
+  };
+};
+
+export const NewsroomManager = connect(mapStateToProps)(NewsroomManagerComponent);

--- a/packages/newsroom-signup/src/NewsroomManager/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomManager/index.tsx
@@ -17,11 +17,7 @@ import {
 } from "@joincivil/components";
 
 import { StateWithNewsroom } from "../reducers";
-import {
-  getNewsroom,
-  updateCharter,
-  // analyticsEvent,
-} from "../actionCreators";
+import { getNewsroom, updateCharter } from "../actionCreators";
 import { Wrapper, DEFAULT_THEME } from "../styledComponents";
 import { RepublishCharterNotice } from "../RepublishCharterNotice";
 import { NewsroomBio } from "../NewsroomProfile/NewsroomBio";
@@ -39,10 +35,6 @@ export interface NewsroomManagerExternalProps {
 export interface NewsroomManagerReduxProps {
   charter?: Partial<CharterData>;
   newsroom?: NewsroomInstance;
-  // userIsOwner?: boolean;
-  // userIsEditor?: boolean;
-  // userNotOnContract?: boolean;
-  // @TODO/tobek Ensure whitelisted or else send to apply to registry
 }
 
 export type NewsroomManagerProps = NewsroomManagerExternalProps & NewsroomManagerReduxProps & DispatchProp<any>;
@@ -242,7 +234,6 @@ const mapStateToProps = (
 ): NewsroomManagerReduxProps => {
   const { newsroomAddress } = ownProps;
   const newsroom = state.newsrooms.get(newsroomAddress);
-  // const { user } = (state as any).networkDependent; // @TODO Should refactor to use a context here and elsewhere in this package that we pull this state from parent context
 
   return {
     ...ownProps,

--- a/packages/newsroom-signup/src/NewsroomProfile/AddRosterMembers.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/AddRosterMembers.tsx
@@ -16,7 +16,12 @@ import { RosterMemberListItem } from "./RosterMemberListItem";
 export interface AddRosterMemberProps {
   charter: Partial<CharterData>;
   profileWalletAddress?: EthAddress;
+  /** Onboarding complete, now just managing info, so remove onboarding copy. */
+  editMode?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
+  setButtonVisibility?(visibility: boolean): void;
+}
+export interface AddRosterMemberDefaultProps {
   setButtonVisibility(visibility: boolean): void;
 }
 
@@ -54,8 +59,14 @@ const RemoveButton = styled(BorderlessButton)`
   margin-left: auto;
 `;
 
-export class AddRosterMember extends React.Component<AddRosterMemberProps, AddRosterMemberState> {
-  constructor(props: AddRosterMemberProps) {
+export class AddRosterMember extends React.Component<
+  AddRosterMemberProps & AddRosterMemberDefaultProps,
+  AddRosterMemberState
+> {
+  public static defaultProps: AddRosterMemberDefaultProps = {
+    setButtonVisibility: (vis: boolean) => {},
+  };
+  constructor(props: AddRosterMemberProps & AddRosterMemberDefaultProps) {
     super(props);
     this.state = {
       editingMember: null,
@@ -65,17 +76,17 @@ export class AddRosterMember extends React.Component<AddRosterMemberProps, AddRo
   public render(): JSX.Element {
     return (
       <>
-        <OBSectionHeader>Now, add your team to the Newsroom Roster</OBSectionHeader>
-        <OBSectionDescription>
-          Your newsroom roster is a list of journalists who are part of your newsroom. This is part of your public
-          Registry Profile.
-        </OBSectionDescription>
-        <LearnMoreButton />
-        <StyledHr />
+        {!this.props.editMode && this.renderOnboardingHeader()}
         <FormSection>
-          <LowerHeader>Newsroom Roster</LowerHeader>
-          <LowerDescription>Add yourself, in addition to any staff or team members to your roster.</LowerDescription>
-          <StyledCounter>Step 2 of 4: Roster</StyledCounter>
+          {!this.props.editMode && (
+            <>
+              <LowerHeader>Newsroom Roster</LowerHeader>
+              <LowerDescription>
+                Add yourself, in addition to any staff or team members to your roster.
+              </LowerDescription>
+              <StyledCounter>Step 2 of 4: Roster</StyledCounter>
+            </>
+          )}
           {this.state.editingMember ? (
             <RosterMember
               user={{ rosterData: this.state.editingMember }}
@@ -108,6 +119,20 @@ export class AddRosterMember extends React.Component<AddRosterMemberProps, AddRo
             </InvertedButton>
           )}
         </FormSection>
+      </>
+    );
+  }
+
+  private renderOnboardingHeader(): JSX.Element {
+    return (
+      <>
+        <OBSectionHeader>Now, add your team to the Newsroom Roster</OBSectionHeader>
+        <OBSectionDescription>
+          Your newsroom roster is a list of journalists who are part of your newsroom. This is part of your public
+          Registry Profile.
+        </OBSectionDescription>
+        <LearnMoreButton />
+        <StyledHr />
       </>
     );
   }

--- a/packages/newsroom-signup/src/NewsroomProfile/ApplicationSoFarPage.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/ApplicationSoFarPage.tsx
@@ -15,6 +15,8 @@ import { RosterMemberListItem } from "./RosterMemberListItem";
 
 export interface ApplicationSoFarPageProps {
   charter: Partial<CharterData>;
+  /** Onboarding complete, now just managing info, so remove onboarding copy. */
+  editMode?: boolean;
 }
 
 const Collapsable = styled(OBCollapsable)`
@@ -84,11 +86,8 @@ const StyledAvatarWrap = styled(AvatarWrap)`
 export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPageProps> {
   public render(): JSX.Element {
     return (
-      <div>
-        <OBSectionHeader>Here’s your Registry Profile so far</OBSectionHeader>
-        <OBSectionDescription>
-          Please review your newsroom Registry Profile. Keep in mind that this is a public document.
-        </OBSectionDescription>
+      <>
+        {!this.props.editMode && this.renderOnboardingHeader()}
         <Collapsable
           open={true}
           header={
@@ -125,7 +124,7 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
           </CollapsableInner>
         </Collapsable>
         <Collapsable
-          open={false}
+          open={true}
           header={
             <SectionHeaders>
               <SectionHeaderCheck />
@@ -141,7 +140,7 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
           </CollapsableInner>
         </Collapsable>
         <Collapsable
-          open={false}
+          open={true}
           header={
             <SectionHeaders>
               <SectionHeaderCheck />
@@ -173,7 +172,7 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
           </CollapsableInner>
         </Collapsable>
         <Collapsable
-          open={false}
+          open={true}
           header={
             <SectionHeaders>
               <SectionHeaderCheck />
@@ -185,9 +184,21 @@ export class ApplicationSoFarPage extends React.Component<ApplicationSoFarPagePr
             I agree to abide by the Civil Community's ethical principles as described in the Civil Constitution.
           </CollapsableInner>
         </Collapsable>
-      </div>
+      </>
     );
   }
+
+  private renderOnboardingHeader(): JSX.Element {
+    return (
+      <>
+        <OBSectionHeader>Here’s your Registry Profile so far</OBSectionHeader>
+        <OBSectionDescription>
+          Please review your newsroom Registry Profile. Keep in mind that this is a public document.
+        </OBSectionDescription>
+      </>
+    );
+  }
+
   private renderSocial = (): JSX.Element | null => {
     if (!this.props.charter.socialUrls) {
       return null;

--- a/packages/newsroom-signup/src/NewsroomProfile/CharterQuestions.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/CharterQuestions.tsx
@@ -9,6 +9,8 @@ import { urlConstants } from "@joincivil/utils";
 
 export interface CharterQuestionsProps extends StepProps {
   charter: Partial<CharterData>;
+  /** Onboarding complete, now just managing info, so remove onboarding copy. */
+  editMode?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
 }
 
@@ -34,26 +36,7 @@ export class CharterQuestions extends React.Component<CharterQuestionsProps> {
   public render(): JSX.Element {
     return (
       <>
-        <OBSectionHeader>Let’s write your Newsroom Charter</OBSectionHeader>
-        <OBSectionDescription>
-          Your Charter is an outline of your Newsroom's journalistic mission and purpose. It helps the Civil community
-          discover and learn more about your newsroom. It's one of the first things the community views about your
-          organization.
-        </OBSectionDescription>
-        <LearnMoreButton />
-        <StyledHr />
-        <StepSectionCounter>Step 3 of 4: Charter</StepSectionCounter>
-        <MoreQuestionsBox>
-          Have any questions?{" "}
-          <a target="_blank" href={urlConstants.FAQ_CHARTER_BEST_PRACTICES}>
-            Read the Civil Foundation's best practices on creating great charters.
-          </a>
-          <br />
-          You can also view{" "}
-          <a target="_blank" href={urlConstants.FAQ_CHARTER_EXAMPLE}>
-            a sample charter.
-          </a>
-        </MoreQuestionsBox>
+        {!this.props.editMode && this.renderOnboardingHeader()}
         <FormSection>
           <FormSubhead>{questionsCopy[charterQuestions.PURPOSE]}</FormSubhead>
           <Textarea
@@ -90,6 +73,33 @@ export class CharterQuestions extends React.Component<CharterQuestionsProps> {
             onChange={this.missionInputChange}
           />
         </FormSection>
+      </>
+    );
+  }
+
+  private renderOnboardingHeader(): JSX.Element {
+    return (
+      <>
+        <OBSectionHeader>Let’s write your Newsroom Charter</OBSectionHeader>
+        <OBSectionDescription>
+          Your Charter is an outline of your Newsroom's journalistic mission and purpose. It helps the Civil community
+          discover and learn more about your newsroom. It's one of the first things the community views about your
+          organization.
+        </OBSectionDescription>
+        <LearnMoreButton />
+        <StyledHr />
+        <StepSectionCounter>Step 3 of 4: Charter</StepSectionCounter>
+        <MoreQuestionsBox>
+          Have any questions?{" "}
+          <a target="_blank" href={urlConstants.FAQ_CHARTER_BEST_PRACTICES}>
+            Read the Civil Foundation's best practices on creating great charters.
+          </a>
+          <br />
+          You can also view{" "}
+          <a target="_blank" href={urlConstants.FAQ_CHARTER_EXAMPLE}>
+            a sample charter.
+          </a>
+        </MoreQuestionsBox>
       </>
     );
   }

--- a/packages/newsroom-signup/src/NewsroomProfile/NewsroomBio.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/NewsroomBio.tsx
@@ -44,11 +44,11 @@ const LogoFormWrap = styled.div`
 
 const LogoImgWrap = styled.div`
   position: relative;
-  width: 338px;
+  max-width: 130px;
 `;
 
 const LogoImg = styled.img`
-  width: 338px;
+  max-width: 130px;
   height: auto;
 `;
 
@@ -101,7 +101,7 @@ export class NewsroomBio extends React.Component<NewsroomBioProps> {
             <FormSubhead>Newsroom Logo</FormSubhead>
             <LogoFormWrap>
               <LogoImgWrap>{charter.logoUrl && <LogoImg src={charter.logoUrl} />}</LogoImgWrap>
-              <NewsroomLogoURLInput onChange={(dataUri: string) => this.charterInputChange("logoUrl", dataUri)} />
+              <NewsroomLogoURLInput onChange={(dataUri: string) => this.charterInputChange("logoUrl", dataUri)} buttonText={charter.logoUrl ? "Change Image" : "Add Image"} />
             </LogoFormWrap>
           </div>
 

--- a/packages/newsroom-signup/src/NewsroomProfile/NewsroomBio.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/NewsroomBio.tsx
@@ -27,6 +27,8 @@ import { LearnMoreButton } from "./LearnMoreButton";
 
 export interface NewsroomBioProps extends StepProps {
   charter: Partial<CharterData>;
+  /** Onboarding complete, now just managing info, so remove onboarding copy. */
+  editMode?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
 }
 
@@ -70,29 +72,14 @@ export class NewsroomBio extends React.Component<NewsroomBioProps> {
     const charter = this.props.charter;
     return (
       <>
-        <OBSectionHeader>Create your Newsroom Registry profile</OBSectionHeader>
-        <OBSectionDescription>
-          Civil is based on transparency so we ask you to provide the following information to the best of your ability.
-        </OBSectionDescription>
-        <LearnMoreButton />
-        <OBCollapsable
-          open={false}
-          header={<OBCollapsableHeader> Where will this profile be viewable?</OBCollapsableHeader>}
-        >
-          <OBSmallParagraph>
-            The information provided will help the Civil network assess your newsrooms compliance with the Civil
-            Constitution and may be the basis for a challenge if warranted
-          </OBSmallParagraph>
-        </OBCollapsable>
-        <OBSmallParagraph>
-          To create your Newsroom Registry Profile, you will complete 4 steps:
-          <br />
-          Newsroom Details, Roster, Charter, and Signing.
-        </OBSmallParagraph>
-        <StepSectionCounter>Step 1 of 4: Details</StepSectionCounter>
+        {!this.props.editMode && this.renderOnboardingHeader()}
         <FormSection>
-          <FormTitle>First, tell us about your Newsroom</FormTitle>
-          <OBSmallParagraph>Enter your newsroom details below.</OBSmallParagraph>
+          {!this.props.editMode && (
+            <>
+              <FormTitle>First, tell us about your Newsroom</FormTitle>
+              <OBSmallParagraph>Enter your newsroom details below.</OBSmallParagraph>
+            </>
+          )}
           <div>
             <FormSubhead>Newsroom Name</FormSubhead>
             <NewsroomURLInput name="name" value={charter.name || ""} onChange={this.charterInputChange} />
@@ -101,7 +88,10 @@ export class NewsroomBio extends React.Component<NewsroomBioProps> {
             <FormSubhead>Newsroom Logo</FormSubhead>
             <LogoFormWrap>
               <LogoImgWrap>{charter.logoUrl && <LogoImg src={charter.logoUrl} />}</LogoImgWrap>
-              <NewsroomLogoURLInput onChange={(dataUri: string) => this.charterInputChange("logoUrl", dataUri)} buttonText={charter.logoUrl ? "Change Image" : "Add Image"} />
+              <NewsroomLogoURLInput
+                onChange={(dataUri: string) => this.charterInputChange("logoUrl", dataUri)}
+                buttonText={charter.logoUrl ? "Change Image" : "Add Image"}
+              />
             </LogoFormWrap>
           </div>
 
@@ -157,8 +147,35 @@ export class NewsroomBio extends React.Component<NewsroomBioProps> {
               </div>
             </FormRowItem>
           </FormRow>
-          <StepSectionCounter>Step 1 of 4: Details</StepSectionCounter>
+          {!this.props.editMode && <StepSectionCounter>Step 1 of 4: Details</StepSectionCounter>}
         </FormSection>
+      </>
+    );
+  }
+
+  private renderOnboardingHeader(): JSX.Element {
+    return (
+      <>
+        <OBSectionHeader>Create your Newsroom Registry profile</OBSectionHeader>
+        <OBSectionDescription>
+          Civil is based on transparency so we ask you to provide the following information to the best of your ability.
+        </OBSectionDescription>
+        <LearnMoreButton />
+        <OBCollapsable
+          open={false}
+          header={<OBCollapsableHeader> Where will this profile be viewable?</OBCollapsableHeader>}
+        >
+          <OBSmallParagraph>
+            The information provided will help the Civil network assess your newsrooms compliance with the Civil
+            Constitution and may be the basis for a challenge if warranted
+          </OBSmallParagraph>
+        </OBCollapsable>
+        <OBSmallParagraph>
+          To create your Newsroom Registry Profile, you will complete 4 steps:
+          <br />
+          Newsroom Details, Roster, Charter, and Signing.
+        </OBSmallParagraph>
+        <StepSectionCounter>Step 1 of 4: Details</StepSectionCounter>
       </>
     );
   }

--- a/packages/newsroom-signup/src/NewsroomProfile/RosterMember.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/RosterMember.tsx
@@ -101,7 +101,7 @@ export class RosterMemberComponent extends React.Component<RosterMemberProps & D
           <FormSubhead>Name</FormSubhead>
           <Input name="name" value={user.rosterData.name || ""} onChange={this.rosterInputChange} />
           <FormSubhead optional>Avatar URL</FormSubhead>
-          <StyledImageToData onChange={(dataUri: string) => this.rosterInputChange("avatarUrl", dataUri)} />
+          <StyledImageToData onChange={(dataUri: string) => this.rosterInputChange("avatarUrl", dataUri)} buttonText={user.rosterData.avatarUrl ? "Change Image" : "Add Image"} />
           <FormSubhead>Role</FormSubhead>
           <Input name="role" value={user.rosterData.role} onChange={this.rosterInputChange} />
 

--- a/packages/newsroom-signup/src/NewsroomProfile/RosterMember.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/RosterMember.tsx
@@ -101,7 +101,10 @@ export class RosterMemberComponent extends React.Component<RosterMemberProps & D
           <FormSubhead>Name</FormSubhead>
           <Input name="name" value={user.rosterData.name || ""} onChange={this.rosterInputChange} />
           <FormSubhead optional>Avatar URL</FormSubhead>
-          <StyledImageToData onChange={(dataUri: string) => this.rosterInputChange("avatarUrl", dataUri)} buttonText={user.rosterData.avatarUrl ? "Change Image" : "Add Image"} />
+          <StyledImageToData
+            onChange={(dataUri: string) => this.rosterInputChange("avatarUrl", dataUri)}
+            buttonText={user.rosterData.avatarUrl ? "Change Image" : "Add Image"}
+          />
           <FormSubhead>Role</FormSubhead>
           <Input name="role" value={user.rosterData.role} onChange={this.rosterInputChange} />
 

--- a/packages/newsroom-signup/src/NewsroomProfile/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { NextBack } from "../styledComponents";
 import { CharterData, EthAddress } from "@joincivil/core";
+import { STEP } from "../Newsroom";
 import { NewsroomBio } from "./NewsroomBio";
 import { AddRosterMember } from "./AddRosterMembers";
 import { CharterQuestions } from "./CharterQuestions";
@@ -15,6 +16,7 @@ export interface NewsroomProfileState {
 export interface NewsroomProfileProps {
   profileWalletAddress?: EthAddress;
   currentStep: number;
+  furthestStep: STEP;
   charter: Partial<CharterData>;
   grantRequested?: boolean;
   waitingOnGrant?: boolean;
@@ -85,12 +87,13 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
     return steps[this.props.currentStep];
   }
 
-  public renderButtons(): JSX.Element | null {
+  public renderButtons(top?: boolean): JSX.Element | null {
     if (!this.state.showButtons || this.props.waitingOnGrant) {
       return null;
     }
     return (
       <NextBack
+        top={top}
         navigate={this.props.navigate}
         backHidden={this.props.currentStep === 0}
         nextDisabled={this.getDisabled(this.props.currentStep)}
@@ -101,6 +104,9 @@ export class NewsroomProfile extends React.Component<NewsroomProfileProps, Newsr
   public render(): JSX.Element {
     return (
       <>
+        {/*Bit ugly, but people always having issues figuring out how to navigate back to make changes, so once they've gotten this far, show navigation at the top as well:*/}
+        {this.props.furthestStep >= STEP.PROFILE_SO_FAR && this.renderButtons(true)}
+
         {this.renderCurrentStep()}
         {this.renderButtons()}
       </>

--- a/packages/newsroom-signup/src/RepublishCharterNotice.tsx
+++ b/packages/newsroom-signup/src/RepublishCharterNotice.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled from "styled-components";
-import { CharterData, Civil, IPFSProvider, TxHash } from "@joincivil/core";
+import { CharterData, Civil, IPFSProvider, TxHash, NewsroomInstance } from "@joincivil/core";
 import {
   Notice,
   NoticeTypes,
@@ -22,7 +22,7 @@ import { CivilContext, CivilContextValue } from "./CivilContext";
 export interface RepublishCharterNoticeProps {
   civil: Civil;
   charter: Partial<CharterData>;
-  newsroom: any;
+  newsroom: NewsroomInstance;
 }
 
 export interface RepublishCharterNoticeState extends TransactionButtonModalFlowState {
@@ -172,8 +172,10 @@ export class RepublishCharterNotice extends React.Component<RepublishCharterNoti
         <p>You have confirmed the transaction in MetaMask.</p>
         <p>
           Note: this could take a while depending on Ethereum network traffic. You can close this window while the
-          transaction is processing.
+          transaction is processing, but please note that changes won't be reflected until the transaction has
+          completed.
         </p>
+        <p>If you remain on this page, you will be alerted when the transaction has been completed.</p>
         <Button size={buttonSizes.MEDIUM_WIDE} onClick={() => this.setState({ modalOpen: false })}>
           OK
         </Button>
@@ -212,7 +214,7 @@ export class RepublishCharterNotice extends React.Component<RepublishCharterNoti
             isWaitingTransactionModalOpen: true,
             isPreTransactionModalOpen: false,
           });
-          return this.props.newsroom.updateRevisionURIAndHash(0, this.state.contentURI, this.state.contentHash);
+          return this.props.newsroom.updateRevisionURIAndHash(0, this.state.contentURI!, this.state.contentHash!);
         },
         postTransaction: () => {
           this.setState({

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { EthAddress, CharterData, TxHash } from "@joincivil/core";
+import { EthAddress, CharterData, TxHash, NewsroomInstance } from "@joincivil/core";
 import { NextBack } from "../styledComponents";
 import { LetsGetStartedPage } from "./LetsGetStartedPage";
 import { UnderstandingEth } from "./UnderstandingEth";
@@ -17,7 +17,7 @@ export interface SmartContractProps {
   userIsOwner?: boolean;
   newsroomAddress?: EthAddress;
   newsroomDeployTxHash?: TxHash;
-  newsroom?: any;
+  newsroom?: NewsroomInstance;
   navigate(go: 1 | -1): void;
   updateCharter(charter: Partial<CharterData>): void;
 }

--- a/packages/newsroom-signup/src/index.ts
+++ b/packages/newsroom-signup/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./analytics";
 export * from "./Newsroom";
+export * from "./NewsroomManager";
 export * from "./reducers";
 export * from "./actionCreators";
 export * from "./utils";

--- a/packages/newsroom-signup/src/styledComponents.tsx
+++ b/packages/newsroom-signup/src/styledComponents.tsx
@@ -221,11 +221,12 @@ export const NextBackButtonContainer = styled.div`
 export interface NextBackProps {
   backHidden?: boolean;
   nextHidden?: boolean;
+  top?: boolean;
   navigate(go: 1 | -1): void;
   nextDisabled?(): boolean;
 }
 export const NextBack: React.FunctionComponent<NextBackProps> = (props: NextBackProps) => (
-  <NextBackButtonContainer style={{ marginTop: 64 }}>
+  <NextBackButtonContainer style={{ margin: props.top ? "0 0 32px" : "64px 0 0" }}>
     {!props.backHidden ? (
       <BorderlessButton size={buttonSizes.MEDIUM_WIDE} onClick={() => props.navigate(-1)}>
         Back

--- a/packages/newsroom-signup/src/styledComponents.tsx
+++ b/packages/newsroom-signup/src/styledComponents.tsx
@@ -1,6 +1,8 @@
 import {
   colors,
   fonts,
+  DEFAULT_BUTTON_THEME,
+  DEFAULT_CHECKBOX_THEME,
   buttonSizes,
   Button,
   BorderlessButton,
@@ -18,6 +20,20 @@ import {
 // tslint:disable-next-line:no-unused-variable
 import * as React from "react"; // needed to export styled components
 import styled, { StyledComponentClass, css } from "styled-components";
+
+export const DEFAULT_THEME = {
+  ...DEFAULT_BUTTON_THEME,
+  ...DEFAULT_CHECKBOX_THEME,
+  primaryButtonTextTransform: "none",
+  primaryButtonFontWeight: "bold",
+  borderlessButtonSize: "14px",
+};
+
+export const Wrapper: StyledComponentClass<any, "div"> = styled.div`
+  max-width: 720px;
+  margin: auto;
+  font-size: 14px;
+`;
 
 export const FormSection = styled.div`
   padding-top: 10px;


### PR DESCRIPTION
- Reuses `newsroom-signup` components in new "manage newsroom" page, reworking them with copy/design updates to support this new context
- Misc `newsroom-signup` updates and improvements
- Designs are in flux, this is a barebones version. It's clean and nothing looks broken, but it doesn't match the designs.
- UI is behind `newsroom-channels` flag for now.