### PR TITLE
chore(sdk): "select wallet" button on project boost [CIVIL-1134]

### DIFF
--- a/packages/components/src/CurrencyConverter/CurrencyConverter.tsx
+++ b/packages/components/src/CurrencyConverter/CurrencyConverter.tsx
@@ -21,6 +21,7 @@ export interface CurrencyConverterProps {
   currencyLabelTo?: string | JSX.Element;
   displayErrorMsg?: boolean;
   fromValue?: string;
+  className?: string;
   doConversion(fromValue: number): Promise<number>;
   onConversion(fromValue: number, toValue: number): void;
   onNotEnoughEthError?(error: boolean): void;
@@ -71,7 +72,7 @@ export class CurrencyConverter extends React.Component<CurrencyConverterProps, C
 
   public render(): JSX.Element {
     return (
-      <CurrencyConverterContain>
+      <CurrencyConverterContain className={this.props.className}>
         <CurrencyContain>
           <CurrencyLabel>{this.props.currencyLabelFrom}</CurrencyLabel>
           <StyledCurrencyInputWithButton>

--- a/packages/components/src/CurrencyConverter/UsdEthConverter.tsx
+++ b/packages/components/src/CurrencyConverter/UsdEthConverter.tsx
@@ -12,6 +12,7 @@ const ethPriceQuery = gql`
 export interface UsdEthConverterProps {
   fromValue?: string;
   displayErrorMsg?: boolean;
+  className?: string;
   onNotEnoughEthError?(error: boolean): void;
   onConversion(usdValue: number, ethValue: number): void;
 }
@@ -25,6 +26,7 @@ export const UsdEthConverter = (props: UsdEthConverterProps) => {
         return (
           <>
             <CurrencyConverter
+              className={props.className}
               fromValue={props.fromValue}
               currencyCodeFrom="USD"
               currencyLabelFrom="Enter USD Amount"

--- a/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
+++ b/packages/sdk/src/react/boosts/BoostStyledComponents.tsx
@@ -105,8 +105,13 @@ export const BoostButton = styled(Button)`
   text-transform: none;
 
   ${mediaQueries.MOBILE} {
+    display: block;
     margin-bottom: 20px;
     width: 100%;
+  }
+
+  ${mediaQueries.MOBILE_SMALL} {
+    margin-bottom: 10px;
   }
 `;
 
@@ -533,30 +538,6 @@ export const BoostFlexEnd = styled.div`
   }
 `;
 
-export const BoostFlexEth = styled.div`
-  align-items: flex-start;
-  display: flex;
-  justify-content: space-between;
-
-  button {
-    margin: 9px 0 0 15px;
-    ${mediaQueries.MOBILE} {
-      margin-left: 0;
-    }
-    ${mediaQueries.MOBILE_SMALL} {
-      margin-top: 0;
-    }
-  }
-
-  label {
-    display: none;
-  }
-
-  ${mediaQueries.MOBILE} {
-    display: block;
-  }
-`;
-
 export const BoostModalContain = styled.div`
   font-family: ${fonts.SANS_SERIF};
   overflow: scroll;
@@ -687,7 +668,7 @@ export const BoostWarningLabel = styled.div`
   color: ${colors.accent.CIVIL_RED};
   font-size: 14px;
   line-height: 22px;
-  margin-bottom: 15px;
+  margin: 10px 0;
 
   svg {
     vertical-align: sub;


### PR DESCRIPTION
Instead of popping up kirby selection as soon as you enter ETH payment flow.