### PR TITLE
fix(sdk): call eth check even if boost eth pay is mounted selected [CIVIL-1142]

### DIFF
--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -314,6 +314,7 @@ export const BoostDescriptionWhy = styled.div`
   color: ${colors.accent.CIVIL_GRAY_0};
   margin-bottom: 30px;
   width: 500px;
+  max-width: 100%;
 
   p {
     font-size: 18px;


### PR DESCRIPTION
The error was kind of dumb and unrelated to my investigations.

Previously this only checked wallet in componentDidUpdate transition from not selected (i.e. choosing between when eth and credit card options) to selected. If stripe isn't enabled for a boost, component mounts with eth option already selected so it wasn't getting called.

Also has tiny mobile responsive css fix.