### PR TITLE
feat: boost proceeds [CIVIL-1017]

### DIFF
--- a/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
@@ -41,6 +41,7 @@ export interface DashboardNewsroomProps {
   inProgressPhaseDisplayName?: string;
   inProgressPhaseCountdown?: JSX.Element;
   inProgressPhaseDetails?: string | JSX.Element;
+  boostProceeds?: JSX.Element;
   rejectedDate?: string;
 }
 
@@ -188,10 +189,14 @@ const DashboardNewsroomBase: React.FunctionComponent<DashboardNewsroomProps> = p
             Learn more
           </a>
         </p>
+
+        {/*@HACK We need to include `NewsroomWithdraw` from `sdk` package, but this component is in `components` package which `sdk` uses so we'd have a circular dependency. @TODO/tobek all these TCR dashboard components should be moved into `dapp` package.*/}
+        {props.boostProceeds}
+
         {/*@TODO Because we're in components we can't access dapp routes so we have to hard code the route*/}
         <p>
           <Button size={buttonSizes.MEDIUM_WIDE} to={`/manage-newsroom/${props.newsroomAddress}/launch-boost`}>
-            Launch Boost
+            Launch New Boost
           </Button>
         </p>
         <p>

--- a/packages/dapp/src/components/Dashboard/NewsroomsListItemComponent.tsx
+++ b/packages/dapp/src/components/Dashboard/NewsroomsListItemComponent.tsx
@@ -6,6 +6,7 @@ import { ListingWrapper, WrappedChallengeData, EthContentHeader, CharterData } f
 import { NewsroomState, getNewsroom, getNewsroomMultisigBalance } from "@joincivil/newsroom-signup";
 import { DashboardNewsroom } from "@joincivil/components";
 import { getFormattedTokenBalance, getEtherscanBaseURL, getLocalDateTimeStrings } from "@joincivil/utils";
+import { NewsroomWithdraw } from "@joincivil/sdk";
 
 import { routes } from "../../constants";
 import { State } from "../../redux/reducers";
@@ -164,6 +165,7 @@ class NewsroomsListItemListingRedux extends React.Component<
         manageNewsroomURL,
         newsroomDeposit: getFormattedTokenBalance(listing.data.unstakedDeposit, true),
         etherscanBaseURL,
+        boostProceeds: <NewsroomWithdraw newsroomAddress={listingAddress} />,
       };
 
       return <DashboardNewsroom {...displayProps} {...newsroomStatusOnRegistry} />;

--- a/packages/sdk/src/react/NewsroomWithdraw.tsx
+++ b/packages/sdk/src/react/NewsroomWithdraw.tsx
@@ -13,7 +13,7 @@ import {
   Button,
   TransactionButton,
 } from "@joincivil/components";
-import { BoostButton } from "./boosts/BoostStyledComponents";
+import { BoostButton, CurrencyLabel } from "./boosts/BoostStyledComponents";
 import { BoostProceeds } from "./boosts/BoostProceeds";
 import { urlConstants } from "./urlConstants";
 
@@ -139,7 +139,7 @@ export class NewsroomWithdraw extends React.Component<NewsroomWithdrawProps, New
             {(this.props.isStripeConnected === true || typeof this.props.isStripeConnected === "undefined") && (
               <p>
                 {this.props.isStripeConnected === true ? "Y" : "If you have connected Stripe to your newsroom, y"}ou may
-                have additional funds in your{" "}
+                have additional funds from credit card proceeds in your{" "}
                 <a href="https://dashboard.stripe.com" target="_blank">
                   Stripe account
                 </a>
@@ -155,16 +155,27 @@ export class NewsroomWithdraw extends React.Component<NewsroomWithdrawProps, New
           <BalanceAndButton>
             <p>
               Newsroom balance:{" "}
+              <b>
+                {typeof this.state.multisigBalance !== "undefined" && (
+                  <>
+                    {this.state.multisigBalance.toFixed(4)} <CurrencyLabel>ETH</CurrencyLabel>
+                  </>
+                )}
+              </b>
+              <br />
               <Query query={ethPriceQuery}>
                 {({ loading, error, data }) => {
                   if (loading || typeof this.state.multisigBalance === "undefined") {
                     return <LoadingIndicator />;
                   }
-                  return <b>${(data.storefrontEthPrice * this.state.multisigBalance).toFixed(2)}</b>;
+                  return (
+                    <>
+                      (${(data.storefrontEthPrice * this.state.multisigBalance).toFixed(2)}{" "}
+                      <CurrencyLabel secondary={true}>USD</CurrencyLabel>)
+                    </>
+                  );
                 }}
               </Query>
-              <br />
-              {typeof this.state.multisigBalance !== "undefined" && <>({this.state.multisigBalance.toFixed(4)} ETH)</>}
             </p>
             {this.renderButton()}
           </BalanceAndButton>

--- a/packages/sdk/src/react/boosts/Boost.tsx
+++ b/packages/sdk/src/react/boosts/Boost.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Query } from "react-apollo";
 import { withRouter, RouteComponentProps } from "react-router";
+import styled from "styled-components";
 import { boostQuery, boostNewsroomQuery } from "./queries";
 import { BoostData, BoostNewsroomData } from "./types";
 import { BoostCard } from "./BoostCard";
@@ -9,7 +10,18 @@ import { BoostPayments } from "./payments/BoostPayments";
 import { BoostWrapper } from "./BoostStyledComponents";
 import { NewsroomWithdraw } from "../NewsroomWithdraw";
 import { withBoostPermissions, BoostPermissionsInjectedProps } from "./BoostPermissionsHOC";
-import { LoadingMessage, CivilContext, ICivilContext } from "@joincivil/components";
+import { LoadingMessage, CivilContext, ICivilContext, colors, mediaQueries } from "@joincivil/components";
+
+const WithdrawWrapper = styled.div`
+  border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
+  border-top: 1px solid ${colors.accent.CIVIL_GRAY_4};
+  padding: 0 0 16px;
+  margin: 36px 0;
+
+  ${mediaQueries.MOBILE} {
+    margin: 18px 0;
+  }
+`;
 
 export interface BoostExternalProps {
   boostId: string;
@@ -121,10 +133,13 @@ class BoostComponent extends React.Component<BoostProps, BoostStates> {
                   <>
                     {/*@TODO/tobek Move to Newsroom Boosts page when we have that.*/}
                     {this.props.open && this.props.newsroom && this.props.boostOwner && (
-                      <NewsroomWithdraw
-                        newsroom={this.props.newsroom}
-                        isStripeConnected={boostData.channel.isStripeConnected}
-                      />
+                      <WithdrawWrapper>
+                        <NewsroomWithdraw
+                          newsroomAddress={boostData.channel.newsroom.contractAddress}
+                          newsroom={this.props.newsroom}
+                          isStripeConnected={boostData.channel.isStripeConnected}
+                        />
+                      </WithdrawWrapper>
                     )}
                     <BoostCard
                       boostData={boostData}

--- a/packages/sdk/src/react/boosts/BoostProceeds.tsx
+++ b/packages/sdk/src/react/boosts/BoostProceeds.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import styled from "styled-components";
+import { Query } from "react-apollo";
+import {
+  LoadingIndicator,
+  colors,
+  fonts,
+  mediaQueries,
+  withNewsroomChannel,
+  NewsroomChannelInjectedProps,
+} from "@joincivil/components";
+import { boostProceedsQuery } from "./queries";
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 32px 0;
+  font-size: 14px;
+
+  ${mediaQueries.MOBILE} {
+    display: block;
+  }
+`;
+const Proceed = styled.div`
+  padding: 20px;
+  flex: 1;
+`;
+const TotalProceeds = styled(Proceed)`
+  font-family: ${fonts.SANS_SERIF};
+  border: 1px solid ${colors.accent.CIVIL_GRAY_4};
+`;
+
+const Amount = styled.span`
+  color: ${colors.primary.BLACK};
+  font-size: 16px;
+`;
+const TotalAmount = styled(Amount)`
+  font-size: 20px;
+`;
+const CurrencyLabel = styled.span`
+  color: ${colors.primary.CIVIL_GRAY_0};
+  font-size: 12px;
+  font-weight: bold;
+`;
+
+export interface BoostProceedsProps {
+  newsroomAddress: string;
+}
+
+class BoostProceedsComponent extends React.Component<BoostProceedsProps & NewsroomChannelInjectedProps> {
+  public constructor(props: BoostProceedsProps & NewsroomChannelInjectedProps) {
+    super(props);
+  }
+  public render(): JSX.Element {
+    return (
+      <Query query={boostProceedsQuery} variables={{ channelID: this.props.channelData.id }}>
+        {({ loading, error, data }) => {
+          if (loading) {
+            return <LoadingIndicator />;
+          } else if (error || !data || !data.getChannelTotalProceeds) {
+            console.error("Error loading boost proceeds query:", error || "no data returned");
+            return (
+              <span style={{ color: "red" }}>
+                Error loading Boost proceed amounts: {JSON.stringify(error || "no data returned")}
+              </span>
+            );
+          }
+
+          let { totalAmount, ether, ethUsdAmount, usd } = data.getChannelTotalProceeds;
+          totalAmount = parseFloat(totalAmount || 0).toFixed(2);
+          ether = parseFloat(ether || 0).toFixed(5);
+          ethUsdAmount = parseFloat(ethUsdAmount || 0).toFixed(2);
+          usd = parseFloat(usd || 0).toFixed(2);
+
+          return (
+            <Wrapper>
+              <TotalProceeds>
+                <div>
+                  <TotalAmount>${totalAmount}</TotalAmount> <CurrencyLabel>USD</CurrencyLabel>
+                </div>
+                <div>Total Proceeds from Boosts</div>
+              </TotalProceeds>
+              <Proceed>
+                <div>
+                  <Amount>{ether}</Amount> <CurrencyLabel>ETH</CurrencyLabel> ~= ${ethUsdAmount}{" "}
+                  <CurrencyLabel>USD</CurrencyLabel>
+                </div>
+                <div>ETH Proceeds</div>
+              </Proceed>
+              <Proceed>
+                <div>
+                  <Amount>${usd}</Amount> <CurrencyLabel>USD</CurrencyLabel>
+                </div>
+                <div>Credit Card Proceeds</div>
+              </Proceed>
+            </Wrapper>
+          );
+        }}
+      </Query>
+    );
+  }
+}
+
+export const BoostProceeds: React.ComponentType<BoostProceedsProps> = withNewsroomChannel(
+  BoostProceedsComponent,
+) as any;

--- a/packages/sdk/src/react/boosts/BoostProceeds.tsx
+++ b/packages/sdk/src/react/boosts/BoostProceeds.tsx
@@ -10,6 +10,7 @@ import {
   NewsroomChannelInjectedProps,
 } from "@joincivil/components";
 import { boostProceedsQuery } from "./queries";
+import { CurrencyLabel } from "./BoostStyledComponents";
 
 const Wrapper = styled.div`
   display: flex;
@@ -36,11 +37,6 @@ const Amount = styled.span`
 `;
 const TotalAmount = styled(Amount)`
   font-size: 20px;
-`;
-const CurrencyLabel = styled.span`
-  color: ${colors.primary.CIVIL_GRAY_0};
-  font-size: 12px;
-  font-weight: bold;
 `;
 
 export interface BoostProceedsProps {
@@ -82,14 +78,14 @@ class BoostProceedsComponent extends React.Component<BoostProceedsProps & Newsro
               </TotalProceeds>
               <Proceed>
                 <div>
-                  <Amount>{ether}</Amount> <CurrencyLabel>ETH</CurrencyLabel> ~= ${ethUsdAmount}{" "}
-                  <CurrencyLabel>USD</CurrencyLabel>
+                  <Amount>{ether}</Amount> <CurrencyLabel>ETH</CurrencyLabel> ≈ ${ethUsdAmount}{" "}
+                  <CurrencyLabel secondary={true}>USD</CurrencyLabel>
                 </div>
                 <div>ETH Proceeds</div>
               </Proceed>
               <Proceed>
                 <div>
-                  <Amount>${usd}</Amount> <CurrencyLabel>USD</CurrencyLabel>
+                  <Amount>${usd}</Amount> <CurrencyLabel secondary={true}>USD</CurrencyLabel>
                 </div>
                 <div>Credit Card Proceeds</div>
               </Proceed>

--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -798,3 +798,12 @@ export const BoostUserInfoForm = styled.div`
     width: 100%;
   }
 `;
+
+export interface CurrencyLabelProps {
+  secondary?: boolean;
+}
+export const CurrencyLabel = styled.span`
+  color: ${colors.primary.CIVIL_GRAY_0};
+  font-size: 12px;
+  font-weight: ${(props: CurrencyLabelProps) => (props.secondary ? 500 : 600)};
+`;

--- a/packages/sdk/src/react/boosts/queries.ts
+++ b/packages/sdk/src/react/boosts/queries.ts
@@ -71,6 +71,17 @@ export const boostNewsroomQuery = gql`
   }
 `;
 
+export const boostProceedsQuery = gql`
+  query proceeds($channelID: String!) {
+    getChannelTotalProceeds(channelID: $channelID) {
+      totalAmount
+      usd
+      ethUsdAmount
+      ether
+    }
+  }
+`;
+
 export const createBoostMutation = gql`
   mutation($input: PostCreateBoostInput!) {
     postsCreateBoost(input: $input) {

--- a/packages/sdk/src/react/urlConstants.ts
+++ b/packages/sdk/src/react/urlConstants.ts
@@ -8,7 +8,8 @@ export const urlConstants = {
 
   // FAQ Boosts
   FAQ_BOOSTS: FAQ_BASE_URL + "/hc/en-us/categories/360001939731-Boosts",
-  FAQ_BOOST_WITHDRAWL: FAQ_BASE_URL + "/hc/en-us/articles/360030522631-How-to-create-and-launch-a-Boost",
+  FAQ_BOOST_WITHDRAWL:
+    FAQ_BASE_URL + "/hc/en-us/articles/360030195272-How-do-I-withdraw-my-ETH-proceeds-once-a-Boost-has-ended-",
   FAQ_BOOST_SUPPORTERS: FAQ_BASE_URL + "/hc/en-us/sections/360005752331-Supporters",
   FAQ_WALLETS: FAQ_BASE_URL + "/hc/en-us/sections/360003838452-Wallets",
   FAQ_CVL_TOKENS: FAQ_BASE_URL + "/hc/en-us/articles/360016409251-What-are-Civil-tokens-CVL-",

--- a/packages/utils/src/urlConstants.ts
+++ b/packages/utils/src/urlConstants.ts
@@ -63,7 +63,7 @@ export const urlConstants = {
   FAQ_CHARTER_BEST_PRACTICES: "https://blog.joincivil.com/creating-great-charters-6b37cbca47c3",
   FAQ_CVL_TOKENS: FAQ_BASE_URL + "/hc/en-us/articles/360016409251-What-are-Civil-tokens-CVL-",
   FAQ_BOOSTS: FAQ_BASE_URL + "/hc/en-us/categories/360001939731-Boosts",
-  FAQ_BOOST_WITHDRAWL: FAQ_BASE_URL + "/hc/en-us/articles/360030522631-How-to-create-and-launch-a-Boost",
+  FAQ_BOOST_WITHDRAWL: FAQ_BASE_URL + "/hc/en-us/articles/360030195272-How-do-I-withdraw-my-ETH-proceeds-once-a-Boost-has-ended-",
   FAQ_BOOST_SUPPORTERS: FAQ_BASE_URL + "/hc/en-us/sections/360005752331-Supporters",
   FAQ_BOOST_HOW_TO_SUPPORT: FAQ_BASE_URL + "/hc/en-us/articles/360030520791-How-do-I-support-a-Boost-",
   FAQ_BOOST_WHEN_CHARGED: FAQ_BASE_URL + "/hc/en-us/articles/360030521331-When-will-my-payment-be-charged-",


### PR DESCRIPTION
Shows ETH and USD proceeds for a newsroom both on the My Newsrooms dashboard and on the Boost permalink page (if you're an admin for that newsroom).