### PR TITLE
fix(dapp): add boost embed back in refactored dapp architecture

### DIFF
--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -26,7 +26,6 @@ import config from "../helpers/config";
 import { isNetworkSupported } from "../helpers/networkHelpers";
 
 import AsyncComponent from "./utility/AsyncComponent";
-import { analyticsEvent } from "../redux/actionCreators/analytics";
 import { CivilHelperContext } from "../apis/CivilHelper";
 
 import { initializeContractAddresses } from "../helpers/contractAddresses";
@@ -68,7 +67,6 @@ export const Main: React.FunctionComponent = () => {
 
   React.useEffect(() => {
     setNetworkValue(parseInt(config.DEFAULT_ETHEREUM_NETWORK!, 10));
-    civilCtx.setAnalyticsEvent(fireAnalyticsEvent);
     const civil = civilCtx.civil!;
     const networkSub = civil.networkStream.subscribe(onNetworkUpdated);
     const networkNameSub = civil.networkNameStream.subscribe(onNetworkNameUpdated);
@@ -85,10 +83,6 @@ export const Main: React.FunctionComponent = () => {
       accountSub.unsubscribe();
     };
   }, [civilCtx]);
-
-  function fireAnalyticsEvent(category: string, action: string, label: string, value: number): void {
-    dispatch!(analyticsEvent({ category, action, label, value }));
-  }
 
   async function onNetworkUpdated(network: number): Promise<void> {
     dispatch!(setNetwork(network.toString()));

--- a/packages/dapp/src/constants.ts
+++ b/packages/dapp/src/constants.ts
@@ -2,8 +2,17 @@ import * as React from "react";
 import { BoostLoader } from "@joincivil/sdk";
 
 /** Routes that should load components outside of Main.tsx and header and footer etc., but which will still inherit config, civil context, Apollo provider, etc. */
-export const standaloneRoutes: Array<{ pathname: string; component: React.ComponentType }> = [
-  { pathname: "/boost-embed/:boostId/:payment?", component: BoostLoader },
+export const standaloneRoutes: Array<{
+  /** `pathStem` is a hack needed to determine whether to show `RegistryShell` component or not (since we don't want to show it for boost embed or anything else like it. At the point in which `RegistryShell` is displayed, the `Route` that parses `pathname` hasn't been loaded yet so `router.location.pathname` returns "/boost-embed/abc123" instead of "/boost-embed/:boostId/:payment?", so we just have to check for "/boost-embed/". */
+  pathStem: string;
+  pathname: string;
+  component: React.ComponentType;
+}> = [
+  {
+    pathStem: "/boost-embed/",
+    pathname: "/boost-embed/:boostId/:payment?",
+    component: BoostLoader,
+  },
 ];
 
 export enum routes {

--- a/packages/dapp/src/registry/RegistryApp.tsx
+++ b/packages/dapp/src/registry/RegistryApp.tsx
@@ -3,10 +3,10 @@ import { withRouter, RouteComponentProps } from "react-router";
 import { RegistryShell } from "./RegistryShell";
 import { standaloneRoutes } from "../constants";
 
-const RegistrySection = React.lazy(async () => {
-  console.log("loading RegistrySection");
-  const rtn = await import("./RegistrySection");
-  console.log("loaded RegistrySection");
+const RegistryWrapper = React.lazy(async () => {
+  console.log("loading RegistryWrapper");
+  const rtn = await import("./RegistryWrapper");
+  console.log("loaded RegistryWrapper");
   return rtn;
 });
 
@@ -15,7 +15,7 @@ const RegistryAppComponent = (props: RouteComponentProps) => {
 
   return (
     <React.Suspense fallback={isStandaloneRoute ? <></> : <RegistryShell />}>
-      <RegistrySection />
+      <RegistryWrapper />
     </React.Suspense>
   );
 };

--- a/packages/dapp/src/registry/RegistryApp.tsx
+++ b/packages/dapp/src/registry/RegistryApp.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
+import { withRouter, RouteComponentProps } from "react-router";
 import { RegistryShell } from "./RegistryShell";
+import { standaloneRoutes } from "../constants";
 
 const RegistrySection = React.lazy(async () => {
   console.log("loading RegistrySection");
@@ -8,10 +10,16 @@ const RegistrySection = React.lazy(async () => {
   return rtn;
 });
 
-export const RegistryApp = () => (
-  <React.Suspense fallback={<RegistryShell />}>
-    <RegistrySection />
-  </React.Suspense>
-);
+const RegistryAppComponent = (props: RouteComponentProps) => {
+  const isStandaloneRoute = standaloneRoutes.find(route => props.location.pathname.indexOf(route.pathStem) === 0);
+
+  return (
+    <React.Suspense fallback={isStandaloneRoute ? <></> : <RegistryShell />}>
+      <RegistrySection />
+    </React.Suspense>
+  );
+};
+
+export const RegistryApp = withRouter(RegistryAppComponent);
 
 export default RegistryApp;

--- a/packages/dapp/src/registry/RegistrySection.tsx
+++ b/packages/dapp/src/registry/RegistrySection.tsx
@@ -5,10 +5,12 @@ import Footer from "../components/Footer";
 import { ApolloProvider } from "react-apollo";
 import { getApolloClient } from "@joincivil/utils";
 import config from "../helpers/config";
+import { standaloneRoutes } from "../constants";
 import { ErrorBoundry } from "../components/errors/ErrorBoundry";
 
 import { CivilProvider } from "@joincivil/components";
 import { ConnectedRouter } from "connected-react-router";
+import { Route, Switch } from "react-router-dom";
 
 import { store, history } from "../redux/store";
 import { CivilHelperProvider } from "../apis/CivilHelper";
@@ -78,12 +80,21 @@ export class RegistrySection extends React.Component {
             >
               <CivilHelperProvider>
                 <ConnectedRouter history={history}>
-                  <>
-                    <Web3AuthWrapper />
-                    <GlobalNav />
-                    <Main />
-                    <Footer />
-                  </>
+                  <React.Suspense fallback={<></>}>
+                    <Switch>
+                      {standaloneRoutes.map((route: any) => (
+                        <Route key={route.pathname} path={route.pathname} component={route.component} />
+                      ))}
+                      <Route>
+                        <>
+                          <Web3AuthWrapper />
+                          <GlobalNav />
+                          <Main />
+                          <Footer />
+                        </>
+                      </Route>
+                    </Switch>
+                  </React.Suspense>
                 </ConnectedRouter>
               </CivilHelperProvider>
             </CivilProvider>

--- a/packages/dapp/src/registry/RegistrySection.tsx
+++ b/packages/dapp/src/registry/RegistrySection.tsx
@@ -1,108 +1,42 @@
 import * as React from "react";
+import { useDispatch } from "react-redux";
+import { Route, Switch } from "react-router-dom";
+import { CivilContext, ICivilContext } from "@joincivil/components";
+import { standaloneRoutes } from "../constants";
+import { Web3AuthWrapper } from "../components/Web3AuthWrapper";
 import { GlobalNav } from "../components/GlobalNav";
 import Main from "../components/Main";
 import Footer from "../components/Footer";
-import { ApolloProvider } from "react-apollo";
-import { getApolloClient } from "@joincivil/utils";
-import config from "../helpers/config";
-import { standaloneRoutes } from "../constants";
-import { ErrorBoundry } from "../components/errors/ErrorBoundry";
+import { analyticsEvent } from "../redux/actionCreators/analytics";
 
-import { CivilProvider } from "@joincivil/components";
-import { ConnectedRouter } from "connected-react-router";
-import { Route, Switch } from "react-router-dom";
+export const RegistrySection: React.FunctionComponent = () => {
+  const civilCtx = React.useContext<ICivilContext>(CivilContext);
+  const dispatch = useDispatch();
 
-import { store, history } from "../redux/store";
-import { CivilHelperProvider } from "../apis/CivilHelper";
-import * as WSProvider from "web3-providers-ws";
-import { INFURA_WEBSOCKET_HOSTS } from "@joincivil/ethapi";
-import Web3 from "web3";
-import { Web3AuthWrapper } from "../components/Web3AuthWrapper";
-
-import { Provider } from "react-redux";
-
-console.log("using config:", config);
-
-const client = getApolloClient();
-
-const pluginConfig = {
-  dmz: {
-    targetOrigin: config.KIRBY_TARGET_ORIGIN,
-    iframeSrc: config.KIRBY_IFRAME_SRC,
-  },
-  ethereum: {
-    defaultNetwork: config.DEFAULT_ETHEREUM_NETWORK === "1" ? "mainnet" : "rinkeby",
-    networks: {
-      mainnet: INFURA_WEBSOCKET_HOSTS.MAINNET + "/" + config.INFURA_APP_KEY,
-      rinkeby: INFURA_WEBSOCKET_HOSTS.RINKEBY + "/" + config.INFURA_APP_KEY,
-    },
-  },
-};
-
-function makeLegacyWeb3(): any {
-  let provider;
-  if ((window as any).ethereum) {
-    provider = (window as any).ethereum;
-  } else {
-    switch (config.DEFAULT_ETHEREUM_NETWORK!) {
-      case "1":
-        provider = new WSProvider(INFURA_WEBSOCKET_HOSTS.MAINNET + "/" + config.INFURA_APP_KEY);
-        break;
-      case "4":
-        provider = new WSProvider(INFURA_WEBSOCKET_HOSTS.RINKEBY + "/" + config.INFURA_APP_KEY);
-        break;
-      default:
-        provider = new WSProvider(INFURA_WEBSOCKET_HOSTS.RINKEBY + "/" + config.INFURA_APP_KEY);
-        break;
+  React.useEffect(() => {
+    function fireAnalyticsEvent(category: string, action: string, label: string, value: number): void {
+      dispatch!(analyticsEvent({ category, action, label, value }));
     }
-  }
+    civilCtx.setAnalyticsEvent(fireAnalyticsEvent);
+  }, [civilCtx, dispatch]);
 
-  const web3 = new Web3(provider);
-  return web3;
-}
-
-export class RegistrySection extends React.Component {
-  private featureFlags: string[];
-  public constructor(props: any) {
-    super(props);
-    this.featureFlags = config.FEATURE_FLAGS ? config.FEATURE_FLAGS.split(",") : [];
-  }
-  public render(): JSX.Element {
-    return (
-      <Provider store={store}>
-        <ErrorBoundry>
-          <ApolloProvider client={client}>
-            <CivilProvider
-              pluginConfig={pluginConfig}
-              featureFlags={this.featureFlags}
-              config={config}
-              makeLegacyWeb3={makeLegacyWeb3}
-            >
-              <CivilHelperProvider>
-                <ConnectedRouter history={history}>
-                  <React.Suspense fallback={<></>}>
-                    <Switch>
-                      {standaloneRoutes.map((route: any) => (
-                        <Route key={route.pathname} path={route.pathname} component={route.component} />
-                      ))}
-                      <Route>
-                        <>
-                          <Web3AuthWrapper />
-                          <GlobalNav />
-                          <Main />
-                          <Footer />
-                        </>
-                      </Route>
-                    </Switch>
-                  </React.Suspense>
-                </ConnectedRouter>
-              </CivilHelperProvider>
-            </CivilProvider>
-          </ApolloProvider>
-        </ErrorBoundry>
-      </Provider>
-    );
-  }
-}
+  return (
+    <React.Suspense fallback={<></>}>
+      <Switch>
+        {standaloneRoutes.map((route: any) => (
+          <Route key={route.pathname} path={route.pathname} component={route.component} />
+        ))}
+        <Route>
+          <>
+            <Web3AuthWrapper />
+            <GlobalNav />
+            <Main />
+            <Footer />
+          </>
+        </Route>
+      </Switch>
+    </React.Suspense>
+  );
+};
 
 export default RegistrySection;

--- a/packages/dapp/src/registry/RegistryWrapper.tsx
+++ b/packages/dapp/src/registry/RegistryWrapper.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+import { ApolloProvider } from "react-apollo";
+import { getApolloClient } from "@joincivil/utils";
+import config from "../helpers/config";
+import { ErrorBoundry } from "../components/errors/ErrorBoundry";
+import { RegistrySection } from "./RegistrySection";
+
+import { CivilProvider } from "@joincivil/components";
+import { ConnectedRouter } from "connected-react-router";
+
+import { store, history } from "../redux/store";
+import { CivilHelperProvider } from "../apis/CivilHelper";
+import * as WSProvider from "web3-providers-ws";
+import { INFURA_WEBSOCKET_HOSTS } from "@joincivil/ethapi";
+import Web3 from "web3";
+
+import { Provider } from "react-redux";
+
+console.log("using config:", config);
+
+const client = getApolloClient();
+
+const pluginConfig = {
+  dmz: {
+    targetOrigin: config.KIRBY_TARGET_ORIGIN,
+    iframeSrc: config.KIRBY_IFRAME_SRC,
+  },
+  ethereum: {
+    defaultNetwork: config.DEFAULT_ETHEREUM_NETWORK === "1" ? "mainnet" : "rinkeby",
+    networks: {
+      mainnet: INFURA_WEBSOCKET_HOSTS.MAINNET + "/" + config.INFURA_APP_KEY,
+      rinkeby: INFURA_WEBSOCKET_HOSTS.RINKEBY + "/" + config.INFURA_APP_KEY,
+    },
+  },
+};
+
+function makeLegacyWeb3(): any {
+  let provider;
+  if ((window as any).ethereum) {
+    provider = (window as any).ethereum;
+  } else {
+    switch (config.DEFAULT_ETHEREUM_NETWORK!) {
+      case "1":
+        provider = new WSProvider(INFURA_WEBSOCKET_HOSTS.MAINNET + "/" + config.INFURA_APP_KEY);
+        break;
+      case "4":
+        provider = new WSProvider(INFURA_WEBSOCKET_HOSTS.RINKEBY + "/" + config.INFURA_APP_KEY);
+        break;
+      default:
+        provider = new WSProvider(INFURA_WEBSOCKET_HOSTS.RINKEBY + "/" + config.INFURA_APP_KEY);
+        break;
+    }
+  }
+
+  const web3 = new Web3(provider);
+  return web3;
+}
+
+export class RegistryWrapper extends React.Component {
+  private featureFlags: string[];
+  public constructor(props: any) {
+    super(props);
+    this.featureFlags = config.FEATURE_FLAGS ? config.FEATURE_FLAGS.split(",") : [];
+  }
+  public render(): JSX.Element {
+    return (
+      <Provider store={store}>
+        <ErrorBoundry>
+          <ApolloProvider client={client}>
+            <CivilProvider
+              pluginConfig={pluginConfig}
+              featureFlags={this.featureFlags}
+              config={config}
+              makeLegacyWeb3={makeLegacyWeb3}
+            >
+              <CivilHelperProvider>
+                <ConnectedRouter history={history}>
+                  <RegistrySection />
+                </ConnectedRouter>
+              </CivilHelperProvider>
+            </CivilProvider>
+          </ApolloProvider>
+        </ErrorBoundry>
+      </Provider>
+    );
+  }
+}
+
+export default RegistryWrapper;


### PR DESCRIPTION
A bit hacky because boost embed should go inside `RegistrySection` (it reuses no less than 6 of the registry wrapper components) BUT if we are on the boost embed then we don't want to show the fallback `RegistryShell` nav bar (and whatever else that contains in the future) while it's loading.

It's a small hack, but open to any other ideas about how to do this or how to make more explicit.