### PR TITLE
fix(dapp): set up analytics in AppProvider so boost embed can use again

### DIFF
--- a/packages/dapp/src/components/providers/AnalyticsProvider.tsx
+++ b/packages/dapp/src/components/providers/AnalyticsProvider.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { useDispatch } from "react-redux";
+import { CivilContext, ICivilContext } from "@joincivil/components";
+import { analyticsEvent } from "../../redux/actionCreators/analytics";
+
+export const AnalyticsProvider: React.FunctionComponent = ({ children }) => {
+  const civilCtx = React.useContext<ICivilContext>(CivilContext);
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    function fireAnalyticsEvent(category: string, action: string, label: string, value: number): void {
+      dispatch!(analyticsEvent({ category, action, label, value }));
+    }
+    civilCtx.setAnalyticsEvent(fireAnalyticsEvent);
+  }, [civilCtx, dispatch]);
+
+  return <>{children}</>;
+};
+
+export default AnalyticsProvider;

--- a/packages/dapp/src/components/providers/AppProvider.tsx
+++ b/packages/dapp/src/components/providers/AppProvider.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundry } from "../errors/ErrorBoundry";
 
 import config from "../../helpers/config";
 import { store, history } from "../../redux/store";
+import AnalyticsProvider from "./AnalyticsProvider";
 
 import { Provider } from "react-redux";
 
@@ -39,7 +40,9 @@ export const AppProvider: React.FunctionComponent = ({ children }) => {
       <Provider store={store}>
         <ApolloProvider client={client}>
           <CivilProvider pluginConfig={pluginConfig} featureFlags={featureFlags} config={config}>
-            <ConnectedRouter history={history}>{children}</ConnectedRouter>
+            <AnalyticsProvider>
+              <ConnectedRouter history={history}>{children}</ConnectedRouter>
+            </AnalyticsProvider>
           </CivilProvider>
         </ApolloProvider>
       </Provider>

--- a/packages/dapp/src/registry/RegistryApp.tsx
+++ b/packages/dapp/src/registry/RegistryApp.tsx
@@ -1,25 +1,12 @@
 import * as React from "react";
-import { useDispatch } from "react-redux";
 import { Route, Switch } from "react-router-dom";
-import { CivilContext, ICivilContext } from "@joincivil/components";
 import { Web3AuthWrapper } from "../components/Web3AuthWrapper";
 import Main from "../components/Main";
 import Footer from "../components/footer/Footer";
-import { analyticsEvent } from "../redux/actionCreators/analytics";
 import { NavBar } from "../components/header/NavBar";
 import { CivilHelperProvider } from "../apis/CivilHelper";
 
 export const RegistrySection: React.FunctionComponent = () => {
-  const civilCtx = React.useContext<ICivilContext>(CivilContext);
-  const dispatch = useDispatch();
-
-  React.useEffect(() => {
-    function fireAnalyticsEvent(category: string, action: string, label: string, value: number): void {
-      dispatch!(analyticsEvent({ category, action, label, value }));
-    }
-    civilCtx.setAnalyticsEvent(fireAnalyticsEvent);
-  }, [civilCtx, dispatch]);
-
   return (
     <React.Suspense fallback={<></>}>
       <CivilHelperProvider>


### PR DESCRIPTION
Moves analytics event setup into AppProvider, via new AnalyticsProvider, so that embeds can use. This was done in a clunky way in #1430 but was removed by refactor in #1432, but the refactor supports a simpler way to implement it.