### PR TITLE
Move "under challenge" lock to Edit Charter tab [CIVIL-995]

### DIFF
--- a/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Link } from "react-router-dom";
 import { urlConstants } from "@joincivil/utils";
 import { EthAddressViewer } from "../EthAddressViewer";
-import { ErrorIcon } from "../icons";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
 
@@ -20,7 +19,6 @@ import {
   StyledDashboardNewsroomTokensContainer,
   StyledDashboardNewsroomTokensLabel,
   StyledCVLLabel,
-  StyledWarningText,
 } from "./DashboardStyledComponents";
 import { DashboardNewsroomStripeConnect } from "./DashboardNewsroomStripeConnect";
 import { DashboardNewsroomSubmitLink } from "./DashboardNewsroomSubmitLink";

--- a/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
@@ -100,23 +100,6 @@ const DashboardNewsroomRegistryStatusBase: React.FunctionComponent<DashboardNews
 const DashboardNewsroomRegistryStatus = React.memo(DashboardNewsroomRegistryStatusBase);
 
 const DashboardNewsroomBase: React.FunctionComponent<DashboardNewsroomProps> = props => {
-  const { isUnderChallenge } = props;
-  const renderEditLink = () => {
-    if (isUnderChallenge) {
-      return (
-        <StyledWarningText>
-          <ErrorIcon width={16} height={16} /> Your charter is locked until the challenge period has ended.
-        </StyledWarningText>
-      );
-    }
-
-    return (
-      <ChevronAnchor component={Link} to={props.manageNewsroomURL}>
-        Manage Newsroom
-      </ChevronAnchor>
-    );
-  };
-
   return (
     <StyledDashboardNewsroom>
       <StyledDashboardNewsroomSection>
@@ -124,7 +107,9 @@ const DashboardNewsroomBase: React.FunctionComponent<DashboardNewsroomProps> = p
           <StyledDashboardNewsroomName>{props.newsroomName}</StyledDashboardNewsroomName>
 
           <StyledDashboardNewsroomLinks>
-            {renderEditLink()}
+            <ChevronAnchor component={Link} to={props.manageNewsroomURL}>
+              Manage Newsroom
+            </ChevronAnchor>
             <ChevronAnchor component={Link} to={props.listingDetailURL}>
               View on Registry
             </ChevronAnchor>

--- a/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
@@ -6,7 +6,7 @@ import { BigNumber } from "@joincivil/typescript-types";
 import styled from "styled-components";
 import { ListingWrapper, WrappedChallengeData, UserChallengeData, CharterData } from "@joincivil/core";
 import { NewsroomState } from "@joincivil/newsroom-signup";
-import { DashboardActivityItem, PHASE_TYPE_NAMES, FeatureFlag, colors } from "@joincivil/components";
+import { DashboardActivityItem, PHASE_TYPE_NAMES, FeatureFlag } from "@joincivil/components";
 import { getFormattedTokenBalance } from "@joincivil/utils";
 
 import { routes } from "../../constants";

--- a/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
+++ b/packages/dapp/src/components/Dashboard/ActivityListItem.tsx
@@ -6,7 +6,7 @@ import { BigNumber } from "@joincivil/typescript-types";
 import styled from "styled-components";
 import { ListingWrapper, WrappedChallengeData, UserChallengeData, CharterData } from "@joincivil/core";
 import { NewsroomState } from "@joincivil/newsroom-signup";
-import { DashboardActivityItem, PHASE_TYPE_NAMES, FeatureFlag, colors, ErrorIcon } from "@joincivil/components";
+import { DashboardActivityItem, PHASE_TYPE_NAMES, FeatureFlag, colors } from "@joincivil/components";
 import { getFormattedTokenBalance } from "@joincivil/utils";
 
 import { routes } from "../../constants";
@@ -24,14 +24,6 @@ import { PhaseCountdownTimer } from "./PhaseCountdownTimer";
 import { fetchAndAddListingData } from "../../redux/actionCreators/listings";
 import { getContent } from "../../redux/actionCreators/newsrooms";
 import { CivilHelperContext, CivilHelper } from "../../apis/CivilHelper";
-
-const StyledWarningText = styled.span`
-  color: ${colors.accent.CIVIL_RED};
-
-  & svg {
-    margin: 0 2px -9px 0;
-  }
-`;
 
 export interface ActivityListItemOwnProps {
   listingAddress?: string;
@@ -248,21 +240,8 @@ class ActivityListItemComponent extends React.Component<
 
     // This is a listing
     if (!userChallengeData && listingAddress) {
-      // @TODO/tobek When we release the post-application newsroom manager we should fix NEWSROOM_MANAGEMENT route and point this to that, but for now just send them to APPLY_TO_REGISTRY
-      if (listingPhaseState) {
-        if (listingPhaseState.isUnderChallenge) {
-          return [
-            "View",
-            <StyledWarningText>
-              <ErrorIcon width={16} height={16} /> Your charter is locked until the challenge period has ended.
-            </StyledWarningText>,
-          ];
-        } else {
-          const manageNewsroomUrl = formatRoute(routes.APPLY_TO_REGISTRY, { action: "manage" });
-          return ["View", <Link to={manageNewsroomUrl}>Manage Newsroom</Link>];
-        }
-      }
-      return ["View", undefined];
+      const manageNewsroomUrl = formatRoute(routes.MANAGE_NEWSROOM, { newsroomAddress: listingAddress });
+      return ["View", <Link to={manageNewsroomUrl}>Manage Newsroom</Link>];
     }
 
     return ["View", undefined];

--- a/packages/newsroom-signup/src/NewsroomManager/index.tsx
+++ b/packages/newsroom-signup/src/NewsroomManager/index.tsx
@@ -14,6 +14,7 @@ import {
   LoadingMessage,
   LoadingIndicator,
   metaMaskLoginImgUrl,
+  ErrorIcon,
 } from "@joincivil/components";
 
 import { StateWithNewsroom } from "../reducers";
@@ -28,6 +29,7 @@ import { ApplicationSoFarPage } from "../NewsroomProfile/ApplicationSoFarPage";
 export interface NewsroomManagerExternalProps {
   newsroomAddress: EthAddress;
   publishedCharter: Partial<CharterData>;
+  listingPhaseState: any;
   theme?: ButtonTheme;
 }
 
@@ -71,6 +73,14 @@ const SaveNotice = styled(RepublishCharterNotice)`
 const SaveButtonWrapper = styled.div`
   display: inline-block;
   margin: 8px auto 0;
+`;
+
+const LockedWarning = styled.span`
+  color: ${colors.accent.CIVIL_RED};
+
+  & svg {
+    margin: 0 2px -3px 0;
+  }
 `;
 
 const DEFAULT_DIRTY_MESSAGE = "Are you sure you want to leave this page? Your changes have not been saved.";
@@ -132,7 +142,12 @@ class NewsroomManagerComponent extends React.Component<NewsroomManagerProps, New
           <Prompt when={!!this.unsavedWarning()} message={DEFAULT_DIRTY_MESSAGE} />
 
           <p>
-            {this.state.saving ? (
+            {this.props.listingPhaseState.isUnderChallenge ? (
+              <LockedWarning>
+                <ErrorIcon width={16} height={16} /> Your newsroom is under challenge. Your charter is locked from
+                editing until the challenge period has ended.
+              </LockedWarning>
+            ) : this.state.saving ? (
               <>
                 Saving <LoadingIndicator inline={true} />
               </>

--- a/packages/sdk/src/react/boosts/BoostForm.tsx
+++ b/packages/sdk/src/react/boosts/BoostForm.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Prompt } from "react-router";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 import {
   colors,
@@ -269,8 +270,7 @@ class BoostFormComponent extends React.Component<BoostFormProps, BoostFormState>
             if (!userLoading && !user) {
               return (
                 <BoostWrapper>
-                  {/*@TODO/auth Add redirect param when we one day implement that.*/}
-                  You must <a href="/auth/login">login</a> to edit a Boost.
+                  You must log in to edit a Boost. Please use the "Log In" link in the header to do so.
                 </BoostWrapper>
               );
             }
@@ -301,8 +301,8 @@ class BoostFormComponent extends React.Component<BoostFormProps, BoostFormState>
                     return (
                       <BoostWrapper>
                         Your newsroom <b>{this.props.newsroomData.name}</b> has not yet applied to the Civil Registry.
-                        Please <a href="/apply-to-registry">continue your newsroom application</a> and then, once you
-                        have applied and your newsroom has been approved, you can return to create a Boost.
+                        Please <Link to="/apply-to-registry">continue your newsroom application</Link> and then, once
+                        you have applied and your newsroom has been approved, you can return to create a Boost.
                       </BoostWrapper>
                     );
                   }
@@ -311,8 +311,8 @@ class BoostFormComponent extends React.Component<BoostFormProps, BoostFormState>
                     return (
                       <BoostWrapper>
                         Your newsroom <b>{this.props.newsroomData.name}</b> is not currently approved on the Civil
-                        Registry. Please <a href="/dashboard/newsrooms">visit your newsroom dashboard</a> to check on
-                        the status of your application. Once your newsroom is approved, you can return to create a
+                        Registry. Please <Link to="/dashboard/newsrooms">visit your newsroom dashboard</Link> to check
+                        on the status of your application. Once your newsroom is approved, you can return to create a
                         Boost.
                       </BoostWrapper>
                     );


### PR DESCRIPTION
Rather than blocking access entire "Manage Newsroom" page if newsroom is under challenge, only the "Edit Charter" tab should be blocked.