### PR TITLE
fix(components): use default import for png

### DIFF
--- a/packages/components/src/Account/Auth/AuthStyledComponents.tsx
+++ b/packages/components/src/Account/Auth/AuthStyledComponents.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import styled from "styled-components";
 import { colors, fonts, mediaQueries } from "../../styleConstants";
-import * as checkEmailImage from "../../images/auth/img-check-email@2x.png";
-import * as confirmedEmailImage from "../../images/auth/img-confirm-email@2x.png";
-import * as iconError from "../../images/icons/ico-error-red@2x.png";
+import checkEmailImage from "../../images/auth/img-check-email@2x.png";
+import confirmedEmailImage from "../../images/auth/img-confirm-email@2x.png";
+import iconError from "../../images/icons/ico-error-red@2x.png";
 import { urlConstants as links } from "@joincivil/utils";
 
 import {

--- a/packages/components/src/Account/Auth/__snapshots__/EthAuth.stories.storyshot
+++ b/packages/components/src/Account/Auth/__snapshots__/EthAuth.stories.storyshot
@@ -49,49 +49,13 @@ exports[`Storyshots Common / Auth / ETH AccountEthAuth Component 1`] = `
           >
             <img
               className="sc-fzXfQu ihvvef"
-              src={
-                Object {
-                  "0": "t",
-                  "1": "e",
-                  "10": "s",
-                  "11": "t",
-                  "12": "u",
-                  "13": "b",
-                  "2": "s",
-                  "3": "t",
-                  "4": "-",
-                  "5": "f",
-                  "6": "i",
-                  "7": "l",
-                  "8": "e",
-                  "9": "-",
-                  "default": "test-file-stub",
-                }
-              }
+              src="test-file-stub"
             />
           </div>
           Open MetaMask
         </button>
         <img
-          src={
-            Object {
-              "0": "t",
-              "1": "e",
-              "10": "s",
-              "11": "t",
-              "12": "u",
-              "13": "b",
-              "2": "s",
-              "3": "t",
-              "4": "-",
-              "5": "f",
-              "6": "i",
-              "7": "l",
-              "8": "e",
-              "9": "-",
-              "default": "test-file-stub",
-            }
-          }
+          src="test-file-stub"
         />
       </div>
     </div>

--- a/packages/components/src/Account/Auth/__snapshots__/VerifyToken.stories.storyshot
+++ b/packages/components/src/Account/Auth/__snapshots__/VerifyToken.stories.storyshot
@@ -30,7 +30,7 @@ exports[`Storyshots Common / Auth / VerifyToken Complete 1`] = `
     >
       <div>
         <div
-          className="sc-LzNtQ sc-LzNtR dzCNId"
+          className="sc-LzNtQ sc-LzNtR eyIVon"
         />
       </div>
     </div>
@@ -707,7 +707,7 @@ exports[`Storyshots Common / Auth / VerifyToken Loading 1`] = `
     >
       <div>
         <div
-          className="sc-LzNtQ sc-LzNtR dzCNId"
+          className="sc-LzNtQ sc-LzNtR eyIVon"
         />
       </div>
     </div>

--- a/packages/components/src/BrowserCompatible/BrowserCompatible.tsx
+++ b/packages/components/src/BrowserCompatible/BrowserCompatible.tsx
@@ -8,8 +8,8 @@ import {
   BrowserCompatLinks,
 } from "./BrowserCompatibleStyledComponents";
 import { BrowserCompatHeadingText, BrowserCompatIntroText } from "./BrowserCompatibleTextComponents";
-import * as chromeLogoImgUrl from "../images/img-chrome-logo@2x.png";
-import * as firefoxLogoImgUrl from "../images/img-firefox-logo@2x.png";
+import chromeLogoImgUrl from "../images/img-chrome-logo@2x.png";
+import firefoxLogoImgUrl from "../images/img-firefox-logo@2x.png";
 import { urlConstants as links } from "@joincivil/utils";
 
 export const BrowserCompatible: React.FunctionComponent = props => {

--- a/packages/components/src/BrowserCompatible/__snapshots__/BrowserCompatible.stories.storyshot
+++ b/packages/components/src/BrowserCompatible/__snapshots__/BrowserCompatible.stories.storyshot
@@ -45,25 +45,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
         >
           <img
             className="sc-LzMEb qTqPx"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           Get Google Chrome
         </a>
@@ -81,25 +63,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
         >
           <img
             className="sc-LzMEb qTqPx"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           Get Firefox
         </a>

--- a/packages/components/src/DAppMessageContent/WrongNetwork.tsx
+++ b/packages/components/src/DAppMessageContent/WrongNetwork.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { urlConstants } from "@joincivil/utils";
-import * as metaMaskNetworkSwitchUrl from "../images/img-metamask-networkswitch@2x.png";
+import metaMaskNetworkSwitchUrl from "../images/img-metamask-networkswitch@2x.png";
 import { Modal } from "../Modal";
 import { MetaMaskMockImage, MetaMaskIcon, StyledLargeModalText, StyledSmallModalText } from "./styledComponents";
 

--- a/packages/components/src/Hero/Hero.stories.tsx
+++ b/packages/components/src/Hero/Hero.stories.tsx
@@ -3,7 +3,7 @@ import StoryRouter from "storybook-react-router";
 import * as React from "react";
 import { Hero } from "./Hero";
 import { HomepageHero } from "./HomepageHero";
-import * as heroImgUrl from "./img-hero-listings.png";
+import heroImgUrl from "./img-hero-listings.png";
 
 storiesOf("Registry / Hero", module)
   .addDecorator(StoryRouter())

--- a/packages/components/src/Hero/__snapshots__/Hero.stories.storyshot
+++ b/packages/components/src/Hero/__snapshots__/Hero.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Hero Homepage 1`] = `
     }
   >
     <div
-      className="sc-LzMja ljHaDg"
+      className="sc-LzMja gFLBKC"
     >
       <div
         className="sc-LzMjb jxlvEw"

--- a/packages/components/src/ListingDetailHeader/ListingDetailHeader.tsx
+++ b/packages/components/src/ListingDetailHeader/ListingDetailHeader.tsx
@@ -7,7 +7,7 @@ import { buttonSizes } from "../Button";
 import { StyledContentRow } from "../Layout";
 import ListingPhaseLabel from "../ListingSummary/ListingPhaseLabel";
 import { colors } from "../styleConstants";
-import * as defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
+import defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
 
 import {
   ListingDetailOuter,

--- a/packages/components/src/ListingSummary/NewsroomInfo.tsx
+++ b/packages/components/src/ListingSummary/NewsroomInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
+import defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
 import { ListingSummaryComponentProps } from "./types";
 import { NewsroomIcon, StyledListingSummaryTop, StyledListingSummaryNewsroomName } from "./styledComponents";
 import NewsroomTagline from "./NewsroomTagline";

--- a/packages/components/src/MetaMaskModal.tsx
+++ b/packages/components/src/MetaMaskModal.tsx
@@ -11,9 +11,9 @@ import {
   MetaMaskSideIcon,
   MetaMaskLogoButton,
 } from ".";
-import * as metaMaskModalUrl from "./images/img-metamask-modalconfirm@2x.png";
-import * as confirmButton from "./images/img-metamask-confirm@2x.png";
-import * as signImage from "./images/img-metamaskmodal-new-signature.png";
+import metaMaskModalUrl from "./images/img-metamask-modalconfirm@2x.png";
+import confirmButton from "./images/img-metamask-confirm@2x.png";
+import signImage from "./images/img-metamaskmodal-new-signature.png";
 
 const ModalP = styled.p`
   font-size: 16px;

--- a/packages/components/src/TCRUserDashboard/DashboardActivityItem.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardActivityItem.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { buttonSizes, InvertedButton } from "../Button";
 import { CharterData } from "@joincivil/core";
 import { SmallNewsroomIcon } from "../ListingSummary/styledComponents";
-import * as defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
+import defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
 import {
   StyledDashboardActivityItem,
   StyledDashboardActivityItemDetails,

--- a/packages/components/src/TCRUserDashboard/DashboardActivityItemTask.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardActivityItemTask.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 import { SmallNewsroomIcon } from "../ListingSummary/styledComponents";
-import * as defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
+import defaultNewsroomImgUrl from "../images/img-default-newsroom@2x.png";
 
 import { DashboardActivityItemProps } from "./DashboardTypes";
 import {

--- a/packages/components/src/TCRUserDashboard/DashboardNewsroomStripeConnect.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardNewsroomStripeConnect.tsx
@@ -15,9 +15,9 @@ import { ErrorIcon, NorthEastArrow } from "../icons";
 import { colors } from "../styleConstants";
 import { InvertedButton, buttonSizes } from "../Button";
 
-import * as stripeLogo from "../images/stripe-logo-blue.png";
-import * as stripeConnectButtonLight from "../images/stripe-connect-blue-on-light.png";
-import * as stripeConnectButtonDark from "../images/stripe-connect-blue-on-dark.png";
+import stripeLogo from "../images/stripe-logo-blue.png";
+import stripeConnectButtonLight from "../images/stripe-connect-blue-on-light.png";
+import stripeConnectButtonDark from "../images/stripe-connect-blue-on-dark.png";
 
 export const StripeContainer = styled.div`
   border: 1px solid ${colors.accent.CIVIL_GRAY_4};

--- a/packages/components/src/Tokens/TokensAccountFaq.tsx
+++ b/packages/components/src/Tokens/TokensAccountFaq.tsx
@@ -10,7 +10,7 @@ import {
   TokenETHFAQQuestion7Text,
 } from "./TokensTextComponents";
 import { Collapsable } from "../Collapsable";
-import * as metamaskEthAmount from "../images/img-metamask-eth-amount@2x.png";
+import metamaskEthAmount from "../images/img-metamask-eth-amount@2x.png";
 
 export const UserTokenAccountFaq: React.FunctionComponent = props => {
   return (

--- a/packages/components/src/WalletOnboarding.tsx
+++ b/packages/components/src/WalletOnboarding.tsx
@@ -10,8 +10,8 @@ import {
   ManagerSectionHeading,
 } from "./";
 import styled from "styled-components";
-import * as metaMaskNetworkSwitchUrl from "./images/img-metamask-networkswitch@2x.png";
-import * as metaMaskLoginUrl from "./images/img-metamask-login@2x.png";
+import metaMaskNetworkSwitchUrl from "./images/img-metamask-networkswitch@2x.png";
+import metaMaskLoginUrl from "./images/img-metamask-login@2x.png";
 
 export interface WalletOnboardingProps {
   civil?: Civil;

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.connected.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.connected.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Connected Connected 1`] = `
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.disabled.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.disabled.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Not Enabled Not Enabled 1`] = 
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.locked.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.locked.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Locked Locked 1`] = `
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.mismatch.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.mismatch.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/Mismatch Civil account vs. Met
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.network.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.network.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/ Wrong Network Wrong Network 1
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.provider.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.provider.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2/No Provider No Provider 1`] = 
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.save.stories.storyshot
+++ b/packages/components/src/WalletOnboardingV2/__snapshots__/WalletOnboardingV2.save.stories.storyshot
@@ -32,25 +32,7 @@ exports[`Storyshots Common / Wallet Onboarding V2 / Save Address Save address to
         >
           <img
             className="sc-LzMFm fMqHMt"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           <div
             className="sc-LzMFn gKZQzr"

--- a/packages/components/src/__snapshots__/Button.stories.storyshot
+++ b/packages/components/src/__snapshots__/Button.stories.storyshot
@@ -1859,25 +1859,7 @@ exports[`Storyshots Pattern Library / Buttons MetaMaskLogoButton 1`] = `
         >
           <img
             className="sc-fzXfQu ihvvef"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
         </div>
         MetaMaskLogo Transaction Button

--- a/packages/components/src/__snapshots__/WalletOnboarding.stories.storyshot
+++ b/packages/components/src/__snapshots__/WalletOnboarding.stories.storyshot
@@ -51,25 +51,7 @@ exports[`Storyshots Common / Wallet Onboarding CMS profile vs. MetaMask address 
         >
           <img
             className="sc-fzXfQu ihvvef"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           0xabc1230000000000000000000000000000abc123
         </div>
@@ -553,25 +535,7 @@ exports[`Storyshots Common / Wallet Onboarding Connected 1`] = `
         >
           <img
             className="sc-fzXfQu ihvvef"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           0xabc1230000000000000000000000000000abc123
         </div>
@@ -950,25 +914,7 @@ exports[`Storyshots Common / Wallet Onboarding Locked 1`] = `
     >
       <img
         className="sc-LzMDZ emoDzV"
-        src={
-          Object {
-            "0": "t",
-            "1": "e",
-            "10": "s",
-            "11": "t",
-            "12": "u",
-            "13": "b",
-            "2": "s",
-            "3": "t",
-            "4": "-",
-            "5": "f",
-            "6": "i",
-            "7": "l",
-            "8": "e",
-            "9": "-",
-            "default": "test-file-stub",
-          }
-        }
+        src="test-file-stub"
       />
       <h4
         className="sc-AykKH CwENs"
@@ -1378,25 +1324,7 @@ exports[`Storyshots Common / Wallet Onboarding No Provider 1`] = `
          
         <img
           className="sc-fzXfQu ihvvef sc-LzMDY hXRxoh"
-          src={
-            Object {
-              "0": "t",
-              "1": "e",
-              "10": "s",
-              "11": "t",
-              "12": "u",
-              "13": "b",
-              "2": "s",
-              "3": "t",
-              "4": "-",
-              "5": "f",
-              "6": "i",
-              "7": "l",
-              "8": "e",
-              "9": "-",
-              "default": "test-file-stub",
-            }
-          }
+          src="test-file-stub"
         />
          to manage your transactions.
          
@@ -1902,25 +1830,7 @@ exports[`Storyshots Common / Wallet Onboarding Not Enabled 1`] = `
         If you do not see the MetaMask popup, please click the 
         <img
           className="sc-fzXfQu ihvvef sc-LzMDY hXRxoh"
-          src={
-            Object {
-              "0": "t",
-              "1": "e",
-              "10": "s",
-              "11": "t",
-              "12": "u",
-              "13": "b",
-              "2": "s",
-              "3": "t",
-              "4": "-",
-              "5": "f",
-              "6": "i",
-              "7": "l",
-              "8": "e",
-              "9": "-",
-              "default": "test-file-stub",
-            }
-          }
+          src="test-file-stub"
         />
          icon in your browser address bar.
       </p>
@@ -2297,25 +2207,7 @@ exports[`Storyshots Common / Wallet Onboarding Save address to CMS profile 1`] =
         >
           <img
             className="sc-fzXfQu ihvvef"
-            src={
-              Object {
-                "0": "t",
-                "1": "e",
-                "10": "s",
-                "11": "t",
-                "12": "u",
-                "13": "b",
-                "2": "s",
-                "3": "t",
-                "4": "-",
-                "5": "f",
-                "6": "i",
-                "7": "l",
-                "8": "e",
-                "9": "-",
-                "default": "test-file-stub",
-              }
-            }
+            src="test-file-stub"
           />
           0xabc1230000000000000000000000000000abc123
         </div>
@@ -2744,25 +2636,7 @@ exports[`Storyshots Common / Wallet Onboarding Wrong Network 1`] = `
     >
       <img
         className="sc-LzMDZ emoDzV"
-        src={
-          Object {
-            "0": "t",
-            "1": "e",
-            "10": "s",
-            "11": "t",
-            "12": "u",
-            "13": "b",
-            "2": "s",
-            "3": "t",
-            "4": "-",
-            "5": "f",
-            "6": "i",
-            "7": "l",
-            "8": "e",
-            "9": "-",
-            "default": "test-file-stub",
-          }
-        }
+        src="test-file-stub"
       />
       <h4
         className="sc-AykKH CwENs"
@@ -2785,25 +2659,7 @@ exports[`Storyshots Common / Wallet Onboarding Wrong Network 1`] = `
         to switch networks in MetaMask 
         <img
           className="sc-fzXfQu ihvvef sc-LzMDY hXRxoh"
-          src={
-            Object {
-              "0": "t",
-              "1": "e",
-              "10": "s",
-              "11": "t",
-              "12": "u",
-              "13": "b",
-              "2": "s",
-              "3": "t",
-              "4": "-",
-              "5": "f",
-              "6": "i",
-              "7": "l",
-              "8": "e",
-              "9": "-",
-              "default": "test-file-stub",
-            }
-          }
+          src="test-file-stub"
         />
       </p>
       <p>

--- a/packages/components/src/icons/MetaMaskIcons.tsx
+++ b/packages/components/src/icons/MetaMaskIcons.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
-import * as metamaskSideLogoUrl from "../images/img-metamask-small@2x.png";
-import * as metamaskFrontLogoUrl from "../images/img-metamask-small-front@2x.png";
+import metamaskSideLogoUrl from "../images/img-metamask-small@2x.png";
+import metamaskFrontLogoUrl from "../images/img-metamask-small-front@2x.png";
 
 export interface MetaMaskImgProps {
   className?: string;

--- a/packages/components/src/icons/__snapshots__/icon.stories.storyshot
+++ b/packages/components/src/icons/__snapshots__/icon.stories.storyshot
@@ -10257,25 +10257,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons MetaMaskFrontIcon 1`] = 
     >
       <img
         className="sc-fzXfQu ihvvef"
-        src={
-          Object {
-            "0": "t",
-            "1": "e",
-            "10": "s",
-            "11": "t",
-            "12": "u",
-            "13": "b",
-            "2": "s",
-            "3": "t",
-            "4": "-",
-            "5": "f",
-            "6": "i",
-            "7": "l",
-            "8": "e",
-            "9": "-",
-            "default": "test-file-stub",
-          }
-        }
+        src="test-file-stub"
       />
     </div>
   </div>
@@ -10595,25 +10577,7 @@ exports[`Storyshots Pattern Library / icons / SVG Icons MetaMaskSideIcon 1`] = `
     >
       <img
         className="sc-fzXfQu ihvvef"
-        src={
-          Object {
-            "0": "t",
-            "1": "e",
-            "10": "s",
-            "11": "t",
-            "12": "u",
-            "13": "b",
-            "2": "s",
-            "3": "t",
-            "4": "-",
-            "5": "f",
-            "6": "i",
-            "7": "l",
-            "8": "e",
-            "9": "-",
-            "default": "test-file-stub",
-          }
-        }
+        src="test-file-stub"
       />
     </div>
   </div>

--- a/packages/components/src/imageUrls.ts
+++ b/packages/components/src/imageUrls.ts
@@ -1,13 +1,13 @@
-import * as metaMaskNetworkSwitchImgUrl from "./images/img-metamask-networkswitch@2x.png";
-import * as metaMaskLoginImgUrl from "./images/img-metamask-login@2x.png";
-import * as metaMaskFrontLargeImgUrl from "./images/img-metamask-large-front@2x.png";
-import * as metaMaskConnectImgUrl from "./images/img-metamask-connectreq-banner@2x.png";
-import * as metaMaskSignImgUrl from "./images/img-metamask-sign@2x.png";
+import metaMaskNetworkSwitchImgUrl from "./images/img-metamask-networkswitch@2x.png";
+import metaMaskLoginImgUrl from "./images/img-metamask-login@2x.png";
+import metaMaskFrontLargeImgUrl from "./images/img-metamask-large-front@2x.png";
+import metaMaskConnectImgUrl from "./images/img-metamask-connectreq-banner@2x.png";
+import metaMaskSignImgUrl from "./images/img-metamask-sign@2x.png";
 
-import * as applicationSavedImgUrl from "./images/img-application-saved@2x.png";
-import * as applicationSubmittedImgUrl from "./images/img-application-submitted@2x.png";
-import * as grantSubmittedImgUrl from "./images/img-grant-submitted@2x.png";
-import * as defaultNewsroomImgUrl from "./images/img-default-newsroom@2x.png";
+import applicationSavedImgUrl from "./images/img-application-saved@2x.png";
+import applicationSubmittedImgUrl from "./images/img-application-submitted@2x.png";
+import grantSubmittedImgUrl from "./images/img-grant-submitted@2x.png";
+import defaultNewsroomImgUrl from "./images/img-default-newsroom@2x.png";
 
 export {
   metaMaskNetworkSwitchImgUrl,


### PR DESCRIPTION
I broke this in the last commit by turning on es6ModuleInterop in order to get web3 library to load. This commit changes it so png imports use the default import https://github.com/joincivil/Civil/commit/24766289f7e80b06e6b650648a9788cbb3999168#diff-52424fbfcf31b62270d93d195c7fd19cR8