### PR TITLE
Boost embed style updates [CIVIL-1079] [CIVIL-1031]

### DIFF
--- a/packages/components/src/BrowserCompatible/__snapshots__/BrowserCompatible.stories.storyshot
+++ b/packages/components/src/BrowserCompatible/__snapshots__/BrowserCompatible.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
     }
   >
     <div
-      className="sc-LzMFq cCStJO"
+      className="sc-LzMFq ePvaOO"
     >
       <h2
         className="sc-LzMEa bdHkEo"
@@ -32,7 +32,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
         className="sc-LzMFs hFLVXZ"
       >
         <a
-          className="sc-fzXfOu sc-fzXfOw sc-LzMFQ eHnhHX"
+          className="sc-fzXfOu sc-fzXfOw sc-LzMFQ lWOSz"
           href="https://www.google.com/chrome/"
           size="MEDIUM_WIDE"
           target="_blank"
@@ -50,7 +50,7 @@ exports[`Storyshots Common / Browser Compatible Message Browser Compatible 1`] =
           Get Google Chrome
         </a>
         <a
-          className="sc-fzXfOu sc-fzXfOw sc-LzMFQ eHnhHX"
+          className="sc-fzXfOu sc-fzXfOw sc-LzMFQ lWOSz"
           href="https://www.mozilla.org/en-US/firefox/"
           size="MEDIUM_WIDE"
           target="_blank"

--- a/packages/components/src/CurrencyConverter/__snapshots__/CurrencyConverter.stories.storyshot
+++ b/packages/components/src/CurrencyConverter/__snapshots__/CurrencyConverter.stories.storyshot
@@ -28,7 +28,7 @@ exports[`Storyshots Common / Currency / Currency Converter CVL to ETH 1`] = `
             Enter CVL Amount
           </label>
           <div
-            className="sc-LzNtn jhRIYT"
+            className="sc-LzNtn iEnFtr"
           >
             <div
               className="sc-fzXfOY gKIhJl"
@@ -56,7 +56,7 @@ exports[`Storyshots Common / Currency / Currency Converter CVL to ETH 1`] = `
           </div>
         </div>
         <div
-          className="sc-LzNtr iSFlZE"
+          className="sc-LzNtr cmdadI"
         >
           <svg
             height="14"
@@ -90,7 +90,7 @@ exports[`Storyshots Common / Currency / Currency Converter CVL to ETH 1`] = `
             Converted ETH
           </label>
           <div
-            className="sc-LzNto guEzcG"
+            className="sc-LzNto dSTFUK"
           >
             <div
               className="sc-LzNtp dUJThs"
@@ -752,7 +752,7 @@ exports[`Storyshots Common / Currency / Currency Converter USD to ETH 1`] = `
             Enter USD Amount
           </label>
           <div
-            className="sc-LzNtn jhRIYT"
+            className="sc-LzNtn iEnFtr"
           >
             <div
               className="sc-fzXfOY gKIhJl"
@@ -781,7 +781,7 @@ exports[`Storyshots Common / Currency / Currency Converter USD to ETH 1`] = `
           </div>
         </div>
         <div
-          className="sc-LzNtr iSFlZE"
+          className="sc-LzNtr cmdadI"
         >
           <svg
             height="14"
@@ -815,7 +815,7 @@ exports[`Storyshots Common / Currency / Currency Converter USD to ETH 1`] = `
             Converted ETH
           </label>
           <div
-            className="sc-LzNto guEzcG"
+            className="sc-LzNto dSTFUK"
           >
             <div
               className="sc-LzNtp dUJThs"

--- a/packages/components/src/EthAddressViewer/__snapshots__/EthAddressViewer.stories.storyshot
+++ b/packages/components/src/EthAddressViewer/__snapshots__/EthAddressViewer.stories.storyshot
@@ -22,7 +22,7 @@ exports[`Storyshots Common / Ethereum / EthAddress Viewer EthAddress Viewer 1`] 
           CVL Token Contract Address
         </div>
         <div
-          className="sc-LzLOP XIdJc"
+          className="sc-LzLOP euxlbs"
         >
           <div
             className="sc-LzLOQ lbxptr"

--- a/packages/components/src/Hero/__snapshots__/Hero.stories.storyshot
+++ b/packages/components/src/Hero/__snapshots__/Hero.stories.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Registry / Hero Homepage 1`] = `
     }
   >
     <div
-      className="sc-LzMkq fjRAnj"
+      className="sc-LzMkq hwgfAP"
     >
       <div
         className="sc-LzMkr dJOLrl"

--- a/packages/components/src/ListingDetailHeader/__snapshots__/ListingDetailHeader.stories.storyshot
+++ b/packages/components/src/ListingDetailHeader/__snapshots__/ListingDetailHeader.stories.storyshot
@@ -18,13 +18,13 @@ exports[`Storyshots Registry / Listing / Listing Details Header Accepting Votes 
           className="sc-LzLOR cdDjQC"
         >
           <div
-            className="sc-LzLPp hqXEqF"
+            className="sc-LzLPp eYwqDp"
           >
             <div
-              className="sc-LzLOK isuHYU"
+              className="sc-LzLOK dsZOeQ"
             >
               <figure
-                className="sc-LzLPq bqXEhH"
+                className="sc-LzLPq efFlWX"
               />
               <div>
                 <div
@@ -33,7 +33,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header Accepting Votes 
                   Submit Vote
                 </div>
                 <h1
-                  className="sc-LzLPy YCXhw"
+                  className="sc-LzLPy cuwkDc"
                 >
                   The Civil Times
                 </h1>
@@ -54,15 +54,15 @@ exports[`Storyshots Registry / Listing / Listing Details Header Accepting Votes 
                   Ethereum Info
                 </button>
                 <p
-                  className="sc-LzLPW dVpYhC"
+                  className="sc-LzLPW gQEri"
                 >
                   Civil is the decentralized marketplace for sustainable journalism.
                 </p>
                 <div
-                  className="sc-LzLPY hbmRyG"
+                  className="sc-LzLPY jcNMZO"
                 >
                   <div
-                    className="sc-LzLPZ fqFpCk"
+                    className="sc-LzLPZ bPGaxs"
                   >
                     <a
                       className="sc-fzXfOu sc-fzXfOy sc-LzLPt dOIxrY"
@@ -748,13 +748,13 @@ exports[`Storyshots Registry / Listing / Listing Details Header In Application 1
           className="sc-LzLOR cdDjQC"
         >
           <div
-            className="sc-LzLPp hqXEqF"
+            className="sc-LzLPp eYwqDp"
           >
             <div
-              className="sc-LzLOK isuHYU"
+              className="sc-LzLOK dsZOeQ"
             >
               <figure
-                className="sc-LzLPq bqXEhH"
+                className="sc-LzLPq efFlWX"
               />
               <div>
                 <div
@@ -763,7 +763,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header In Application 1
                   Awaiting Approval
                 </div>
                 <h1
-                  className="sc-LzLPy YCXhw"
+                  className="sc-LzLPy cuwkDc"
                 >
                   The Civil Times
                 </h1>
@@ -784,15 +784,15 @@ exports[`Storyshots Registry / Listing / Listing Details Header In Application 1
                   Ethereum Info
                 </button>
                 <p
-                  className="sc-LzLPW dVpYhC"
+                  className="sc-LzLPW gQEri"
                 >
                   Civil is the decentralized marketplace for sustainable journalism.
                 </p>
                 <div
-                  className="sc-LzLPY hbmRyG"
+                  className="sc-LzLPY jcNMZO"
                 >
                   <div
-                    className="sc-LzLPZ fqFpCk"
+                    className="sc-LzLPZ bPGaxs"
                   >
                     <a
                       className="sc-fzXfOu sc-fzXfOy sc-LzLPt dOIxrY"
@@ -1478,17 +1478,17 @@ exports[`Storyshots Registry / Listing / Listing Details Header No phase label 1
           className="sc-LzLOR cdDjQC"
         >
           <div
-            className="sc-LzLPp hqXEqF"
+            className="sc-LzLPp eYwqDp"
           >
             <div
-              className="sc-LzLOK isuHYU"
+              className="sc-LzLOK dsZOeQ"
             >
               <figure
-                className="sc-LzLPq bqXEhH"
+                className="sc-LzLPq efFlWX"
               />
               <div>
                 <h1
-                  className="sc-LzLPy YCXhw"
+                  className="sc-LzLPy cuwkDc"
                 >
                   The Civil Times
                 </h1>
@@ -1509,15 +1509,15 @@ exports[`Storyshots Registry / Listing / Listing Details Header No phase label 1
                   Ethereum Info
                 </button>
                 <p
-                  className="sc-LzLPW dVpYhC"
+                  className="sc-LzLPW gQEri"
                 >
                   Civil is the decentralized marketplace for sustainable journalism.
                 </p>
                 <div
-                  className="sc-LzLPY hbmRyG"
+                  className="sc-LzLPY jcNMZO"
                 >
                   <div
-                    className="sc-LzLPZ fqFpCk"
+                    className="sc-LzLPZ bPGaxs"
                   >
                     <a
                       className="sc-fzXfOu sc-fzXfOy sc-LzLPt dOIxrY"
@@ -2221,13 +2221,13 @@ exports[`Storyshots Registry / Listing / Listing Details Header Revealing Votes 
           className="sc-LzLOR cdDjQC"
         >
           <div
-            className="sc-LzLPp hqXEqF"
+            className="sc-LzLPp eYwqDp"
           >
             <div
-              className="sc-LzLOK isuHYU"
+              className="sc-LzLOK dsZOeQ"
             >
               <figure
-                className="sc-LzLPq bqXEhH"
+                className="sc-LzLPq efFlWX"
               />
               <div>
                 <div
@@ -2236,7 +2236,7 @@ exports[`Storyshots Registry / Listing / Listing Details Header Revealing Votes 
                   Confirm Vote
                 </div>
                 <h1
-                  className="sc-LzLPy YCXhw"
+                  className="sc-LzLPy cuwkDc"
                 >
                   The Civil Times
                 </h1>
@@ -2257,15 +2257,15 @@ exports[`Storyshots Registry / Listing / Listing Details Header Revealing Votes 
                   Ethereum Info
                 </button>
                 <p
-                  className="sc-LzLPW dVpYhC"
+                  className="sc-LzLPW gQEri"
                 >
                   Civil is the decentralized marketplace for sustainable journalism.
                 </p>
                 <div
-                  className="sc-LzLPY hbmRyG"
+                  className="sc-LzLPY jcNMZO"
                 >
                   <div
-                    className="sc-LzLPZ fqFpCk"
+                    className="sc-LzLPZ bPGaxs"
                   >
                     <a
                       className="sc-fzXfOu sc-fzXfOy sc-LzLPt dOIxrY"

--- a/packages/components/src/ListingSummary/__snapshots__/ListingSummary.stories.storyshot
+++ b/packages/components/src/ListingSummary/__snapshots__/ListingSummary.stories.storyshot
@@ -15,7 +15,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card 1`] = `
     >
       <div>
         <div
-          className="sc-LzLtm dUFVdq"
+          className="sc-LzLtm ifhTGa"
         >
           <a
             href="/listing/0x0a"
@@ -498,11 +498,11 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
     >
       <div>
         <div
-          className="sc-LzLtl bYgurF"
+          className="sc-LzLtl gpkMoV"
         >
           <div>
             <div
-              className="sc-LzLtm dUFVdq"
+              className="sc-LzLtm ifhTGa"
             >
               <a
                 href="/listing/0x0a"
@@ -553,7 +553,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
           </div>
           <div>
             <div
-              className="sc-LzLtm dUFVdq"
+              className="sc-LzLtm ifhTGa"
             >
               <a
                 href="/listing/0x0b"
@@ -604,7 +604,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
           </div>
           <div>
             <div
-              className="sc-LzLtm dUFVdq"
+              className="sc-LzLtm ifhTGa"
             >
               <a
                 href="/listing/0x0c"
@@ -655,7 +655,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
           </div>
           <div>
             <div
-              className="sc-LzLtm dUFVdq"
+              className="sc-LzLtm ifhTGa"
             >
               <a
                 href="/listing/0x0d"
@@ -706,7 +706,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
           </div>
           <div>
             <div
-              className="sc-LzLtm dUFVdq"
+              className="sc-LzLtm ifhTGa"
             >
               <a
                 href="/listing/0x0e"
@@ -757,7 +757,7 @@ exports[`Storyshots Registry / Listing / Listing Summary Card Grid 1`] = `
           </div>
           <div>
             <div
-              className="sc-LzLtm dUFVdq"
+              className="sc-LzLtm ifhTGa"
             >
               <a
                 href="/listing/0x0f"

--- a/packages/components/src/NavBar/__snapshots__/NavBar.stories.storyshot
+++ b/packages/components/src/NavBar/__snapshots__/NavBar.stories.storyshot
@@ -20,7 +20,7 @@ exports[`Storyshots Common / Nav / Nav Bar Global Nav 1`] = `
           className="sc-LzMlF hrLAKv"
         >
           <div
-            className="sc-LzMlE jkxlSr"
+            className="sc-LzMlE jdTvIT"
           >
             <a
               href="https://civil.co"
@@ -42,13 +42,13 @@ exports[`Storyshots Common / Nav / Nav Bar Global Nav 1`] = `
             </a>
           </div>
           <div
-            className="sc-LzMCc jpJYpm"
+            className="sc-LzMCc eUBxW"
           >
             <div
-              className="sc-LzMCh cpwtKI"
+              className="sc-LzMCh iHvUso"
             >
               <span
-                className="sc-LzMCi giievm"
+                className="sc-LzMCi jWoYyK"
               >
                 <a
                   href="/registry"
@@ -57,11 +57,11 @@ exports[`Storyshots Common / Nav / Nav Bar Global Nav 1`] = `
                   Registry
                 </a>
                 <div
-                  className="sc-LzMCj jTOUhk"
+                  className="sc-LzMCj zGXEc"
                 />
               </span>
               <div
-                className="sc-LzMCH kduuTE"
+                className="sc-LzMCH eCTMlA"
               >
                 <a
                   href="/registry"
@@ -100,7 +100,7 @@ exports[`Storyshots Common / Nav / Nav Bar Global Nav 1`] = `
             </a>
           </div>
           <div
-            className="sc-LzMCd iMFJdg"
+            className="sc-LzMCd gZlBDs"
           >
             <div
               onClick={[Function]}
@@ -120,7 +120,7 @@ exports[`Storyshots Common / Nav / Nav Bar Global Nav 1`] = `
             </div>
           </div>
           <div
-            className="sc-LzMCe ZtheM"
+            className="sc-LzMCe FTzsI"
           />
         </div>
         <div

--- a/packages/components/src/Table/__snapshots__/Table.stories.storyshot
+++ b/packages/components/src/Table/__snapshots__/Table.stories.storyshot
@@ -14,24 +14,24 @@ exports[`Storyshots Pattern Library / Table Default 1`] = `
       className="sc-LzNRu hzZvuI"
     >
       <table
-        className="sc-LzMHi mMVKb"
+        className="sc-LzMHi ciArwT"
         width="100%"
       >
         <tr
           className="sc-LzMHl kfZUWq"
         >
           <th
-            className="sc-LzMHj efVnMa"
+            className="sc-LzMHj kflQmS"
           >
             Default Header
           </th>
           <th
-            className="sc-LzMHj pwdQJ"
+            className="sc-LzMHj kukOAN"
           >
             Right aligned
           </th>
           <th
-            className="sc-LzMHj fGqPyO"
+            className="sc-LzMHj bEdkym"
             colSpan={2}
           >
             Accent Col spanned header

--- a/packages/components/src/Tabs/__snapshots__/Tabs.stories.storyshot
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.stories.storyshot
@@ -31,7 +31,7 @@ exports[`Storyshots Common / Tabs Default Tabs 1`] = `
           </li>
         </ul>
         <div
-          className="sc-LzLRn bXmvfp"
+          className="sc-LzLRn kUSmeB"
           onClick={[Function]}
         >
           <svg
@@ -675,7 +675,7 @@ exports[`Storyshots Common / Tabs Round Pill Tab 1`] = `
           </li>
         </ul>
         <div
-          className="sc-LzLRn bXmvfp"
+          className="sc-LzLRn kUSmeB"
           onClick={[Function]}
         >
           <svg
@@ -1961,38 +1961,38 @@ exports[`Storyshots Common / Tabs Square Pill Tab 1`] = `
   >
     <div>
       <div
-        className="sc-LzLRq hXTnzB"
+        className="sc-LzLRq jVCnXV"
       >
         <ul
           className="sc-LzLRo gnytuo"
         >
           <li
-            className="sc-LzLRr likMtE"
+            className="sc-LzLRr hvkcSE"
             onClick={[Function]}
           >
             New Applications
           </li>
           <li
-            className="sc-LzLRr djJnPe"
+            className="sc-LzLRr jQpVni"
             onClick={[Function]}
           >
             Under Challenge
           </li>
           <li
-            className="sc-LzLRr djJnPe"
+            className="sc-LzLRr jQpVni"
             onClick={[Function]}
           >
             Appeal to Council
           </li>
           <li
-            className="sc-LzLRr djJnPe"
+            className="sc-LzLRr jQpVni"
             onClick={[Function]}
           >
             Challenge Council Appeal
           </li>
         </ul>
         <div
-          className="sc-LzLRn bXmvfp"
+          className="sc-LzLRn kUSmeB"
           onClick={[Function]}
         >
           <svg
@@ -3129,13 +3129,13 @@ exports[`Storyshots Common / Tabs Styled Large Tab 1`] = `
   >
     <div>
       <div
-        className="sc-LzLRl jdWogb"
+        className="sc-LzLRl fWgZcv"
       >
         <ul
           className="sc-LzLRo gnytuo"
         >
           <li
-            className="sc-LzLRp ifRNIy"
+            className="sc-LzLRp fytVnq"
             onClick={[Function]}
           >
             <svg
@@ -3159,7 +3159,7 @@ exports[`Storyshots Common / Tabs Styled Large Tab 1`] = `
              Approved Newsrooms
           </li>
           <li
-            className="sc-LzLRp hLeRUH"
+            className="sc-LzLRp XgtBX"
             onClick={[Function]}
           >
             <svg
@@ -3177,7 +3177,7 @@ exports[`Storyshots Common / Tabs Styled Large Tab 1`] = `
              Newsrooms In Progress
           </li>
           <li
-            className="sc-LzLRp hLeRUH"
+            className="sc-LzLRp XgtBX"
             onClick={[Function]}
           >
             <svg
@@ -3195,7 +3195,7 @@ exports[`Storyshots Common / Tabs Styled Large Tab 1`] = `
           </li>
         </ul>
         <div
-          className="sc-LzLRn bXmvfp"
+          className="sc-LzLRn kUSmeB"
           onClick={[Function]}
         >
           <svg
@@ -4205,7 +4205,7 @@ exports[`Storyshots Common / Tabs Styled Tab 1`] = `
           </li>
         </ul>
         <div
-          className="sc-LzLRn bXmvfp"
+          className="sc-LzLRn kUSmeB"
           onClick={[Function]}
         >
           <svg
@@ -5111,7 +5111,7 @@ exports[`Storyshots Common / Tabs Tabs with before/after elements in nav 1`] = `
           </span>
         </ul>
         <div
-          className="sc-LzLRn bXmvfp"
+          className="sc-LzLRn kUSmeB"
           onClick={[Function]}
         >
           <svg

--- a/packages/components/src/Tokens/__snapshots__/TokensAccount.stories.storyshot
+++ b/packages/components/src/Tokens/__snapshots__/TokensAccount.stories.storyshot
@@ -34,7 +34,7 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
             </li>
           </ul>
           <div
-            className="sc-LzLRn bXmvfp"
+            className="sc-LzLRn kUSmeB"
             onClick={[Function]}
           >
             <svg
@@ -92,10 +92,10 @@ exports[`Storyshots Storefront / User Token Account Buy Section 1`] = `
               </div>
             </div>
             <div
-              className="sc-LzNaV cELYdN"
+              className="sc-LzNaV ennDmx"
             >
               <div
-                className="sc-LzNaV cELYdN"
+                className="sc-LzNaV ennDmx"
               >
                 <h3>
                   Contribute to the Civil Foundation

--- a/packages/components/src/Tokens/buy/__snapshots__/TokensTabBuy.stories.storyshot
+++ b/packages/components/src/Tokens/buy/__snapshots__/TokensTabBuy.stories.storyshot
@@ -552,10 +552,10 @@ exports[`Storyshots Storefront / Buy Tab Buy Tab 1`] = `
         </div>
       </div>
       <div
-        className="sc-LzNaV cELYdN"
+        className="sc-LzNaV ennDmx"
       >
         <div
-          className="sc-LzNaV cELYdN"
+          className="sc-LzNaV ennDmx"
         >
           <h3>
             Contribute to the Civil Foundation

--- a/packages/components/src/__snapshots__/ModalContent.stories.storyshot
+++ b/packages/components/src/__snapshots__/ModalContent.stories.storyshot
@@ -20,7 +20,7 @@ exports[`Storyshots Pattern Library / Modals content 1`] = `
           I'm a Heading
         </h2>
         <p
-          className="sc-fzXfQt dHvjOu"
+          className="sc-fzXfQt jrRIhm"
         >
           I'm a paragraph of some sorts
         </p>

--- a/packages/components/src/context/CivilContext.ts
+++ b/packages/components/src/context/CivilContext.ts
@@ -3,6 +3,11 @@ import { Civil, UniswapService, FeatureFlagService, EthersProviderResult, makeEt
 import { AuthService } from "./AuthService";
 import ApolloClient from "apollo-client";
 
+export enum RENDER_CONTEXT {
+  DAPP,
+  EMBED,
+}
+
 export interface ICivilContext {
   // services
   civil?: Civil;
@@ -17,6 +22,8 @@ export interface ICivilContext {
   // fields that should trigger context re-renders
   currentUser: any;
 
+  renderContext: RENDER_CONTEXT;
+
   /** See `packages/dapp/src/helpers/config.ts` */
   config: any;
   // other things that should probably be put into a service
@@ -29,6 +36,7 @@ export interface CivilContextOptions {
   web3: any;
   featureFlags: string[];
   config: any;
+  renderContext?: RENDER_CONTEXT;
   apolloClient?: ApolloClient<any>;
   onAuthChange?(nextUser: any): void;
 }
@@ -63,6 +71,8 @@ export function buildCivilContext(opts: CivilContextOptions): ICivilContext {
     // fields that should trigger context re-renders
     currentUser: auth.currentUser,
     network,
+
+    renderContext: opts.renderContext || RENDER_CONTEXT.DAPP,
 
     // other things that should probably be put into a service
     config,

--- a/packages/components/src/input/__snapshots__/Input.stories.storyshot
+++ b/packages/components/src/input/__snapshots__/Input.stories.storyshot
@@ -2147,7 +2147,7 @@ exports[`Storyshots Pattern Library / Inputs Submit a link 1`] = `
   >
     <form>
       <div
-        className="sc-fzXfPL khpgYo"
+        className="sc-fzXfPL bQPrmQ"
       >
         <div
           className=" sc-fzXfLP corfVh"

--- a/packages/elements/src/containers/mediaQueries.ts
+++ b/packages/elements/src/containers/mediaQueries.ts
@@ -1,5 +1,6 @@
 export const mediaQueries = {
-  MOBILE: "@media only screen and (min-width: 320px) and (max-width: 1030px)",
+  MOBILE: "@media only screen and (max-width: 1030px)",
+  MOBILE_SMALL: "@media only screen and (max-width: 640px)",
   COARSE_POINTER: "@media (pointer: coarse)",
   HOVER: "@media (hover: hover)",
 };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,6 +10,7 @@
     "@commitlint/config-conventional": "^7.5.0",
     "@joincivil/components": "^1.9.10",
     "@joincivil/core": "^4.8.11",
+    "@joincivil/elements": "^0.0.1",
     "@joincivil/utils": "^1.9.8",
     "@svgr/webpack": "4.1.0",
     "babel-core": "7.0.0-bridge.0",

--- a/packages/sdk/src/react/boosts/BoostCard.tsx
+++ b/packages/sdk/src/react/boosts/BoostCard.tsx
@@ -15,7 +15,7 @@ import {
   BoostNotificationContain,
   BoostAmountInputWrap,
   BoostAmountInput,
-  BoostCardFlex,
+  BoostDescShareFlex,
 } from "./BoostStyledComponents";
 import { BoostPaymentSuccess } from "./BoostTextComponents";
 import { BoostNewsroom } from "./BoostNewsroom";
@@ -62,6 +62,7 @@ export class BoostCard extends React.Component<BoostCardProps, BoostCardStates> 
       btnText = "Boost Ended";
     }
     const btnDisabled = timeEnded || !newsroomData.whitelisted || this.state.amount === 0;
+    const inputDisabled = timeEnded || !newsroomData.whitelisted;
 
     if (!open) {
       return (
@@ -128,7 +129,13 @@ export class BoostCard extends React.Component<BoostCardProps, BoostCardStates> 
             </BoostProgressCol>
             <BoostAmountInputWrap>
               <BoostAmountInput>
-                <CurrencyInput label={""} placeholder={"0"} name={"BoostAmount"} onChange={this.handleAmount} />
+                <CurrencyInput
+                  label={""}
+                  placeholder={"0"}
+                  name={"BoostAmount"}
+                  onChange={this.handleAmount}
+                  disabled={inputDisabled}
+                />
               </BoostAmountInput>
               <BoostButton disabled={btnDisabled} onClick={() => this.props.handlePayments(this.state.amount)}>
                 {btnText}
@@ -151,17 +158,16 @@ export class BoostCard extends React.Component<BoostCardProps, BoostCardStates> 
               }
             />
           </BoostNotice>
-          <BoostCardFlex>
+          <BoostDescShareFlex>
             <BoostDescriptionWhy>{renderPTagsFromLineBreaks(boostData.why)}</BoostDescriptionWhy>
             <div>
-              <h3>Share this Boost</h3>
               <BoostShare
                 boostId={this.props.boostId}
                 newsroom={this.props.newsroomData.name}
                 title={boostData.title}
               />
             </div>
-          </BoostCardFlex>
+          </BoostDescShareFlex>
           <BoostDescription>
             <h3>What the outcome will be</h3>
             {renderPTagsFromLineBreaks(boostData.what)}

--- a/packages/sdk/src/react/boosts/BoostLoader.tsx
+++ b/packages/sdk/src/react/boosts/BoostLoader.tsx
@@ -1,6 +1,39 @@
 import * as React from "react";
+import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
 import { withRouter, RouteComponentProps } from "react-router";
+import { colors } from "@joincivil/elements";
 import { Boost } from "./Boost";
+
+const GlobalStyleNoScroll = createGlobalStyle`
+  html, body {
+    height: 100%;
+    overflow: hidden;
+  }
+  body {
+    border: 1px solid ${colors.accent.CIVIL_GRAY_4};
+    margin: 1px; // otherwise border can be clipped by inner edge of iframe
+    border-radius: 4px;
+  }
+`
+const OverflowLinkContainer = styled.div`
+  position: absolute;
+  z-index: 1;
+  width: 100%;
+  height: 100px;
+  bottom: 0;
+  left: 0;
+  display: table;
+  background: rgb(255,255,255);
+  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.75) 25%, rgba(255,255,255,1) 100%);
+`;
+const OverflowLink = styled.a`
+  display: table-cell;
+  text-align: center;
+  vertical-align: middle;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
 
 export interface BoostLoaderParams {
   boostId: string;
@@ -8,7 +41,15 @@ export interface BoostLoaderParams {
 }
 
 const BoostLoaderComponent = (props: RouteComponentProps<BoostLoaderParams>) => {
-  return <Boost boostId={props.match.params.boostId} open={true} payment={!!props.match.params.payment} />;
+  return (
+    <>
+      <GlobalStyleNoScroll />
+      <OverflowLinkContainer>
+        <OverflowLink href={"https://registry.civil.co/boosts/" + props.match.params.boostId} target="_blank">View this Boost &gt;</OverflowLink>
+      </OverflowLinkContainer>
+        <Boost boostId={props.match.params.boostId} open={true} payment={!!props.match.params.payment} />
+    </>
+  );
 };
 
 export const BoostLoader: React.ComponentType = withRouter(BoostLoaderComponent);

--- a/packages/sdk/src/react/boosts/BoostLoader.tsx
+++ b/packages/sdk/src/react/boosts/BoostLoader.tsx
@@ -15,7 +15,7 @@ const GlobalStyleNoScroll = createGlobalStyle`
     margin: 1px; // otherwise border can be clipped by inner edge of iframe
     border-radius: 4px;
   }
-`
+`;
 const OverflowLinkContainer = styled.div`
   position: absolute;
   z-index: 1;
@@ -24,8 +24,13 @@ const OverflowLinkContainer = styled.div`
   bottom: 0;
   left: 0;
   display: table;
-  background: rgb(255,255,255);
-  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.75) 25%, rgba(255,255,255,1) 100%);
+  background: rgb(255, 255, 255);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.75) 25%,
+    rgba(255, 255, 255, 1) 100%
+  );
 `;
 const OverflowLink = styled.a`
   display: table-cell;
@@ -53,7 +58,9 @@ const BoostLoaderComponent = (props: RouteComponentProps<BoostLoaderParams>) => 
     <>
       <GlobalStyleNoScroll />
       <OverflowLinkContainer>
-        <OverflowLink href={"https://registry.civil.co/boosts/" + props.match.params.boostId} target="_blank">View this Boost &gt;</OverflowLink>
+        <OverflowLink href={"https://registry.civil.co/boosts/" + props.match.params.boostId} target="_blank">
+          View this Boost &gt;
+        </OverflowLink>
       </OverflowLinkContainer>
       <ThemeProvider theme={theme}>
         <Boost boostId={props.match.params.boostId} open={true} payment={!!props.match.params.payment} />

--- a/packages/sdk/src/react/boosts/BoostLoader.tsx
+++ b/packages/sdk/src/react/boosts/BoostLoader.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
 import { withRouter, RouteComponentProps } from "react-router";
+import { CivilContext, ICivilContext, RENDER_CONTEXT } from "@joincivil/components";
 import { colors } from "@joincivil/elements";
 import { Boost } from "./Boost";
 
@@ -41,13 +42,22 @@ export interface BoostLoaderParams {
 }
 
 const BoostLoaderComponent = (props: RouteComponentProps<BoostLoaderParams>) => {
+  // @TODO/toby Once https://github.com/joincivil/Civil/pull/1432 is merged this should be set at the point at which embeds fork from other paths.
+  const civilContext = React.useContext<ICivilContext>(CivilContext);
+  civilContext.renderContext = RENDER_CONTEXT.EMBED;
+  const theme = {
+    renderContext: RENDER_CONTEXT.EMBED,
+  };
+
   return (
     <>
       <GlobalStyleNoScroll />
       <OverflowLinkContainer>
         <OverflowLink href={"https://registry.civil.co/boosts/" + props.match.params.boostId} target="_blank">View this Boost &gt;</OverflowLink>
       </OverflowLinkContainer>
+      <ThemeProvider theme={theme}>
         <Boost boostId={props.match.params.boostId} open={true} payment={!!props.match.params.payment} />
+      </ThemeProvider>
     </>
   );
 };

--- a/packages/sdk/src/react/boosts/BoostNewsroom.tsx
+++ b/packages/sdk/src/react/boosts/BoostNewsroom.tsx
@@ -71,7 +71,9 @@ export class BoostNewsroom extends React.Component<BoostNewsroomProps, BoostNews
         <BoostFlexStartMobile>
           <BoostImgDivMobile>{this.renderImage()}</BoostImgDivMobile>
           <BoostNewsroomInfo>
-            <BoostNewsroomName>{this.props.newsroomData.name}</BoostNewsroomName>
+            <BoostNewsroomName href={this.state.charter && this.state.charter.newsroomUrl} target="_blank">
+              {this.props.newsroomData.name}
+            </BoostNewsroomName>
             {this.props.open && (
               <>
                 {this.props.boostOwner && (

--- a/packages/sdk/src/react/boosts/BoostNewsroom.tsx
+++ b/packages/sdk/src/react/boosts/BoostNewsroom.tsx
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { defaultNewsroomImgUrl, HelmetHelper } from "@joincivil/components";
+import {
+  defaultNewsroomImgUrl,
+  HelmetHelper,
+  CivilContext,
+  ICivilContext,
+  RENDER_CONTEXT,
+} from "@joincivil/components";
 import { CharterData } from "@joincivil/core";
 import * as IPFS from "ipfs-http-client";
 import { promisify } from "@joincivil/utils";
@@ -41,6 +47,9 @@ export interface BoostNewsroomState {
 }
 
 export class BoostNewsroom extends React.Component<BoostNewsroomProps, BoostNewsroomState> {
+  public static contextType = CivilContext;
+  public context!: ICivilContext;
+
   constructor(props: BoostNewsroomProps) {
     super(props);
     this.state = {
@@ -113,7 +122,7 @@ export class BoostNewsroom extends React.Component<BoostNewsroomProps, BoostNews
   }
 
   private renderNewsroomURL(): JSX.Element {
-    if (this.state.charter) {
+    if (this.state.charter && this.context.renderContext !== RENDER_CONTEXT.EMBED) {
       return (
         <a href={this.state.charter.newsroomUrl} target="_blank">
           Visit Newsroom <MobileStyle>&raquo;</MobileStyle>

--- a/packages/sdk/src/react/boosts/BoostShare.tsx
+++ b/packages/sdk/src/react/boosts/BoostShare.tsx
@@ -1,11 +1,20 @@
 import * as React from "react";
 import { colors, ShareEmailIcon, ShareTwitterIcon } from "@joincivil/components";
+import { mediaQueries } from "@joincivil/elements";
 import styled from "styled-components";
 import { BoostShareEmbed } from "./BoostShareEmbed";
+import { BoostShareHeading } from "./BoostStyledComponents";
 
 const BoostShareWrap = styled.span`
+  position: relative;
+  z-index: 10;
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
+
+  ${mediaQueries.MOBILE_SMALL} {
+    margin-bottom: 12px;
+    justify-content: space-around;
+  }
 
   a {
     cursor: pointer;
@@ -36,15 +45,18 @@ export class BoostShare extends React.Component<BoostShareProps> {
     const emailShare = this.getEmailURL(boostUrl);
 
     return (
-      <BoostShareWrap>
-        <a href={twitterShare} target="_blank">
-          <ShareTwitterIcon />
-        </a>
-        <a href={emailShare} target="_blank">
-          <ShareEmailIcon />
-        </a>
-        <BoostShareEmbed boostId={this.props.boostId} />
-      </BoostShareWrap>
+      <>
+        <BoostShareHeading>Share this Boost</BoostShareHeading>
+        <BoostShareWrap>
+          <a href={twitterShare} target="_blank">
+            <ShareTwitterIcon />
+          </a>
+          <a href={emailShare} target="_blank">
+            <ShareEmailIcon />
+          </a>
+          <BoostShareEmbed boostId={this.props.boostId} />
+        </BoostShareWrap>
+      </>
     );
   }
 

--- a/packages/sdk/src/react/boosts/BoostShareEmbed.tsx
+++ b/packages/sdk/src/react/boosts/BoostShareEmbed.tsx
@@ -35,8 +35,8 @@ export const BoostShareEmbed = (props: BoostShareEmbedProps) => {
               Copy and paste this HTML code into your website where you would like this Boost to embedded:
             </BoostModalContent>
             <EmbedCode>
-              &lt;iframe src="https://registry.civil.co/boost-embed/{props.boostId}" style="width: 100%; height:
-              500px"&gt;&lt;/iframe&gt;
+              &lt;iframe src="https://registry.civil.co/boost-embed/{props.boostId}" style="display: block; width: 100%;
+              height: 500px; margin: 32px 0;"&gt;&lt;/iframe&gt;
             </EmbedCode>
           </ModalContain>
         </Modal>

--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -196,33 +196,41 @@ export const BoostNewsroomInfo = styled.div`
   }
 `;
 
-export const BoostNewsroomName = styled.div`
-  color: ${colors.accent.CIVIL_GRAY_0};
-  font-family: ${fonts.SANS_SERIF};
-  font-size: 18px;
-  line-height: 26px;
-  font-weight: 200;
-  margin-right: 20px;
+export const BoostNewsroomName = styled.a`
+  // override <a> specificity
+  && {
+    color: ${colors.accent.CIVIL_GRAY_0} !important;
+    font-family: ${fonts.SANS_SERIF};
+    font-size: 18px;
+    line-height: 26px;
+    font-weight: 200;
+    margin-right: 20px;
+  }
 
   ${mediaQueries.MOBILE} {
     font-size: 14px;
   }
 `;
 
-export const BoostCardFlex = styled.div`
+export const BoostDescShareFlex = styled.div`
   display: flex;
+  ${mediaQueries.MOBILE_SMALL} {
+    flex-direction: column-reverse;
+  }
+`;
 
-  h3 {
-    font-size: 14px;
-    font-weight: bold;
-    line-height: 19px;
-    margin: 7px 0 10px;
+export const BoostShareHeading = styled.h3`
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 19px;
+  margin: 5px 0 10px;
+  white-space: nowrap;
 
-    ${mediaQueries.MOBILE} {
-      color: ${colors.primary.BLACK};
-      font-size: 16px;
-      line-height: 28px;
-    }
+  ${mediaQueries.MOBILE} {
+    color: ${colors.primary.BLACK};
+    font-size: 16px;
+    line-height: 28px;
+    margin-top: 1px;
   }
 `;
 

--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { colors, fonts, mediaQueries, Button, InvertedButton } from "@joincivil/components";
+import { colors, fonts, mediaQueries, Button, InvertedButton, RENDER_CONTEXT } from "@joincivil/components";
 
 export interface BoostStyleProps {
   open?: boolean;
@@ -39,6 +39,10 @@ export const BoostTitle = styled.h2`
   font-weight: bold;
   margin: 0 0 8px;
   transition: color 0.25s ease;
+
+  ${props =>
+    props.theme.renderContext === RENDER_CONTEXT.EMBED &&
+    "white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"}
 
   ${mediaQueries.MOBILE} {
     font-size: 16px;


### PR DESCRIPTION
Adds `renderContext` attribute to `CivilContext` which can be (currently) set to `DAPP` (default) or `EMBED` so that we can conditionally render some Boost stuff based on that context. Also adds that value in `styled-components` theme

Style updates:

- Disable input field when boost is ended
- Prevent scrolling in embed + show fading-out "view boost" link
- Add border to embed
- Link boost newsroom name to newsroom
- Better responsiveness for boost share widget
- Hide "visit newsroom" link on embed
- Truncate boost title length in embed