### PR TITLE
fix(components): no default value for CurrencyConverter

### DIFF
--- a/packages/components/src/CurrencyConverter/UsdEthConverter.tsx
+++ b/packages/components/src/CurrencyConverter/UsdEthConverter.tsx
@@ -24,7 +24,7 @@ export const UsdEthConverter = (props: UsdEthConverterProps) => {
         return (
           <>
             <CurrencyConverter
-              fromValue={props.fromValue || "0"}
+              fromValue={props.fromValue}
               currencyCodeFrom="USD"
               currencyLabelFrom="Enter USD Amount"
               currencyCodeTo="ETH"


### PR DESCRIPTION
the token storefront is currently broken, and I suspect it is a result of this commit:
https://github.com/joincivil/Civil/commit/17a4547a151bb42fc81a9d2d712a172682dc8354#diff-723fb43d508074f47fb5a75cb7711617

Removing the default value fixes it, although I am unsure if this has any repercussions to anything Boost related.