### PR TITLE
fix: memory leak/infinite loop when checking newsroom multisig [CIVIL-1019]

### DIFF
--- a/packages/newsroom-signup/src/reducers.ts
+++ b/packages/newsroom-signup/src/reducers.ts
@@ -83,11 +83,24 @@ export function newsrooms(
         isEditor: action.data.isEditor,
       });
     case newsroomActions.SET_MULTISIG_ADDRESS:
+      if (
+        state.get(action.data.address) &&
+        state.get(action.data.address).multisigAddress === action.data.multisigAddress
+      ) {
+        return state;
+      }
       return state.set(action.data.address, {
         ...state.get(action.data.address),
         multisigAddress: action.data.multisigAddress,
       });
     case newsroomActions.SET_MULTISIG_BALANCE:
+      if (
+        state.get(action.data.address) &&
+        state.get(action.data.address).multisigBalance &&
+        state.get(action.data.address).multisigBalance!.toString() === action.data.multisigBalance.toString()
+      ) {
+        return state;
+      }
       return state.set(action.data.address, {
         ...state.get(action.data.address),
         multisigBalance: action.data.multisigBalance,


### PR DESCRIPTION
`NewsroomsListItemComponent` would hydrate newsroom multisig balance whenever its `newsroom` prop from redux was updated. However, checking/dispatching multisig balance would update newsroom state in redux (i.e. `state.set(address, { ...state.get(address), multisigBalance: newBalance })`. Redux connect does a shallow equality check and would see that its newsroom state appeared to have updated and would update `NewsroomsListItemComponent` which would check multisig balance again.

This was infinitely creating newsroom state objects, causing a memory leak either in redux or our code, I couldn't track it down.

This update makes the reducer a little smarter, and won't create a new newsroom state object unless the multisig address or balance has actually changed.

This is a pretty specific fix for this instance of a more general problem with changing state while hydrating data in response to state change. I'm not sure what a more general fix would be except to introduce more explicit "should we really update?" checks or add more checks like this into reducers.