### PR TITLE
fix(sdk): workaround for currentProviderEnable promise issue

### DIFF
--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -313,6 +313,7 @@ export const BoostDescriptionWhy = styled.div`
   color: ${colors.accent.CIVIL_GRAY_0};
   margin-bottom: 30px;
   width: 500px;
+  max-width: 100%;
 
   p {
     font-size: 18px;


### PR DESCRIPTION
Instead of awaiting on `civil.currentProviderEnable()`, just call it without awaiting and then await on `this.context.civil.accountStream.first().toPromise()` instead