### PR TITLE
release sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,26 +24,12 @@ jobs:
             - run:
                 name: Building
                 command:  yarn build
-            - persist_to_workspace:
-                root: ../
-                paths:
-                    - project/
-    lint:
-        <<: *defaults
-        steps:
-            - attach_workspace:
-                at: ../
             - run:
                 name: Ensuring prettified
                 command: yarn prettier
             - run:
                 name: Linting
                 command: yarn lint
-    test:
-        <<: *defaults
-        steps:
-            - attach_workspace:
-                at: ../
             - run:
                 name: Starting Ganache
                 command: yarn ganache:raw
@@ -55,6 +41,10 @@ jobs:
                 name: Running tests (except contracts)
                 command: |
                     yarn test
+            - run:
+                name: Releasing
+                command: |
+                    yarn release
     coverage:
         <<: *defaults
         steps:
@@ -212,22 +202,6 @@ workflows:
                         ignore:
                             - master
                             - production
-            - test:
-                filters:
-                    branches:
-                        ignore:
-                            - master
-                            - production
-                requires:
-                    - build
-            - lint:
-                filters:
-                    branches:
-                        ignore:
-                            - master
-                            - production
-                requires:
-                    - build
     deployment:
         jobs:
             - setup-gcp:

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,5 @@
 {
   "repositoryUrl": "git@github.com:joincivil/Civil.git",
   "branch": "master",
-  "plugins": [
-
-  ]
+  "plugins": []
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@joincivil/root", 
+  "name": "@joincivil/root",
   "private": true,
-  "homepage": "https://joincivil.github.io/civil",
+  "homepage": "https://civil.co",
   "workspaces": [
     "packages/*"
   ],
@@ -48,6 +48,7 @@
     "husky": "^2.1.0",
     "lcov-result-merger": "^3.1.0",
     "lerna": "^3.15.0",
+    "multi-semantic-release": "^1.1.0",
     "ncp": "^2.0.0",
     "npm-run-all": ">=4.1.5",
     "prettier": "1.18.2",

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joincivil/dapp",
   "version": "0.9.11",
-  "homepage": "/",
+  "homepage": "https://registry.civil.co",
   "private": false,
   "dependencies": {
     "@joincivil/civil-sdk": "^1.21.4",

--- a/packages/sdk/.releaserc
+++ b/packages/sdk/.releaserc
@@ -26,5 +26,6 @@
         }
       }
     ],
+    "@semantic-release/npm"
   ]
 }

--- a/packages/utils/test/salt.ts
+++ b/packages/utils/test/salt.ts
@@ -65,9 +65,7 @@ describe("utils/salt", () => {
       const salt = randomSalt(cnt);
       const wrds = saltToWords(salt);
 
-      console.log("ok", wrds, cnt);
       expect(wrds.length).equal(cnt);
-      console.log("ok");
       expect(salt.toString()).equal(wordsToSalt(wrds).toString());
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5625,6 +5625,25 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+bash-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bash-glob/-/bash-glob-2.0.0.tgz#a8ef19450783403ed93fccca2dbe09f2cf6320dc"
+  dependencies:
+    bash-path "^1.0.1"
+    component-emitter "^1.2.1"
+    cross-spawn "^5.1.0"
+    each-parallel-async "^1.0.0"
+    extend-shallow "^2.0.1"
+    is-extglob "^2.1.1"
+    is-glob "^4.0.0"
+
+bash-path@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bash-path/-/bash-path-1.0.3.tgz#dbc9efbdf18b1c11413dcb59b960e6aa56c84258"
+  dependencies:
+    arr-union "^3.1.0"
+    is-windows "^1.0.1"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -5735,6 +5754,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+blork@^9.1.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/blork/-/blork-9.2.1.tgz#a88af9266c30bce9a1de1c8064961d8153087b2b"
 
 bluebird@^2.9.34:
   version "2.11.0"
@@ -7370,7 +7393,7 @@ cross-spawn@^4.0.2:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -8278,6 +8301,10 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+each-parallel-async@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/each-parallel-async/-/each-parallel-async-1.0.0.tgz#91783e190000c7dd588336b2d468ebaf71980f7b"
 
 each-props@^1.3.0:
   version "1.3.2"
@@ -10945,6 +10972,12 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.6.0, hosted-git-info@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
+hosted-git-info@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.0.tgz#dd8af49cd01e73cc8e61ba13e217a772fd4ecd2d"
+  dependencies:
+    lru-cache "^5.1.1"
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -12938,7 +12971,7 @@ jest-worker@^24.6.0:
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
 
-jest@23.6.0:
+jest@23.6.0, jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
   dependencies:
@@ -14287,6 +14320,10 @@ marked@^0.6.0:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.3.tgz#79babad78af638ba4d522a9e715cdfdd2429e946"
 
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+
 marksy@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.1.0.tgz#36482148a1115cc78570855f7ebd744bb453d5cc"
@@ -14774,6 +14811,23 @@ ms@2.1.1:
 ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+
+multi-semantic-release@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/multi-semantic-release/-/multi-semantic-release-1.1.0.tgz#dc5400533ee400cb18b9bf6b80a7b4fef2fba9dd"
+  dependencies:
+    bash-glob "^2.0.0"
+    blork "^9.1.1"
+    execa "^1.0.0"
+    get-stream "^4.1.0"
+    git-log-parser "^1.2.0"
+    jest "^23.6.0"
+    semantic-release "^15.12.4"
+    semver "^5.6.0"
+    signale "^1.2.0"
+    stream-buffers "^3.0.2"
+    tempy "^0.2.1"
+    yargs "^13.2.2"
 
 multiaddr@^4.0.0:
   version "4.0.0"
@@ -19236,6 +19290,37 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.7.5"
 
+semantic-release@^15.12.4:
+  version "15.13.21"
+  resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.13.21.tgz#d021c75f889cff75ae3410736942bee6c4557da7"
+  dependencies:
+    "@semantic-release/commit-analyzer" "^6.1.0"
+    "@semantic-release/error" "^2.2.0"
+    "@semantic-release/github" "^5.1.0"
+    "@semantic-release/npm" "^5.0.5"
+    "@semantic-release/release-notes-generator" "^7.1.2"
+    aggregate-error "^3.0.0"
+    cosmiconfig "^5.0.1"
+    debug "^4.0.0"
+    env-ci "^4.0.0"
+    execa "^1.0.0"
+    figures "^3.0.0"
+    find-versions "^3.0.0"
+    get-stream "^5.0.0"
+    git-log-parser "^1.2.0"
+    hook-std "^2.0.0"
+    hosted-git-info "^3.0.0"
+    lodash "^4.17.15"
+    marked "^0.7.0"
+    marked-terminal "^3.2.0"
+    p-locate "^4.0.0"
+    p-reduce "^2.0.0"
+    read-pkg-up "^6.0.0"
+    resolve-from "^5.0.0"
+    semver "^6.0.0"
+    signale "^1.2.1"
+    yargs "^13.1.0"
+
 semantic-release@^15.13.3:
   version "15.13.18"
   resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-15.13.18.tgz#72e284c6f7cb7817e1aaaa0a9d73600a9447d146"
@@ -19521,7 +19606,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-signale@^1.2.1:
+signale@^1.2.0, signale@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/signale/-/signale-1.4.0.tgz#c4be58302fb0262ac00fc3d886a7c113759042f1"
   dependencies:
@@ -19990,6 +20075,10 @@ stream-browserify@^2.0.1:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
+
+stream-buffers@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-3.0.2.tgz#5249005a8d5c2d00b3a32e6e0a6ea209dc4f3521"
 
 stream-combiner2@~1.1.1:
   version "1.1.1"
@@ -20542,6 +20631,13 @@ temp@^0.9.0:
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.0.tgz#61391795a11bd9738d4c4d7f55f012cb8f55edaa"
   dependencies:
     rimraf "~2.6.2"
+
+tempy@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.2.1.tgz#9038e4dbd1c201b74472214179bc2c6f7776e54c"
+  dependencies:
+    temp-dir "^1.0.0"
+    unique-string "^1.0.0"
 
 term-size@^1.2.0:
   version "1.2.0"
@@ -22992,7 +23088,7 @@ yargs@^12.0.1, yargs@^12.0.2:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^13.1.0:
+yargs@^13.1.0, yargs@^13.2.2:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   dependencies:


### PR DESCRIPTION
this doesn't actually move civil-sdk into the monorepo yet, but just does an npm release. I think a lot of the packages are going to complain once they need a release that the tag already exists - the fix would be to just put a commit that bumps the version. I will run through all of them once I get a sdk set up properly

this also moves test/lint into the "build" job. I noticed that a bunch of time in CI is step in between job steps, and persisting workspaces. Combining them cut ~3 minutes off of the build.