### PR TITLE
Fixes and improvements for republish charter flow

### DIFF
--- a/packages/components/src/Account/Auth/EthAuth.tsx
+++ b/packages/components/src/Account/Auth/EthAuth.tsx
@@ -140,7 +140,7 @@ export class AccountEthAuth extends React.Component<AccountEthAuthProps, Account
         denied={true}
         denialText="To authenticate that you own your wallet address, you need to sign the message in your MetaMask wallet."
         cancelTransaction={this.cancelTransaction}
-        denialRestartTransactions={this.signTransactions(userSetEthAddress)}
+        restartTransactions={this.signTransactions(userSetEthAddress)}
       >
         <ModalHeading>Failed to authenticate your wallet address</ModalHeading>
       </MetaMaskModal>

--- a/packages/components/src/ChevronAnchor.tsx
+++ b/packages/components/src/ChevronAnchor.tsx
@@ -13,7 +13,11 @@ export interface ChevronAnchorProps extends React.AnchorHTMLAttributes<HTMLAncho
 export const ChevronAnchor: React.FunctionComponent<ChevronAnchorProps> = props =>
   React.createElement(
     props.component || "a",
-    props,
+    {
+      ...props,
+      // passing prop with name `component` breaks some components
+      component: undefined,
+    },
     <>
       {props.children}
       <Chevron />

--- a/packages/components/src/MetaMaskModal.tsx
+++ b/packages/components/src/MetaMaskModal.tsx
@@ -95,19 +95,21 @@ const SpanWithMargin = styled.span`
 export interface MetaMaskModalProps {
   waiting?: boolean;
   alert?: boolean;
+  errored?: boolean;
   denied?: boolean;
   signing?: boolean;
   ipfsPost?: boolean;
   bodyText?: string;
   denialText?: string;
-  denialRestartTransactions?: Transaction[];
+  errorText?: string;
+  restartTransactions?: Transaction[];
   cancelTransaction?(): void;
   startTransaction?(): void;
 }
 
 export const MetaMaskModal: React.FunctionComponent<MetaMaskModalProps> = props => {
   let buttonSection;
-  if (props.ipfsPost) {
+  if (props.ipfsPost && !props.restartTransactions) {
   } else if (props.alert) {
     buttonSection = (
       <ButtonContainer>
@@ -120,8 +122,8 @@ export const MetaMaskModal: React.FunctionComponent<MetaMaskModalProps> = props 
     buttonSection = (
       <ButtonContainer>
         <IB onClick={props.cancelTransaction}>Cancel</IB>
-        {props.denied ? (
-          <TransactionButtonNoModal transactions={props.denialRestartTransactions!} Button={MetaMaskLogoButton}>
+        {props.restartTransactions ? (
+          <TransactionButtonNoModal transactions={props.restartTransactions!} Button={MetaMaskLogoButton}>
             {" "}
             Try Again{" "}
           </TransactionButtonNoModal>
@@ -181,11 +183,23 @@ export const MetaMaskModal: React.FunctionComponent<MetaMaskModalProps> = props 
       </HalfPWrapper>
     );
   }
+  if (props.errored) {
+    paragraph = (
+      <HalfPWrapper>
+        <ModalP>There was an error executing this transaction.</ModalP>
+        {!!props.errorText && (
+          <ModalP>
+            <code>{props.errorText}</code>
+          </ModalP>
+        )}
+      </HalfPWrapper>
+    );
+  }
 
   let image;
   if (props.ipfsPost || props.alert) {
     image = undefined;
-  } else if (props.denied) {
+  } else if (props.denied || props.errored) {
     image = <MainImg src={confirmButton} />;
   } else {
     image = (
@@ -198,7 +212,7 @@ export const MetaMaskModal: React.FunctionComponent<MetaMaskModalProps> = props 
   return (
     <Modal width={560} padding={"8px 26px 0 26px"}>
       {props.children}
-      <ContentSectionWrapper row={props.denied}>
+      <ContentSectionWrapper row={props.denied || props.errored}>
         {paragraph}
         {image}
       </ContentSectionWrapper>

--- a/packages/components/src/TransactionButton.tsx
+++ b/packages/components/src/TransactionButton.tsx
@@ -25,6 +25,7 @@ export interface TransactionButtonModalFlowState {
   isPreTransactionModalOpen?: boolean;
   isWaitingTransactionModalOpen?: boolean;
   metaMaskRejectionModal?: boolean;
+  metaMaskErrorModal?: boolean;
   completeModalOpen?: boolean;
   startTransaction?(): any;
   cancelTransaction?(): any;

--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -686,7 +686,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
     contentId: ContentId,
     uri: string,
     hash: string,
-    signature: string = "",
+    signature: string = "0x",
   ): Promise<TwoStepEthTransaction<RevisionId | MultisigTransaction>> {
     if (contentId === 0) {
       await this.requireOwner();

--- a/packages/core/src/contracts/newsroom.ts
+++ b/packages/core/src/contracts/newsroom.ts
@@ -578,8 +578,8 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
   public async estimatePublishURIAndHash(
     uriOrContent: any,
     hash: string,
-    author: string = "",
-    signature: string = "",
+    author: string = "0x",
+    signature: string = "0x",
     archive?: boolean,
   ): Promise<number> {
     const uriForEstimate = archive ? "self-tx:1.0" : uriOrContent;
@@ -604,7 +604,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
     contentId: number,
     uriOrContent: any,
     hash: string,
-    signature: string = "",
+    signature: string = "0x",
     archive?: boolean,
   ): Promise<number> {
     const uriForEstimate = archive ? "self-tx:1.0" : uriOrContent;
@@ -663,8 +663,8 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
   public async publishURIAndHash(
     uri: string,
     hash: string,
-    author: string = "",
-    signature: string = "",
+    author: string = "0x",
+    signature: string = "0x",
   ): Promise<TwoStepEthTransaction<ContentId | MultisigTransaction>> {
     if (!(await this.isEditor()) && (await this.isOwner())) {
       return this.twoStepOrMulti(
@@ -742,8 +742,8 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
   public async publishWithArchive(
     content: any,
     hash: string,
-    author: string = "",
-    signature: string = "",
+    author: string = "0x",
+    signature: string = "0x",
   ): Promise<TwoStepEthTransaction<MultisigTransaction | ContentId>> {
     const revision = typeof content === "string" ? content : JSON.stringify(content);
     const gas = await this.estimatePublishURIAndHash(content, hash, author, signature, true);
@@ -774,7 +774,7 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
     contentId: ContentId,
     content: any,
     hash: string,
-    signature: string = "",
+    signature: string = "0x",
   ): Promise<TwoStepEthTransaction<RevisionId | MultisigTransaction>> {
     const revision = typeof content === "string" ? content : JSON.stringify(content);
     const gas = await this.estimateUpdateURIAndHash(contentId, content, hash, signature, true);
@@ -1016,8 +1016,8 @@ export class Newsroom extends BaseWrapper<NewsroomContract> {
   ): Promise<{ storageHeader: StorageHeader; author: EthAddress; signature: Hex }> {
     const storageHeader = await this.contentProvider.put(content);
 
-    let author: EthAddress = "";
-    let signature: Hex = "";
+    let author: EthAddress = "0x";
+    let signature: Hex = "0x";
 
     if (signedData) {
       this.verifyApprovedRevision(storageHeader, signedData);

--- a/packages/dapp/src/components/Dashboard/NewsroomsListItemComponent.tsx
+++ b/packages/dapp/src/components/Dashboard/NewsroomsListItemComponent.tsx
@@ -4,7 +4,7 @@ import { formatRoute } from "react-router-named-routes";
 import { Link } from "react-router-dom";
 import { ListingWrapper, WrappedChallengeData, EthContentHeader, CharterData } from "@joincivil/core";
 import { NewsroomState, getNewsroom, getNewsroomMultisigBalance } from "@joincivil/newsroom-signup";
-import { DashboardNewsroom } from "@joincivil/components";
+import { DashboardNewsroom, LoadingMessage } from "@joincivil/components";
 import { getFormattedTokenBalance, getEtherscanBaseURL, getLocalDateTimeStrings } from "@joincivil/utils";
 import { NewsroomWithdraw } from "@joincivil/sdk";
 
@@ -34,11 +34,21 @@ export interface NewsroomsListItemReduxProps {
   listingPhaseState?: any;
 }
 
+export interface NewsroomsListItemListingReduxState {
+  loading?: boolean;
+}
+
 class NewsroomsListItemListingRedux extends React.Component<
-  NewsroomsListItemOwnProps & NewsroomsListItemReduxProps & DispatchProp<any>
+  NewsroomsListItemOwnProps & NewsroomsListItemReduxProps & DispatchProp<any>,
+  NewsroomsListItemListingReduxState
 > {
   public static contextType = CivilHelperContext;
   public context: CivilHelper;
+
+  constructor(props: NewsroomsListItemOwnProps & NewsroomsListItemReduxProps & DispatchProp<any>) {
+    super(props);
+    this.state = {};
+  }
 
   public async componentDidUpdate(): Promise<void> {
     await this.hydrateData();
@@ -171,6 +181,10 @@ class NewsroomsListItemListingRedux extends React.Component<
       return <DashboardNewsroom {...displayProps} {...newsroomStatusOnRegistry} />;
     }
 
+    if (this.state.loading) {
+      return <LoadingMessage />;
+    }
+
     return <></>;
   }
 
@@ -179,6 +193,9 @@ class NewsroomsListItemListingRedux extends React.Component<
     const { civil } = this.context;
 
     if (!listing && !listingDataRequestStatus) {
+      if (!this.state.loading) {
+        this.setState({ loading: true });
+      }
       this.props.dispatch!(fetchAndAddListingData(this.context, listingAddress!));
     }
     if (newsroom) {
@@ -186,9 +203,15 @@ class NewsroomsListItemListingRedux extends React.Component<
         this.props.dispatch!(await getNewsroomMultisigBalance(listingAddress!, newsroom.multisigAddress, civil));
       }
     } else if (charter) {
+      if (!this.state.loading) {
+        this.setState({ loading: true });
+      }
       this.props.dispatch!(await getNewsroom(listingAddress!, civil, charter));
     }
     if (newsroomCharterHeader && !charter) {
+      if (!this.state.loading) {
+        this.setState({ loading: true });
+      }
       this.props.dispatch!(await getContent(this.context, newsroomCharterHeader!));
     }
   };

--- a/packages/dapp/src/components/utility/TransactionStatusModalsHOC.tsx
+++ b/packages/dapp/src/components/utility/TransactionStatusModalsHOC.tsx
@@ -202,7 +202,7 @@ export const hasTransactionStatusModals = (transactionStatusModalConfig: Transac
           denied={true}
           denialText={denialContent[1] as string}
           cancelTransaction={cancelTransaction}
-          denialRestartTransactions={this.transactions}
+          restartTransactions={this.transactions}
         >
           <ModalHeading>{denialContent[0]}</ModalHeading>
         </MetaMaskModal>

--- a/packages/newsroom-manager/src/CompleteYourProfile.tsx
+++ b/packages/newsroom-manager/src/CompleteYourProfile.tsx
@@ -138,7 +138,7 @@ class CompleteYourProfileComponent extends React.Component<
             denied={true}
             denialText={denialMessage}
             cancelTransaction={() => this.cancelTransaction()}
-            denialRestartTransactions={this.getTransaction(true)}
+            restartTransactions={this.getTransaction(true)}
           >
             <ModalHeading>{message}</ModalHeading>
           </MetaMaskModal>

--- a/packages/newsroom-manager/src/NameAndAddress.tsx
+++ b/packages/newsroom-manager/src/NameAndAddress.tsx
@@ -164,7 +164,7 @@ class NameAndAddressComponent extends React.Component<NameAndAddressProps & Disp
             denied={true}
             denialText={denialMessage}
             cancelTransaction={() => this.cancelTransaction()}
-            denialRestartTransactions={this.getTransactions(value.civil!, true)}
+            restartTransactions={this.getTransactions(value.civil!, true)}
           >
             <ModalHeading>{message}</ModalHeading>
           </MetaMaskModal>

--- a/packages/newsroom-manager/src/NewsroomUser.tsx
+++ b/packages/newsroom-manager/src/NewsroomUser.tsx
@@ -151,7 +151,7 @@ export class NewsroomUserComponent extends React.Component<
             denied={true}
             denialText={denialMessage}
             cancelTransaction={() => this.cancelTransaction()}
-            denialRestartTransactions={this.getTransaction(true)}
+            restartTransactions={this.getTransaction(true)}
           >
             <ModalHeading>{message}</ModalHeading>
           </MetaMaskModal>

--- a/packages/newsroom-manager/src/SignConstitution.tsx
+++ b/packages/newsroom-manager/src/SignConstitution.tsx
@@ -183,7 +183,7 @@ class SignConstitutionComponent extends React.Component<
             denied={true}
             denialText={denialMessage}
             cancelTransaction={() => this.cancelTransaction()}
-            denialRestartTransactions={this.getTransactions(value.civil!, true)}
+            restartTransactions={this.getTransactions(value.civil!, true)}
           >
             <MetaMaskStepCounter>Step 1 of 2</MetaMaskStepCounter>
             <ModalHeading>{message}</ModalHeading>
@@ -210,7 +210,7 @@ class SignConstitutionComponent extends React.Component<
             denied={true}
             denialText={denialMessage}
             cancelTransaction={() => this.cancelTransaction()}
-            denialRestartTransactions={this.getPublishTransaction(value.civil!)}
+            restartTransactions={this.getPublishTransaction(value.civil!)}
           >
             <MetaMaskStepCounter>Step 2 of 2</MetaMaskStepCounter>
             <ModalHeading>{message}</ModalHeading>

--- a/packages/newsroom-signup/src/NewsroomProfile/SignConstitution.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/SignConstitution.tsx
@@ -179,7 +179,7 @@ class SignConstitutionComponent extends React.Component<
         denied={true}
         denialText={denialMessage}
         cancelTransaction={() => this.cancelTransaction()}
-        denialRestartTransactions={this.getTransactions(this.context.civil!, true)}
+        restartTransactions={this.getTransactions(this.context.civil!, true)}
       >
         <ModalHeading>{message}</ModalHeading>
       </MetaMaskModal>

--- a/packages/newsroom-signup/src/NewsroomUser.tsx
+++ b/packages/newsroom-signup/src/NewsroomUser.tsx
@@ -148,7 +148,7 @@ export class NewsroomUserComponent extends React.Component<
         denied={true}
         denialText={denialMessage}
         cancelTransaction={() => this.cancelTransaction()}
-        denialRestartTransactions={this.getTransaction(true)}
+        restartTransactions={this.getTransaction(true)}
       >
         <ModalHeading>{message}</ModalHeading>
       </MetaMaskModal>

--- a/packages/newsroom-signup/src/SmartContract/AddMember.tsx
+++ b/packages/newsroom-signup/src/SmartContract/AddMember.tsx
@@ -325,7 +325,7 @@ export class AddMemberComponent extends React.Component<AddMemberProps & Dispatc
         denied={true}
         denialText={denialMessage}
         cancelTransaction={() => this.cancelTransaction()}
-        denialRestartTransactions={this.getTransaction(true)}
+        restartTransactions={this.getTransaction(true)}
       >
         <ModalHeading>{message}</ModalHeading>
       </MetaMaskModal>

--- a/packages/newsroom-signup/src/SmartContract/CreateNewsroomContract.tsx
+++ b/packages/newsroom-signup/src/SmartContract/CreateNewsroomContract.tsx
@@ -46,7 +46,7 @@ export interface NameAndAddressProps {
 }
 
 const STANDIN_IPFS_URL = "ipfs://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-const STAND_IN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const STAND_IN_HASH = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 export interface NameAndAddressState extends TransactionButtonModalFlowState {
   collapsableOpen: boolean;

--- a/packages/newsroom-signup/src/SmartContract/CreateNewsroomContract.tsx
+++ b/packages/newsroom-signup/src/SmartContract/CreateNewsroomContract.tsx
@@ -244,7 +244,7 @@ export class CreateNewsroomContractComponent extends React.Component<
         denied={true}
         denialText={denialMessage}
         cancelTransaction={() => this.cancelTransaction()}
-        denialRestartTransactions={this.getTransactions(this.context.civil!, true)}
+        restartTransactions={this.getTransactions(this.context.civil!, true)}
       >
         <ModalHeading>{message}</ModalHeading>
       </MetaMaskModal>

--- a/packages/newsroom-signup/src/TransactionStatusModalsHOC.tsx
+++ b/packages/newsroom-signup/src/TransactionStatusModalsHOC.tsx
@@ -193,7 +193,7 @@ export const hasTransactionStatusModals = (transactionStatusModalConfig: Transac
           denied={true}
           denialText={denialContent[1] as string}
           cancelTransaction={cancelTransaction}
-          denialRestartTransactions={this.transactions}
+          restartTransactions={this.transactions}
         >
           <ModalHeading>{denialContent[0]}</ModalHeading>
         </MetaMaskModal>


### PR DESCRIPTION
Fixes the two issues affecting republish charter:

1. `newsroom.updateRevisionURIAndHash` passed default `signature` argument to web3 call as `""` which errored on "invalid bytes value" - `"0x"` instead fixed that.
2. Sometimes IPFS charter publish times out, but there's no feedback so UI just hangs. This catches IPFS (also any web3) errors and displays an error modal.

Also some other misc fixes.