### PR TITLE
Min $2 for embedded project boost card payments + small tweaks

### DIFF
--- a/packages/components/src/ListingDetailPhaseCard/textComponents.tsx
+++ b/packages/components/src/ListingDetailPhaseCard/textComponents.tsx
@@ -191,13 +191,13 @@ export const WhitelistedNewroomsToolTipText: React.FunctionComponent = props => 
   return (
     <>
       <p>
-        This Newsroom has been approved to be on the Civil Registry, on condition they commit to uphold the values of
-        the Civil Constitution.
+        This Newsroom has committed to uphold the values of the Civil Constitution and has been approved by the Civil
+        community to be on the Civil Registry.
       </p>
       <p>
-        CVL token holders are the stewards of ethical journalism on the Civil Registry. If for any reason you believe
-        that a Newsroom has violated either the Civil Constitution or the Newsroom's own stated mission and charter, you
-        may challenge them at any time.
+        The community of CVL token holders are the stewards of ethical journalism on the Civil Registry. If for any
+        reason you believe that a Newsroom has violated either the Civil Constitution or the Newsroom's own stated
+        mission and charter, you may challenge them at any time.
       </p>
     </>
   );

--- a/packages/sdk/src/react/boosts/BoostShare.tsx
+++ b/packages/sdk/src/react/boosts/BoostShare.tsx
@@ -8,8 +8,10 @@ import { BoostShareHeading } from "./BoostStyledComponents";
 const Wrapper = styled.div`
   position: relative;
   z-index: 10;
+  margin-left: 24px;
   ${mediaQueries.MOBILE_SMALL} {
     display: flex;
+    margin-bottom: 8px;
   }
 `;
 

--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -405,8 +405,9 @@ export const BoostPayCardDetails = styled.div`
   }
 
   a {
-    color: ${colors.accent.CIVIL_BLUE}
+    color: ${colors.accent.CIVIL_BLUE};
     text-decoration: none;
+    cursor: pointer;
 
     &:hover {
       text-decoration: underline;

--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -313,8 +313,6 @@ export const BoostDescription = styled.div`
 export const BoostDescriptionWhy = styled.div`
   color: ${colors.accent.CIVIL_GRAY_0};
   margin-bottom: 30px;
-  width: 500px;
-  max-width: 100%;
 
   p {
     font-size: 18px;

--- a/packages/sdk/src/react/boosts/payments/BoostPayOptions.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayOptions.tsx
@@ -29,6 +29,7 @@ export interface BoostPayOptionsProps {
   paymentAddr: EthAddress;
   isStripeConnected: boolean;
   stripeAccountID: string;
+  handleBackToListing(): void;
   handlePaymentSuccess(): void;
 }
 
@@ -179,6 +180,7 @@ export class BoostPayOptions extends React.Component<BoostPayOptionsProps, Boost
             paymentType={PAYMENT_TYPE.STRIPE}
             paymentStarted={true}
             stripeAccountID={this.props.stripeAccountID}
+            handleBackToListing={this.props.handleBackToListing}
             handleNext={this.handleStripeNext}
             handlePaymentSuccess={handlePaymentSuccess}
           />
@@ -211,6 +213,7 @@ export class BoostPayOptions extends React.Component<BoostPayOptionsProps, Boost
                   optionLabel={<PaymentLabelCardText />}
                   paymentType={PAYMENT_TYPE.STRIPE}
                   stripeAccountID={this.props.stripeAccountID}
+                  handleBackToListing={this.props.handleBackToListing}
                   handleNext={this.handleStripeNext}
                   handlePaymentSuccess={handlePaymentSuccess}
                   handlePaymentSelected={this.handlePaymentSelected}

--- a/packages/sdk/src/react/boosts/payments/BoostPayStripe.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayStripe.tsx
@@ -1,12 +1,20 @@
 import * as React from "react";
+import styled from "styled-components";
 import { Mutation, MutationFunc } from "react-apollo";
 import { boostPayStripeMutation } from "../queries";
 import makeAsyncScriptLoader from "react-async-script";
 import { BoostPayCardDetails, BoostFlexCenter, BoostButton } from "../BoostStyledComponents";
 import { StripeProvider, Elements } from "react-stripe-elements";
 import BoostPayFormStripe from "./BoostPayFormStripe";
-import { CivilContext, ICivilContext, LoadingMessage } from "@joincivil/components";
+import { CivilContext, ICivilContext, LoadingMessage, ChevronAnchor, colors } from "@joincivil/components";
 import { BoostPayOption } from "./BoostPayOption";
+
+export const MinPayWarning = styled.p`
+  color: ${colors.accent.CIVIL_RED};
+  a {
+    display: inline-block;
+  }
+`;
 
 export interface BoostPayStripeProps {
   boostId: string;
@@ -18,6 +26,7 @@ export interface BoostPayStripeProps {
   optionLabel: string | JSX.Element;
   paymentStarted?: boolean;
   stripeAccountID: string;
+  handleBackToListing(): void;
   handleNext(usdToSpend: number): void;
   handlePaymentSelected?(paymentType: string): void;
   handlePaymentSuccess(): void;
@@ -66,9 +75,20 @@ export class BoostPayStripe extends React.Component<BoostPayStripeProps, BoostPa
                 .
               </p>
               {this.props.selected && (
-                <BoostButton onClick={() => this.props.handleNext(this.props.usdToSpend)}>Next</BoostButton>
+                <BoostButton
+                  onClick={() => this.props.handleNext(this.props.usdToSpend)}
+                  disabled={this.props.usdToSpend < 2}
+                >
+                  Next
+                </BoostButton>
               )}
             </BoostFlexCenter>
+            {this.props.selected && this.props.usdToSpend < 2 && (
+              <MinPayWarning>
+                Due to credit card processing fees, the minimum boost amount for cards is $2.00.{" "}
+                <ChevronAnchor onClick={this.props.handleBackToListing}>Change boost amount</ChevronAnchor>
+              </MinPayWarning>
+            )}
           </BoostPayCardDetails>
         </BoostPayOption>
       </>

--- a/packages/sdk/src/react/boosts/payments/BoostPayments.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayments.tsx
@@ -129,6 +129,7 @@ export const BoostPayments: React.FunctionComponent<BoostPaymentsProps> = props 
         boostId={props.boostId}
         isStripeConnected={props.isStripeConnected}
         stripeAccountID={props.stripeAccountID}
+        handleBackToListing={props.handleBackToListing}
         handlePaymentSuccess={() => props.handlePaymentSuccess()}
       />
     </BoostWrapper>


### PR DESCRIPTION
Because of how usdToSpend is stored in history state it was slightly harder (or maybe I'm missing something) to do what story boost flow does and just update payment amount to $2 if they continue, so instead I added a link to go back and edit payment amount, which isn't as nice, but it's kind of an edge case, and we'll replace this flow at some point anyway.