### PR TITLE
fix(dapp): don't cache index.html

### DIFF
--- a/packages/dapp/devops/nginx.conf
+++ b/packages/dapp/devops/nginx.conf
@@ -52,6 +52,7 @@ server {
             proxy_pass https://$prerender;
         }
         if ($prerender = 0) {
+            add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
             rewrite .* /index.html break;
         }
     }

--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -26,19 +26,19 @@ const GlobalStyle = createGlobalStyle`
 // apps
 const LazyRegistryApp = React.lazy(async () => {
   console.log("loading registry");
-  return import("./registry/LazyRegistryApp");
+  return import(/* webpackChunkName: "registry-app" */ "./registry/LazyRegistryApp");
 });
 const EmbedsApp = React.lazy(async () => {
   console.log("loading embed");
-  return import("./embeds/EmbedsApp");
+  return import(/* webpackChunkName: "embeds-app" */ "./embeds/EmbedsApp");
 });
 const StoriesApp = React.lazy(async () => {
   console.log("loading stories");
-  return import("./stories/StoriesApp");
+  return import(/* webpackChunkName: "stories-app" */ "./stories/StoriesApp");
 });
 const KirbyApp = React.lazy(async () => {
   console.log("loading kirby");
-  return import("@joincivil/kirby");
+  return import(/* webpackChunkName: "kirby-app" */ "@joincivil/kirby");
 });
 
 export const App = () => {

--- a/packages/dapp/src/components/Auth/index.tsx
+++ b/packages/dapp/src/components/Auth/index.tsx
@@ -7,14 +7,14 @@ import { routes } from "../../constants";
 import SetUsername from "./SetUsername";
 import ConfirmEmail from "./ConfirmEmail";
 
-const AuthLogin = React.lazy(async () => import("./Login"));
-const AuthWeb3Login = React.lazy(async () => import("./AuthWeb3Login"));
-const AuthWeb3Signup = React.lazy(async () => import("./AuthWeb3Signup"));
-const AuthEthConnected = React.lazy(async () => import("./Eth"));
-const AuthSignup = React.lazy(async () => import("./Signup"));
-const AuthCheckEmail = React.lazy(async () => import("./CheckEmail"));
-const AuthVerifyToken = React.lazy(async () => import("./VerifyToken"));
-const AuthLogout = React.lazy(async () => import("./AuthLogout"));
+const AuthLogin = React.lazy(async () => import(/* webpackChunkName: "auth-login" */ "./Login"));
+const AuthWeb3Login = React.lazy(async () => import(/* webpackChunkName: "auth-web3login" */ "./AuthWeb3Login"));
+const AuthWeb3Signup = React.lazy(async () => import(/* webpackChunkName: "auth-web3-signup" */ "./AuthWeb3Signup"));
+const AuthEthConnected = React.lazy(async () => import(/* webpackChunkName: "auth-eth" */ "./Eth"));
+const AuthSignup = React.lazy(async () => import(/* webpackChunkName: "auth-signup" */ "./Signup"));
+const AuthCheckEmail = React.lazy(async () => import(/* webpackChunkName: "auth-check-email" */ "./CheckEmail"));
+const AuthVerifyToken = React.lazy(async () => import(/* webpackChunkName: "auth-verify-token" */ "./VerifyToken"));
+const AuthLogout = React.lazy(async () => import(/* webpackChunkName: "auth-logout" */ "./AuthLogout"));
 
 interface AuthVerifyTokenRouteParams {
   token: string;

--- a/packages/dapp/src/components/Main.tsx
+++ b/packages/dapp/src/components/Main.tsx
@@ -30,24 +30,40 @@ import { CivilHelperContext } from "../apis/CivilHelper";
 
 import { initializeContractAddresses } from "../helpers/contractAddresses";
 // PAGES
-const ChallengePage = React.lazy(async () => import("./listing/Challenge"));
-const Listing = React.lazy(async () => import("./listing/Listing"));
-const Listings = React.lazy(async () => import("./listinglist/Listings"));
-const NewsroomManagementV1 = React.lazy(async () => import("./newsroom/NewsroomManagement"));
-const Parameterizer = React.lazy(async () => import("./Parameterizer"));
-const Government = React.lazy(async () => import("./council/Government"));
-const SubmitChallengePage = React.lazy(async () => import("./listing/SubmitChallenge"));
-const SubmitAppealChallengePage = React.lazy(async () => import("./listing/SubmitAppealChallenge"));
-const RequestAppealPage = React.lazy(async () => import("./listing/RequestAppeal"));
-const ContractAddresses = React.lazy(async () => import("./ContractAddresses"));
-const SignUpNewsroom = React.lazy(async () => import("./SignUpNewsroom"));
-const StorefrontPage = React.lazy(async () => import("./Tokens/StorefrontPage"));
-const DashboardPage = React.lazy(async () => import("./Dashboard/DashboardPage"));
-const BoostPage = React.lazy(async () => import("./Boosts/Boost"));
-const BoostFeedPage = React.lazy(async () => import("./Boosts/BoostFeed"));
-const StoryFeedPage = React.lazy(async () => import("./StoryFeed/StoryFeed"));
+const ChallengePage = React.lazy(async () => import(/* webpackChunkName: "challenge-page" */ "./listing/Challenge"));
+const Listing = React.lazy(async () => import(/* webpackChunkName: "listing-page" */ "./listing/Listing"));
+const Listings = React.lazy(async () => import(/* webpackChunkName: "listings-page" */ "./listinglist/Listings"));
+const NewsroomManagementV1 = React.lazy(async () =>
+  import(/* webpackChunkName: "newsroom-mgmt-page" */ "./newsroom/NewsroomManagement"),
+);
+const Parameterizer = React.lazy(async () => import(/* webpackChunkName: "parameterizer-page" */ "./Parameterizer"));
+const Government = React.lazy(async () => import(/* webpackChunkName: "government-page" */ "./council/Government"));
+const SubmitChallengePage = React.lazy(async () =>
+  import(/* webpackChunkName: "submit-challenge-page" */ "./listing/SubmitChallenge"),
+);
+const SubmitAppealChallengePage = React.lazy(async () =>
+  import(/* webpackChunkName: "challenge-page" */ "./listing/SubmitAppealChallenge"),
+);
+const RequestAppealPage = React.lazy(async () =>
+  import(/* webpackChunkName: "request-appeal-page" */ "./listing/RequestAppeal"),
+);
+const ContractAddresses = React.lazy(async () =>
+  import(/* webpackChunkName: "contract-addresses-page" */ "./ContractAddresses"),
+);
+const SignUpNewsroom = React.lazy(async () =>
+  import(/* webpackChunkName: "signup-newsroom-page" */ "./SignUpNewsroom"),
+);
+const StorefrontPage = React.lazy(async () =>
+  import(/* webpackChunkName: "storefront-page" */ "./Tokens/StorefrontPage"),
+);
+const DashboardPage = React.lazy(async () =>
+  import(/* webpackChunkName: "dashboard-page" */ "./Dashboard/DashboardPage"),
+);
+const BoostPage = React.lazy(async () => import(/* webpackChunkName: "boost-page" */ "./Boosts/Boost"));
+const BoostFeedPage = React.lazy(async () => import(/* webpackChunkName: "boost-feed-page" */ "./Boosts/BoostFeed"));
+const StoryFeedPage = React.lazy(async () => import(/* webpackChunkName: "storyfeed-page" */ "./StoryFeed/StoryFeed"));
 const ManageNewsroomChannelPage = React.lazy(async () =>
-  import("./Dashboard/ManageNewsroom/ManageNewsroomChannelPage"),
+  import(/* webpackChunkName: "manage-newsroom-channel" */ "./Dashboard/ManageNewsroom/ManageNewsroomChannelPage"),
 );
 
 export interface MainReduxProps {

--- a/packages/dapp/src/components/header/NavBar.tsx
+++ b/packages/dapp/src/components/header/NavBar.tsx
@@ -3,7 +3,9 @@ import { CivilLogo, colors } from "@joincivil/elements";
 import { NavMenu } from "./NavMenu";
 import { NavContainer, NavOuter, NavLogo, NavInner, NavInnerRight } from "./styledComponents";
 
-const UserAccountContainer = React.lazy(async () => import("./UserAccountContainer"));
+const UserAccountContainer = React.lazy(async () =>
+  import(/* webpackChunkName: "user-account-container" */ "./UserAccountContainer"),
+);
 
 export const NavBar: React.FunctionComponent<NavBarProps> = () => {
   return (

--- a/packages/dapp/src/components/header/UserAccountContainer.tsx
+++ b/packages/dapp/src/components/header/UserAccountContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const UserAccount = React.lazy(async () => import("./UserAccount"));
+const UserAccount = React.lazy(async () => import(/* webpackChunkName: "user-account" */ "./UserAccount"));
 
 export const UserAccountContainer: React.FunctionComponent = () => {
   return (

--- a/packages/dapp/src/embeds/EmbedsApp.tsx
+++ b/packages/dapp/src/embeds/EmbedsApp.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Route, Switch } from "react-router-dom";
 import { embedRoutes } from "../constants";
 // apps
-const BoostLoader = React.lazy(async () => import("./BoostLoader"));
+const BoostLoader = React.lazy(async () => import(/* webpackChunkName: "boost-loader" */ "./BoostLoader"));
 
 export const EmbedsApp = () => {
   return (

--- a/packages/dapp/src/registry/LazyRegistryApp.tsx
+++ b/packages/dapp/src/registry/LazyRegistryApp.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import { RegistryShell } from "./RegistryShell";
 
-const AppProvider = React.lazy(async () => import("../components/providers/AppProvider"));
-const RegistryApp = React.lazy(async () => import("./RegistryApp"));
+const AppProvider = React.lazy(async () =>
+  import(/* webpackChunkName: "app-provider" */ "../components/providers/AppProvider"),
+);
+const RegistryApp = React.lazy(async () => import(/* webpackChunkName: "registry" */ "./RegistryApp"));
 
 const LazyRegistryApp = () => {
   return (


### PR DESCRIPTION
change to nginx so that index.html is sent with no-cache headers. this is definitely less than ideal since it requires the initial page load to always come from origin, however it should fix the "chunk failed to load" in (most) scenarios. 

Longer term fix is to put this in front of an edge cache, but that requires some more doing. 

Also sneaking in webpack bundle names. Pleas use this for any async loaded components going forward. 