### PR TITLE
fix(newsroom-signup): greatThanOrEqualTo should be gte

### DIFF
--- a/packages/newsroom-signup/src/ApplyToTCR/index.tsx
+++ b/packages/newsroom-signup/src/ApplyToTCR/index.tsx
@@ -112,7 +112,7 @@ const mapStateToProps = (state: any, ownProps: ApplyToTCRStepOwnProps): TApplyTo
 
   const minDeposit = new BigNumber((parameters && parameters[Parameters.minDeposit]) || 0);
 
-  const multisigHasMinDeposit = multisigBalance.greaterThanOrEqualTo(minDeposit);
+  const multisigHasMinDeposit = multisigBalance.gte(minDeposit);
 
   return {
     ...ownProps,


### PR DESCRIPTION
this was the old bignumber.js api and should be using bn.js
this didn't get caught since it the type was "any".