### PR TITLE
fix(dapp): workaround to fix payment route in boost embed [CIVIL-1107]

### DIFF
--- a/packages/dapp/src/constants.ts
+++ b/packages/dapp/src/constants.ts
@@ -1,3 +1,7 @@
+export enum embedRoutes {
+  BOOST = "/embed/boost/:boostId/:payment?",
+}
+
 export enum routes {
   REGISTRY_HOME = "/registry/:listingType/:subListingType?",
   REGISTRY_HOME_ROOT = "/registry",

--- a/packages/dapp/src/embeds/BoostLoader.tsx
+++ b/packages/dapp/src/embeds/BoostLoader.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled, { ThemeProvider } from "styled-components";
-import { useParams } from "react-router";
+import { useRouteMatch } from "react-router";
 import {
   CivilContext,
   ICivilContext,
@@ -12,6 +12,7 @@ import {
 import { mediaQueries } from "@joincivil/elements";
 import { Boost } from "@joincivil/sdk";
 
+import { embedRoutes } from "../constants";
 import AppProvider from "../components/providers/AppProvider";
 
 const CivilLogoLink = styled.a`
@@ -40,10 +41,10 @@ const CivilLogoLink = styled.a`
 
 export interface BoostLoaderParams {
   boostId: string;
-  payment: boolean;
+  payment?: string;
 }
 
-const BoostLoaderComponent: React.FunctionComponent<BoostLoaderParams> = ({ boostId, payment }) => {
+const BoostLoaderComponent: React.FunctionComponent = () => {
   const civilContext = React.useContext<ICivilContext>(CivilContext);
   civilContext.renderContext = RENDER_CONTEXT.EMBED;
   const theme = {
@@ -51,6 +52,9 @@ const BoostLoaderComponent: React.FunctionComponent<BoostLoaderParams> = ({ boos
     ...DEFAULT_BUTTON_THEME,
     renderContext: RENDER_CONTEXT.EMBED,
   };
+
+  // Due to a conflict between react-router v5's `BrowserRouter`, which we use, and react/redux `ConnectedRouter`, which we also use (and which would take an unknown/large refactor to change without breaking code splitting gains), neither `useParams` hook nor `withRouter` are receiving updates here, so we have to use `useRouteMatch` and manually provide the boost embed route. - @tobek
+  const { boostId, payment } = useRouteMatch<BoostLoaderParams>(embedRoutes.BOOST)!.params;
 
   return (
     <>
@@ -65,11 +69,10 @@ const BoostLoaderComponent: React.FunctionComponent<BoostLoaderParams> = ({ boos
 };
 
 const BoostLoader: React.FunctionComponent = () => {
-  const { boostId, payment } = useParams();
   return (
     <React.Suspense fallback={<></>}>
       <AppProvider>
-        <BoostLoaderComponent boostId={boostId!} payment={!!payment} />
+        <BoostLoaderComponent />
       </AppProvider>
     </React.Suspense>
   );

--- a/packages/dapp/src/embeds/EmbedsApp.tsx
+++ b/packages/dapp/src/embeds/EmbedsApp.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 
 import { Route, Switch } from "react-router-dom";
+import { embedRoutes } from "../constants";
 // apps
 const BoostLoader = React.lazy(async () => import("./BoostLoader"));
 
 export const EmbedsApp = () => {
   return (
     <Switch>
-      <Route path="/embed/boost/:boostId/:payment?" render={() => <BoostLoader />} />
+      <Route path={embedRoutes.BOOST} render={() => <BoostLoader />} />
     </Switch>
   );
 };


### PR DESCRIPTION
Dumping my notes/slack convo about this issue for posterity, but the TL;DR is just to read the code.

according to react-redux ConnectedRouter docs, if you use it you have to remove any use of BrowserRouter or else there will be these problems syncing route state. this wasn't an issue before but with upgrade from react-router v4 to v5 it's now an issue: boost embed component doesn't receive updates when route changes and no use of useParams or withRouter anywhere in the component tree works.

so one fix that works is to replace the top level BrowserRouter with ConnectedRouter, which only works when wrapped in redux Provider, so we have to lift that too, and all the redux store code, which shouldn't need much, but in practice at the moment it ends up bringing in the whole codebase and borks all the code splitting progress.

also considered getting rid of ConnectedRouter, which we only use for one thing right now, which is to automatically dispatch route change events to google analytics for pageviews, not sure how much a refactor it would be to change how that works

we could also perform the top-level App.tsx split between kirby/stories/embed/registry just using document.location instead of a router, so that we can load ConnectedRouter further down

we could also downgrade react router

for now i found a workaround where useRouteMatch works instead of useParams if you hard code the path you're on. don't know why, i assume it relies on router logic that isn't clobbered by the BrowserRouter/ConnectedRouter issue. not sure how widespread this issue will be, if it blossoms then downgrading react router will be the better call but will leave this for now