### PR TITLE
fix(sdk): get web3 working in boost embed [CIVIL-1107]

### DIFF
--- a/packages/dapp/src/embeds/BoostLoader.tsx
+++ b/packages/dapp/src/embeds/BoostLoader.tsx
@@ -62,7 +62,7 @@ const BoostLoaderComponent: React.FunctionComponent = () => {
         <CivilIcon />
       </CivilLogoLink>
       <ThemeProvider theme={theme}>
-        <Boost boostId={boostId} open={true} payment={!!payment} />
+        <Boost boostId={boostId} open={true} payment={!!payment} disableOwnerCheck={true} />
       </ThemeProvider>
     </>
   );

--- a/packages/sdk/src/react/boosts/Boost.tsx
+++ b/packages/sdk/src/react/boosts/Boost.tsx
@@ -128,7 +128,6 @@ class BoostComponent extends React.Component<BoostProps, BoostStates> {
                       title={boostData.title}
                       newsroomName={newsroomData.name}
                       paymentAddr={newsroomData.owner}
-                      walletConnected={!!this.props.walletConnected}
                       handleBackToListing={this.handleBackToListing}
                       handlePaymentSuccess={this.handlePaymentSuccess}
                       isStripeConnected={boostData.channel.isStripeConnected}

--- a/packages/sdk/src/react/boosts/BoostPermissionsHOC.tsx
+++ b/packages/sdk/src/react/boosts/BoostPermissionsHOC.tsx
@@ -10,7 +10,6 @@ export interface BoostPermissionsOuterProps {
 
 export interface BoostPermissionsInjectedProps {
   boostOwner?: boolean;
-  walletConnected?: boolean;
   newsroom?: NewsroomInstance;
   setNewsroomContractAddress(address: EthAddress): void;
 }
@@ -18,7 +17,6 @@ export interface BoostPermissionsInjectedProps {
 export interface BoostPermissionsState {
   waitingForEthEnable?: boolean;
   boostOwner?: boolean;
-  walletConnected?: boolean;
   checkingIfOwner?: boolean;
   userEthAddress?: EthAddress;
   newsroomOwners?: EthAddress[];
@@ -47,12 +45,11 @@ export const withBoostPermissions = <TProps extends BoostPermissionsInjectedProp
     }
 
     public async componentDidMount(): Promise<void> {
-      // @TODO/loginV2 migrate away from window.ethereum
-      if ((window as any).ethereum) {
+      if (!this.props.disableOwnerCheck && this.context.civil) {
         this.setState({
           waitingForEthEnable: true,
         });
-        await (window as any).ethereum.enable();
+        await this.context.civil.currentProviderEnable();
         this.setState({
           waitingForEthEnable: false,
         });
@@ -99,7 +96,6 @@ export const withBoostPermissions = <TProps extends BoostPermissionsInjectedProp
         <WrappedComponent
           {...(this.props as TProps)}
           boostOwner={this.state.boostOwner}
-          walletConnected={this.state.walletConnected}
           newsroom={this.state.newsroom}
           setNewsroomContractAddress={this.setNewsroomContractAddress}
         />
@@ -165,12 +161,7 @@ export const withBoostPermissions = <TProps extends BoostPermissionsInjectedProp
 
         if (user) {
           this.setState({
-            walletConnected: true,
             userEthAddress: user,
-          });
-        } else {
-          this.setState({
-            walletConnected: true,
           });
         }
       }

--- a/packages/sdk/src/react/boosts/payments/BoostPayOptions.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayOptions.tsx
@@ -19,7 +19,6 @@ export interface BoostPayOptionsProps {
   newsroomName: string;
   title: string;
   paymentAddr: EthAddress;
-  walletConnected: boolean;
   isStripeConnected: boolean;
   handlePaymentSuccess(): void;
 }
@@ -127,7 +126,7 @@ export class BoostPayOptions extends React.Component<BoostPayOptionsProps, Boost
   }
 
   private getPaymentTypes = () => {
-    const { isStripeConnected, boostId, newsroomName, paymentAddr, walletConnected, handlePaymentSuccess } = this.props;
+    const { isStripeConnected, boostId, newsroomName, paymentAddr, handlePaymentSuccess } = this.props;
     const { selectedEth, selectedStripe, etherToSpend, usdToSpend } = this.state;
     let isEthSelected = false;
 
@@ -150,7 +149,6 @@ export class BoostPayOptions extends React.Component<BoostPayOptionsProps, Boost
             etherToSpend={etherToSpend}
             usdToSpend={usdToSpend}
             paymentAddr={paymentAddr}
-            walletConnected={walletConnected}
             handlePaymentSuccess={handlePaymentSuccess}
           />
         );
@@ -183,7 +181,6 @@ export class BoostPayOptions extends React.Component<BoostPayOptionsProps, Boost
               usdToSpend={usdToSpend}
               handleNext={this.handleEthNext}
               paymentAddr={paymentAddr}
-              walletConnected={walletConnected}
               handlePaymentSuccess={handlePaymentSuccess}
               handlePaymentSelected={this.handlePaymentSelected}
             />

--- a/packages/sdk/src/react/boosts/payments/BoostPayments.stories.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayments.stories.tsx
@@ -50,7 +50,6 @@ storiesOf("Boosts", module)
           title={"Help The Colorado Sun stage a panel discussion about the impact of the opioid crisis on Colorado"}
           newsroomName={"The Colorado Sun"}
           paymentAddr={"0x"}
-          walletConnected={true}
           handleBackToListing={handlePaymentSuccess}
           handlePaymentSuccess={handlePaymentSuccess}
           isStripeConnected={true}

--- a/packages/sdk/src/react/boosts/payments/BoostPayments.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayments.tsx
@@ -50,7 +50,6 @@ const BoostAmount = styled.p`
 
 export interface BoostPaymentsProps {
   isStripeConnected: boolean;
-  walletConnected: boolean;
   paymentAddr: EthAddress;
   boostId: string;
   title: string;
@@ -96,7 +95,6 @@ export const BoostPayments: React.FunctionComponent<BoostPaymentsProps> = props 
         newsroomName={props.newsroomName}
         title={props.title}
         boostId={props.boostId}
-        walletConnected={props.walletConnected}
         isStripeConnected={props.isStripeConnected}
         handlePaymentSuccess={() => props.handlePaymentSuccess()}
       />


### PR DESCRIPTION
In the dapp registry app we call this from the global nav, wasn't getting called properly here. Also with this update, ethereum enable will only be called from embed once the user enters the payment flow.