### PR TITLE
fix(dapp): listing page boost crashing

### DIFF
--- a/packages/sdk/src/react/boosts/BoostFeed.tsx
+++ b/packages/sdk/src/react/boosts/BoostFeed.tsx
@@ -38,7 +38,7 @@ export const BoostFeed: React.FunctionComponent<BoostFeedProps> = props => {
             return "Error loading Boosts.";
           }
 
-          if (!feedQueryData.postsSearch.posts) {
+          if (!feedQueryData.postsSearch.posts || !feedQueryData.postsSearch.posts.length) {
             return <NoBoostsText />;
           }
 

--- a/packages/sdk/src/react/boosts/BoostFeed.tsx
+++ b/packages/sdk/src/react/boosts/BoostFeed.tsx
@@ -38,7 +38,7 @@ export const BoostFeed: React.FunctionComponent<BoostFeedProps> = props => {
             return "Error loading Boosts.";
           }
 
-          if (!feedQueryData.postsSearch.posts.length) {
+          if (!feedQueryData.postsSearch.posts) {
             return <NoBoostsText />;
           }
 


### PR DESCRIPTION
Issue: Page crashes if there is a channel associated with a newsroom that has not created a Boost.