### PR TITLE
Reduce unnecessary/premature kirby popups on Boosts [CIVIL-1134] [CIVIL-1186]

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,7 @@
     "bfj": "6.1.1",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "css-loader": "1.0.0",
+    "detect-browser": "^4.7.0",
     "dotenv": "6.0.0",
     "dotenv-expand": "4.2.0",
     "eslint": "5.12.0",

--- a/packages/sdk/src/react/NewsroomWithdraw.tsx
+++ b/packages/sdk/src/react/NewsroomWithdraw.tsx
@@ -80,8 +80,6 @@ const BalanceAndButton = styled.div`
 
 export interface NewsroomWithdrawProps {
   newsroomAddress: EthAddress;
-  /** Pass newsroom instance if handy to avoid unecessary instantiation. */
-  newsroom?: NewsroomInstance;
   isStripeConnected?: boolean;
 }
 
@@ -97,17 +95,12 @@ export class NewsroomWithdraw extends React.Component<NewsroomWithdrawProps, New
 
   public constructor(props: NewsroomWithdrawProps) {
     super(props);
-    this.state = {
-      newsroom: props.newsroom,
-    };
+    this.state = {};
   }
 
   public async componentDidMount(): Promise<void> {
     const userAccount = await this.context.civil!.accountStream.first().toPromise();
-    let newsroom = this.props.newsroom;
-    if (!newsroom) {
-      newsroom = await this.context.civil!.newsroomAtUntrusted(this.props.newsroomAddress);
-    }
+    const newsroom = await this.context.civil!.newsroomAtUntrusted(this.props.newsroomAddress);
 
     const multisigAddress = await newsroom!.getMultisigAddress();
     if (!multisigAddress) {

--- a/packages/sdk/src/react/boosts/Boost.tsx
+++ b/packages/sdk/src/react/boosts/Boost.tsx
@@ -144,11 +144,10 @@ class BoostComponent extends React.Component<BoostProps, BoostStates> {
                     )}
 
                     {/*@TODO/tobek Move to Newsroom Boosts page when we have that.*/}
-                    {this.props.open && this.props.newsroom && this.props.boostOwner && (
+                    {this.props.open && this.props.boostOwner && (
                       <WithdrawWrapper>
                         <NewsroomWithdraw
                           newsroomAddress={boostData.channel.newsroom.contractAddress}
-                          newsroom={this.props.newsroom}
                           isStripeConnected={boostData.channel.isStripeConnected}
                         />
                       </WithdrawWrapper>

--- a/packages/sdk/src/react/boosts/BoostForm.tsx
+++ b/packages/sdk/src/react/boosts/BoostForm.tsx
@@ -46,7 +46,6 @@ const PageWrapper = styled.div`
   font-weight: normal;
   margin: auto;
   max-width: 880px;
-  padding: 50px 20px 20px;
 
   p {
     margin-top: 15px;

--- a/packages/sdk/src/react/boosts/BoostNewsroom.tsx
+++ b/packages/sdk/src/react/boosts/BoostNewsroom.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 import {
   defaultNewsroomImgUrl,
   HelmetHelper,
@@ -86,7 +87,7 @@ export class BoostNewsroom extends React.Component<BoostNewsroomProps, BoostNews
             {this.props.open && (
               <>
                 {this.props.boostOwner && (
-                  <ChevronAnchor href={`/boosts/${this.props.boostId}/edit`}>
+                  <ChevronAnchor component={Link} to={`/boosts/${this.props.boostId}/edit`}>
                     <b>Edit Boost</b>
                   </ChevronAnchor>
                 )}

--- a/packages/sdk/src/react/boosts/BoostShareEmbed.tsx
+++ b/packages/sdk/src/react/boosts/BoostShareEmbed.tsx
@@ -37,8 +37,8 @@ export const BoostShareEmbed = (props: BoostShareEmbedProps) => {
             </BoostModalContent>
             <EmbedCode>
               &lt;iframe src="{document.location.origin}/embed/boost/{props.boostId}" style="display: block; width:
-              100%; height: 525px; margin: 32px 0; border: 1px solid {colors.accent.CIVIL_GRAY_4}; border-radius:
-              4px;"&gt;&lt;/iframe&gt;
+              100%; height: 525px !important; margin: 32px 0; border: 1px solid {colors.accent.CIVIL_GRAY_4};
+              border-radius: 4px;"&gt;&lt;/iframe&gt;
             </EmbedCode>
           </ModalContain>
         </Modal>

--- a/packages/sdk/src/react/boosts/payments/BoostPayEth.tsx
+++ b/packages/sdk/src/react/boosts/payments/BoostPayEth.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { detect as detectBrowser } from "detect-browser";
 import {
   BoostPayCardDetails,
   LearnMore,
@@ -222,8 +223,10 @@ export class BoostPayEth extends React.Component<BoostPayEthProps, BoostPayEthSt
   private showMobileWalletModal = () => {
     let showMobileWalletModal = false;
 
-    // TODO(sruddy) do we have a check for mobile browser util?
-    if (window.innerWidth < 800 && !this.state.walletConnected) {
+    const browser = detectBrowser();
+    const isMobile = browser && browser.os && ["Android", "iOS", "Windows Mobile"].indexOf(browser.os) !== -1;
+
+    if (isMobile && !this.state.walletConnected) {
       showMobileWalletModal = true;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9918,6 +9918,11 @@ detect-browser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-4.1.0.tgz#4f1cd47952be8fb16511053c37275f513b96d74a"
 
+detect-browser@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-4.7.0.tgz#982429971b68cffcdfa03267e91e3de7e194a9f0"
+  integrity sha512-x+7zkRxwEiQ8qLKKfln9pTa4n87fbPHVpHyImmpEQn5lAmKurWBVbg0tb99ruAHqSA0ejrXMp0MahKEulE7LqA==
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -11395,9 +11400,57 @@ ethereumjs-wallet@^0.6.3:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@3.0.27, ethers@4.0.0-beta.3, ethers@4.0.27, ethers@^4.0.27, ethers@^4.0.33, ethers@^4.0.36, ethers@^4.0.37, ethers@~4.0.4:
+ethers@3.0.27:
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-3.0.27.tgz#f9e89bb43a7265a65512d3142c51f26489667f53"
+  integrity sha512-Ymop12NYKLTejQKv3l4a4vwwZNG+V0D2KmBGuSMa0eEguPJYCouNUoJ/8IiDTwqxKsthoSeCRrcXIz5HJDbHqA==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "^1.0.0"
+    inherits "2.0.1"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.3"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
+ethers@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.0-beta.3.tgz#15bef14e57e94ecbeb7f9b39dd0a4bd435bc9066"
+  integrity sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.3"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
+ethers@^4.0.27, ethers@~4.0.4:
   version "4.0.27"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.27.tgz#e570b0da9d805ad65c83d81919abe02b2264c6bf"
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
+ethers@^4.0.33, ethers@^4.0.36, ethers@^4.0.37:
+  version "4.0.38"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.38.tgz#3fabafb4f79c435205b143b66b4a1af035043e37"
+  integrity sha512-l7l7RIfk2/rIFgRRVLFY3H06S9dhXXPUdMlYm6SCelB6oG+ABmoRig7xSVOLcHLayBfSwssjAAYLKxf1jWhbuQ==
   dependencies:
     "@types/node" "^10.3.2"
     aes-js "3.0.0"
@@ -22281,6 +22334,11 @@ schema-utils@^2.0.0, schema-utils@^2.0.1:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
 
+scrypt-js@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
+  integrity sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=
+
 scrypt-js@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
@@ -25712,7 +25770,6 @@ websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
Primarily a refactor of `BoostPermissionsHOC` to use channel admin gql query to check whether user should have permission to edit a boost, instead of web3.