### PR TITLE
fix(dapp): use styled-components macro for consistent class names

### DIFF
--- a/packages/dapp/src/App.tsx
+++ b/packages/dapp/src/App.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import config from "./helpers/config";
-import { createGlobalStyle } from "styled-components";
+import { createGlobalStyle } from "styled-components/macro";
 
 import { fonts, colors } from "@joincivil/elements";
 

--- a/packages/dapp/src/components/Auth/AuthButtonContent.tsx
+++ b/packages/dapp/src/components/Auth/AuthButtonContent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { colors } from "@joincivil/components";
 
 const StyledAuthServiceIconContainer = styled.div`

--- a/packages/dapp/src/components/Auth/authStyledComponents.tsx
+++ b/packages/dapp/src/components/Auth/authStyledComponents.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 export const StyledAuthHeader = styled.div`
   font-size: 24px;

--- a/packages/dapp/src/components/Boosts/BoostStyledComponents.tsx
+++ b/packages/dapp/src/components/Boosts/BoostStyledComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { colors, fonts, mediaQueries, ChevronAnchor } from "@joincivil/components";
 
 export const ComingSoonText: React.FunctionComponent = props => <ComingSoon>Coming soon!</ComingSoon>;

--- a/packages/dapp/src/components/ContractAddresses.tsx
+++ b/packages/dapp/src/components/ContractAddresses.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect } from "react-redux";
 import { Map } from "immutable";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { Helmet } from "react-helmet";
 
 import { EthAddress } from "@joincivil/core";

--- a/packages/dapp/src/components/Dashboard/ChallengeSummary.tsx
+++ b/packages/dapp/src/components/Dashboard/ChallengeSummary.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 import { doesChallengeHaveAppeal } from "@joincivil/core";
 import {

--- a/packages/dapp/src/components/Dashboard/Dashboard.tsx
+++ b/packages/dapp/src/components/Dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { connect } from "react-redux";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { Helmet } from "react-helmet";
 
 import { EthAddress } from "@joincivil/core";

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { formatRoute } from "react-router-named-routes";
 import { Map, Set } from "immutable";
-import styled, { StyledComponentClass } from "styled-components";
+import styled from "styled-components/macro";
 import { BigNumber } from "@joincivil/typescript-types";
 import { EthAddress } from "@joincivil/core";
 import {

--- a/packages/dapp/src/components/Dashboard/DepositTokens.tsx
+++ b/packages/dapp/src/components/Dashboard/DepositTokens.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 import { BigNumber } from "@joincivil/typescript-types";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { TwoStepEthTransaction, TxHash } from "@joincivil/core";
 import {
   TransactionButtonNoModal,

--- a/packages/dapp/src/components/Dashboard/ManageNewsroom/ManageNewsroomChannelPage.tsx
+++ b/packages/dapp/src/components/Dashboard/ManageNewsroom/ManageNewsroomChannelPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { ManageNewsroom } from "./ManageNewsroom";
 
 const ManageNewsroomChannelPage = (props: any) => {

--- a/packages/dapp/src/components/Dashboard/ManageNewsroom/WithNewsroomChannelAdminList.tsx
+++ b/packages/dapp/src/components/Dashboard/ManageNewsroom/WithNewsroomChannelAdminList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { Query } from "react-apollo";
 import { Set } from "immutable";
 import { EthAddress } from "@joincivil/core";

--- a/packages/dapp/src/components/Parameterizer/Parameter.tsx
+++ b/packages/dapp/src/components/Parameterizer/Parameter.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled, { StyledComponentClass } from "styled-components";
+import styled from "styled-components/macro";
 import { BigNumber } from "@joincivil/typescript-types";
 import {
   CivilContext,

--- a/packages/dapp/src/components/Parameterizer/index.tsx
+++ b/packages/dapp/src/components/Parameterizer/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { connect, DispatchProp } from "react-redux";
 import { BigNumber } from "@joincivil/typescript-types";
 import { Helmet } from "react-helmet";

--- a/packages/dapp/src/components/StoryFeed/StoryFeed.tsx
+++ b/packages/dapp/src/components/StoryFeed/StoryFeed.tsx
@@ -8,7 +8,7 @@ import { showWeb3LoginModal } from "../../redux/actionCreators/ui";
 import { ICivilContext, CivilContext, StoryFeedItem, LoadingMessage } from "@joincivil/components";
 import { Button, buttonSizes } from "@joincivil/elements";
 import { StoryFeedWrapper, StoryFeedHeader } from "./StoryFeedStyledComponents";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 export const STORY_FEED_QUERY = gql`
   query Storyfeed($cursor: String) {

--- a/packages/dapp/src/components/StoryFeed/StoryFeedStyledComponents.tsx
+++ b/packages/dapp/src/components/StoryFeed/StoryFeedStyledComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { fonts, mediaQueries } from "@joincivil/components";
 
 export const StoryFeedWrapper = styled.div`

--- a/packages/dapp/src/components/council/Government.tsx
+++ b/packages/dapp/src/components/council/Government.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { State } from "../../redux/reducers";
 import { connect, DispatchProp } from "react-redux";
 import { PageView, ViewModule, ViewModuleHeader } from "../utility/ViewModules";

--- a/packages/dapp/src/components/footer/Footer.tsx
+++ b/packages/dapp/src/components/footer/Footer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 import {
   colors,

--- a/packages/dapp/src/components/header/NavErrorBar.tsx
+++ b/packages/dapp/src/components/header/NavErrorBar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { colors, fonts } from "../styleConstants";
 
 const ErrorBar = styled.div`

--- a/packages/dapp/src/components/header/styledComponents.tsx
+++ b/packages/dapp/src/components/header/styledComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { colors, fonts, mediaQueries, Button, DarkButton } from "@joincivil/elements";
 
 import { NavArrowProps } from "./NavBarTypes";

--- a/packages/dapp/src/components/listing/AppealDetail.tsx
+++ b/packages/dapp/src/components/listing/AppealDetail.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { AppealData, ChallengeData, EthAddress, NewsroomWrapper, UserChallengeData } from "@joincivil/core";
 import { BigNumber } from "@joincivil/typescript-types";
 import AppealChallengeDetail from "./AppealChallengeDetail";

--- a/packages/dapp/src/components/listing/Challenge.tsx
+++ b/packages/dapp/src/components/listing/Challenge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import { Query } from "react-apollo";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { formatRoute } from "react-router-named-routes";
 
 import { routes } from "../../constants";

--- a/packages/dapp/src/components/listing/ChallengeDetail.tsx
+++ b/packages/dapp/src/components/listing/ChallengeDetail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { compose } from "redux";
 import { connect, DispatchProp } from "react-redux";
 import { formatRoute } from "react-router-named-routes";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { BigNumber } from "@joincivil/typescript-types";
 import {
   canRequestAppeal,

--- a/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
+++ b/packages/dapp/src/components/listing/ListingChallengeStatement.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
 import sanitizeHtml from "sanitize-html";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { State } from "../../redux/reducers";
 import { ListingTabHeading } from "./styledComponents";
 import { NewsroomWrapper, ListingWrapper } from "@joincivil/core";

--- a/packages/dapp/src/components/listing/ListingCharter.tsx
+++ b/packages/dapp/src/components/listing/ListingCharter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { Map } from "immutable";
 import { diffSentences } from "diff";
 import {

--- a/packages/dapp/src/components/listing/ListingCharterRosterMember.tsx
+++ b/packages/dapp/src/components/listing/ListingCharterRosterMember.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { fonts, colors } from "@joincivil/components";
 import { RosterMember } from "@joincivil/core";
 import { renderPTagsFromLineBreaks } from "@joincivil/utils";

--- a/packages/dapp/src/components/listing/ListingDiscourse.tsx
+++ b/packages/dapp/src/components/listing/ListingDiscourse.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 import { EthAddress } from "@joincivil/core";
 import { colors, FeatureFlag, LoadingMessage, ChevronAnchor } from "@joincivil/components";

--- a/packages/dapp/src/components/listing/ListingPhaseActions.tsx
+++ b/packages/dapp/src/components/listing/ListingPhaseActions.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { formatRoute } from "react-router-named-routes";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { ListingWrapper, NewsroomWrapper } from "@joincivil/core";
 import {
   InApplicationCard,

--- a/packages/dapp/src/components/listing/SubmitChallenge/SubmitChallengeViewComponent.tsx
+++ b/packages/dapp/src/components/listing/SubmitChallenge/SubmitChallengeViewComponent.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { compose } from "redux";
 import { connect, DispatchProp } from "react-redux";
 import { formatRoute } from "react-router-named-routes";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 import { TwoStepEthTransaction, TxHash } from "@joincivil/core";
 import {

--- a/packages/dapp/src/components/listing/styledComponents.tsx
+++ b/packages/dapp/src/components/listing/styledComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { Heading, mediaQueries } from "@joincivil/components";
 
 export const RightShark = styled.div`

--- a/packages/dapp/src/components/listinglist/ListItemStyle.tsx
+++ b/packages/dapp/src/components/listinglist/ListItemStyle.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 export const SectionHeader = styled.span`
   font-family: Libre-Franklin;

--- a/packages/dapp/src/components/listinglist/RejectedListingListContainer.tsx
+++ b/packages/dapp/src/components/listinglist/RejectedListingListContainer.tsx
@@ -13,7 +13,7 @@ import {
 import ErrorLoadingDataMsg from "../utility/ErrorLoadingData";
 import { NewsroomListing } from "@joincivil/core";
 import { RejectedTabDescription } from "./TabDescriptions";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 const LISTINGS_QUERY = gql`
   query Listings($rejectedOnly: Boolean!, $sortBy: ListingSort, $cursor: String) {

--- a/packages/dapp/src/components/listinglist/WhitelistedListingListContainer.tsx
+++ b/packages/dapp/src/components/listinglist/WhitelistedListingListContainer.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../helpers/queryTransformations";
 import ErrorLoadingDataMsg from "../utility/ErrorLoadingData";
 import { WhitelistedTabDescription } from "./TabDescriptions";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 const LISTINGS_QUERY = gql`
   query Listings($whitelistedOnly: Boolean!, $sortBy: ListingSort, $cursor: String) {

--- a/packages/dapp/src/components/utility/FormElements.tsx
+++ b/packages/dapp/src/components/utility/FormElements.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 export const StyledFormContainer = styled.div`
   margin: 1rem 0;

--- a/packages/dapp/src/components/utility/HigherOrderComponents.tsx
+++ b/packages/dapp/src/components/utility/HigherOrderComponents.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect, DispatchProp } from "react-redux";
 import { BigNumber } from "@joincivil/typescript-types";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import {
   EthAddress,
   ListingWrapper,

--- a/packages/dapp/src/components/utility/ViewModules.tsx
+++ b/packages/dapp/src/components/utility/ViewModules.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 export const dappTheme = {
   borderColor: "#cecece",

--- a/packages/dapp/src/components/utility/styledComponents.tsx
+++ b/packages/dapp/src/components/utility/styledComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 import { mediaQueries } from "@joincivil/components";
 
 export interface StyledPageContentProps {

--- a/packages/dapp/src/embeds/BoostLoader.tsx
+++ b/packages/dapp/src/embeds/BoostLoader.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled, { ThemeProvider } from "styled-components";
+import styled, { ThemeProvider } from "styled-components/macro";
 import { useRouteMatch } from "react-router";
 import {
   CivilContext,

--- a/packages/dapp/src/embeds/StoryBoostLoader.tsx
+++ b/packages/dapp/src/embeds/StoryBoostLoader.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled, { ThemeProvider } from "styled-components";
+import styled, { ThemeProvider } from "styled-components/macro";
 import { useRouteMatch } from "react-router";
 import {
   CivilContext,

--- a/packages/dapp/src/registry/RegistryShell.tsx
+++ b/packages/dapp/src/registry/RegistryShell.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import styled from "styled-components/macro";
 
 import { NavBar } from "../components/header/NavBar";
 import Footer from "../components/footer/Footer";


### PR DESCRIPTION
In order to use automated browser testing we need to have stable class names. This requires using styled-components babel plugin, which would require ejecting from CRA. However, it looks like we can use the "macro" instead:
https://www.styled-components.com/docs/tooling#babel-macro

As far as I can tell there are no downsides to this.

Ran the following to update the files:
```
find . -type f -exec sed -i 's/import styled from "styled-components"/import styled from "styled-components\/macro"/g' {} \;
```
