### PR TITLE
A way to serve boost embed loader script [CIVIL-1243]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
                 command:  yarn build
                 no_output_timeout: 30m
             - run:
+                name: Copying boost loader script
+                command:  yarn copy:boost-loader
+            - run:
                 name: Ensuring prettified
                 command: yarn prettier
             - run:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "watch": "lerna run --parallel build:watch",
     "lint": "lerna run lint --parallel",
     "build:core": "lerna run --scope @joincivil/core build",
+    "copy:boost-loader": "mkdir -p packages/dapp/build/loader/ && cp packages/sdk/build/static/js/boost.js packages/dapp/build/loader/",
     "coverage": "lerna run coverage --parallel",
     "coverage:submit": "lcov-result-merger 'packages/*/coverage/lcov.info' | coveralls",
     "prettier": "prettier --config .prettierrc.yaml --write --list-different './**/*.{ts,tsx,json,md}'",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -79,11 +79,13 @@
     "workbox-webpack-plugin": "3.6.3"
   },
   "scripts": {
+    "build": "yarn package:build && yarn sdk:build",
+    "build:watch": "yarn package:build:watch",
     "sdk:start": "node scripts/start.js",
     "sdk:start:boost-embed": "OPEN_PATH=boost-embed.html node scripts/start.js",
     "sdk:build": "node scripts/build.js",
-    "build": "yarn clean && yarn copy:images && tsc",
-    "build:watch": "yarn copy:images && tsc -w",
+    "package:build": "yarn clean && yarn copy:images && tsc",
+    "package:build:watch": "yarn copy:images && tsc -w",
     "test": "node scripts/test.js",
     "lint": "tslint --project ./",
     "clean": "rimraf build/package",


### PR DESCRIPTION
This will make the standalone boost embed loader script available for newsrooms to embed from `registry.civil.co/loader/boost.js`.

It's clunky because it requires lifting information about dapp and sdk directory structure up into root package.json, but I don't see a way around that. I thought about putting this task inside dapp or sdk, bundling it with an existing build script, but this task will only work after _both_ of those packages have been built, so makes more sense for the root package.json to handle it.

I also can think of various ways to abstract multiple "loader" scripts to be served this way, but don't want to premature refactor until we see if/how we need to do something similar like this in the future, so I'm leaving it boost-specific for now.

Open to any other ways of handling this. Other ideas about it: https://civilmedia.slack.com/archives/GJ45CLYD8/p1572972104008200