### PR TITLE
Support newsroom channels from Launch Boost nav dropdown [CIVIL-1022]

### DIFF
--- a/packages/components/src/WithNewsroomChannelHOC.tsx
+++ b/packages/components/src/WithNewsroomChannelHOC.tsx
@@ -9,6 +9,15 @@ export interface NewsroomChannelData {
   id: string;
   currentUserIsAdmin: boolean;
   isStripeConnected: boolean;
+  newsroom: {
+    multisigAddress: string;
+    charter: {
+      name: string;
+      tagline: string;
+      logoUrl: string;
+      newsroomUrl: string;
+    };
+  };
 }
 
 export interface WithNewsroomChannelOuterProps {
@@ -29,6 +38,15 @@ export const CHANNEL_BY_NEWSROOM_QUERY = gql`
       id
       currentUserIsAdmin
       isStripeConnected
+      newsroom {
+        multisigAddress
+        charter {
+          name
+          tagline
+          logoUrl
+          newsroomUrl
+        }
+      }
     }
   }
 `;

--- a/packages/dapp/src/components/Boosts/BoostCreate.tsx
+++ b/packages/dapp/src/components/Boosts/BoostCreate.tsx
@@ -127,7 +127,7 @@ class BoostCreatePage extends React.Component<
           url: charter && charter.newsroomUrl,
           owner: newsroom.multisigAddress,
         }}
-        newsroomAddress={newsroom.address}
+        newsroomContractAddress={newsroom.address}
         newsroomListingUrl={`${document.location.origin}${listingRoute}`}
         newsroomTagline={charter && charter.tagline}
         newsroomLogoUrl={charter && charter.logoUrl}

--- a/packages/dapp/src/components/Dashboard/ManageNewsroom/WithNewsroomChannelAdminList.tsx
+++ b/packages/dapp/src/components/Dashboard/ManageNewsroom/WithNewsroomChannelAdminList.tsx
@@ -6,7 +6,7 @@ import { EthAddress } from "@joincivil/core";
 import { LoadingMessage } from "@joincivil/components";
 import gql from "graphql-tag";
 
-const newsroomChannelAdminQuery = gql`
+export const newsroomChannelAdminQuery = gql`
   query {
     currentUser {
       uid
@@ -33,6 +33,16 @@ export interface WithNewsroomChannelAdminListProps {
   children(props: { newsroomAddresses: Set<EthAddress> }): any;
 }
 
+export function newsroomChannelsFromQueryData(data?: any): EthAddress[] {
+  if (data && data.currentUser && data.currentUser.channels && data.currentUser.channels.filter) {
+    return data.currentUser.channels
+      .filter((channelMember: any) => channelMember.channel.channelType === "newsroom")
+      .map((channelMember: any) => channelMember.channel.newsroom.contractAddress);
+  } else {
+    return [];
+  }
+}
+
 export default (props: WithNewsroomChannelAdminListProps) => {
   return (
     <Query query={newsroomChannelAdminQuery}>
@@ -43,13 +53,8 @@ export default (props: WithNewsroomChannelAdminListProps) => {
         if (error) {
           console.error("Error loading current user channels:", error);
         }
-        let newsroomAddresses = [];
-        if (data && data.currentUser && data.currentUser.channels) {
-          newsroomAddresses = data.currentUser.channels
-            .filter((channelMember: any) => channelMember.channel.channelType === "newsroom")
-            .map((channelMember: any) => channelMember.channel.newsroom.contractAddress);
-        }
 
+        const newsroomAddresses = newsroomChannelsFromQueryData(data);
         return props.children({ newsroomAddresses: Set(newsroomAddresses) });
       }}
     </Query>

--- a/packages/dapp/src/components/Dashboard/ManageNewsroom/WithNewsroomChannelAdminList.tsx
+++ b/packages/dapp/src/components/Dashboard/ManageNewsroom/WithNewsroomChannelAdminList.tsx
@@ -36,8 +36,10 @@ export interface WithNewsroomChannelAdminListProps {
 export function newsroomChannelsFromQueryData(data?: any): EthAddress[] {
   if (data && data.currentUser && data.currentUser.channels && data.currentUser.channels.filter) {
     return data.currentUser.channels
-      .filter((channelMember: any) => channelMember.channel.channelType === "newsroom")
-      .map((channelMember: any) => channelMember.channel.newsroom.contractAddress);
+      .filter(
+        (memberChannel: any) => memberChannel.role === "admin" && memberChannel.channel.channelType === "newsroom",
+      )
+      .map((memberChannel: any) => memberChannel.channel.newsroom.contractAddress);
   } else {
     return [];
   }


### PR DESCRIPTION
Without this, Launch Boost from nav is broken, so I think we need to deploy this to prod before we have anyone else use boosts (otherwise we'd have to make sure to direct them to launch boost via dashboard).