### PR TITLE
Refactor auth modals into CivilContext and AppProvider to support login flow in story boost embed [CIVIL-1267]

### DIFF
--- a/packages/components/src/Payments/Payments.tsx
+++ b/packages/components/src/Payments/Payments.tsx
@@ -70,11 +70,15 @@ export class Payments extends React.Component<PaymentsProps, PaymentsStates> {
     const { postId, paymentAddress, newsroomName, isStripeConnected } = this.props;
     const isWalletConnected = !!userAddress;
 
-    if (paymentState === PAYMENT_STATE.PAYMENT_CHOOSE_LOGIN_OR_GUEST) {
-      return <PaymentsLoginOrGuest handleNext={this.handleUpdateState} handleLogin={this.props.handleLogin} />;
+    // User logged in from PAYMENT_CHOOSE_LOGIN_OR_GUEST state, which will be reflected in context, and we should now show them SELECT_PAYMENT_TYPE state instead.
+    const proceedToPaymentType =
+      paymentState === PAYMENT_STATE.PAYMENT_CHOOSE_LOGIN_OR_GUEST && !!this.context.currentUser;
+
+    if (paymentState === PAYMENT_STATE.PAYMENT_CHOOSE_LOGIN_OR_GUEST && !proceedToPaymentType) {
+      return <PaymentsLoginOrGuest handleNext={this.handleUpdateState} handleLogin={this.context.auth.showWeb3Login} />;
     }
 
-    if (paymentState === PAYMENT_STATE.SELECT_PAYMENT_TYPE) {
+    if (proceedToPaymentType || paymentState === PAYMENT_STATE.SELECT_PAYMENT_TYPE) {
       return (
         <PaymentsWrapper usdToSpend={usdToSpend} newsroomName={newsroomName}>
           <PaymentsOptions

--- a/packages/components/src/Payments/Payments.tsx
+++ b/packages/components/src/Payments/Payments.tsx
@@ -55,9 +55,6 @@ export class Payments extends React.Component<PaymentsProps, PaymentsStates> {
       return <></>;
     }
 
-    const userAddress = this.context && this.context.currentUser && this.context.currentUser.ethAddress;
-    const userEmail = this.context && this.context.currentUser && this.context.currentUser.email;
-
     const {
       usdToSpend,
       etherToSpend,
@@ -68,7 +65,7 @@ export class Payments extends React.Component<PaymentsProps, PaymentsStates> {
       paymentAdjustedEth,
     } = this.state;
     const { postId, paymentAddress, newsroomName, isStripeConnected } = this.props;
-    const isWalletConnected = !!userAddress;
+    const userEmail = this.context && this.context.currentUser && this.context.currentUser.email;
 
     // User logged in from PAYMENT_CHOOSE_LOGIN_OR_GUEST state, which will be reflected in context, and we should now show them SELECT_PAYMENT_TYPE state instead.
     const proceedToPaymentType =
@@ -105,10 +102,8 @@ export class Payments extends React.Component<PaymentsProps, PaymentsStates> {
             newsroomName={newsroomName}
             paymentAddress={paymentAddress}
             shouldPublicize={shouldPublicize}
-            userAddress={userAddress}
             userEmail={userEmail}
             usdToSpend={usdToSpend}
-            isWalletConnected={isWalletConnected}
             handlePaymentSuccess={this.handleUpdateState}
             etherToSpend={this.state.etherToSpend}
             resetEthPayments={this.state.resetEthPayments}

--- a/packages/components/src/StoryFeed/StoryFeedItem.tsx
+++ b/packages/components/src/StoryFeed/StoryFeedItem.tsx
@@ -9,7 +9,6 @@ import { StoryFeedItemWrap, StoryElementsFlex } from "./StoryFeedStyledComponent
 import { StoryNewsroomData, OpenGraphData } from "./types";
 import { Payments, PaymentsModal } from "../Payments";
 import { PaymentButton, ShareButton, ShareStory, SharePanel } from "@joincivil/elements";
-import { EthAddress } from "@joincivil/core";
 
 export interface StoryFeedItemProps {
   storyId: string;
@@ -21,10 +20,6 @@ export interface StoryFeedItemProps {
   displayedContributors: ContributorData[];
   sortedContributors: ContributorData[];
   totalContributors: number;
-  isLoggedIn: boolean;
-  userAddress?: EthAddress;
-  userEmail?: string;
-  handleLogin(): void;
 }
 
 export interface StoryFeedItemStates {
@@ -92,14 +87,10 @@ export class StoryFeedItem extends React.Component<StoryFeedItemProps, StoryFeed
         </StoryModal>
         <PaymentsModal open={this.state.isPaymentsModalOpen} handleClose={this.handleClose}>
           <Payments
-            isLoggedIn={this.props.isLoggedIn}
-            userAddress={this.props.userAddress}
-            userEmail={this.props.userEmail}
             postId={this.props.storyId}
             newsroomName={this.props.newsroom.charter.name}
             paymentAddress={this.props.newsroom.multisigAddress}
             isStripeConnected={this.props.isStripeConnected}
-            handleLogin={this.props.handleLogin}
             handleClose={this.handleClose}
           />
         </PaymentsModal>

--- a/packages/components/src/TCRUserDashboard/Dashboard.tsx
+++ b/packages/components/src/TCRUserDashboard/Dashboard.tsx
@@ -8,7 +8,7 @@ const StyledDashboardHeaderOuter = styled.div`
   justify-content: center;
   width: 400px;
   min-width: 400px;
-  ${mediaQueries.MOBILE}  {
+  ${mediaQueries.MOBILE} {
     width: 100%;
     min-width: 0;
   }

--- a/packages/components/src/TCRUserDashboard/DashboardUserInfoSummary.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardUserInfoSummary.tsx
@@ -65,27 +65,27 @@ export const DashboardUserInfoSummary = (props: DashboardUserInfoSummaryProps) =
 
       {challengesWonTotalCvl && (
         <StyledUserInfoSection>
-            <>
-              <StyledUserInfoSectionLabel>
-                <ChallengesWonLabelText />
-              </StyledUserInfoSectionLabel>
-              <StyledUserInfoSectionValue>
-                <strong>{challengesWonTotalCvl}</strong>
-              </StyledUserInfoSectionValue>
-            </>
+          <>
+            <StyledUserInfoSectionLabel>
+              <ChallengesWonLabelText />
+            </StyledUserInfoSectionLabel>
+            <StyledUserInfoSectionValue>
+              <strong>{challengesWonTotalCvl}</strong>
+            </StyledUserInfoSectionValue>
+          </>
         </StyledUserInfoSection>
       )}
 
       {rewardsEarned && (
         <StyledUserInfoSection>
-            <>
-              <StyledUserInfoSectionLabel>
-                <RewardsClaimedLabelText />
-              </StyledUserInfoSectionLabel>
-              <StyledUserInfoSectionValue>
-                <strong>{rewardsEarned}</strong>
-              </StyledUserInfoSectionValue>
-            </>
+          <>
+            <StyledUserInfoSectionLabel>
+              <RewardsClaimedLabelText />
+            </StyledUserInfoSectionLabel>
+            <StyledUserInfoSectionValue>
+              <strong>{rewardsEarned}</strong>
+            </StyledUserInfoSectionValue>
+          </>
         </StyledUserInfoSection>
       )}
 

--- a/packages/components/src/context/AuthService.ts
+++ b/packages/components/src/context/AuthService.ts
@@ -97,6 +97,26 @@ export class AuthService {
     return result.data.currentUser;
   }
 
+  public async showWeb3Login(): Promise<void> {
+    console.error("web3 auth not yet initialized");
+  }
+  public async showWeb3Signup(): Promise<void> {
+    console.error("web3 auth not yet initialized");
+  }
+  /** If user is logged in, but web3 not enabled, enable it. */
+  public ensureLoggedInUserEnabled(): void {
+    console.error("web3 auth not yet initialized");
+  }
+  public setShowWeb3Login(func: () => Promise<void>): void {
+    this.showWeb3Login = func;
+  }
+  public setShowWeb3Signup(func: () => Promise<void>): void {
+    this.showWeb3Signup = func;
+  }
+  public setEnsureLoggedInUserEnabled(func: () => void): void {
+    this.ensureLoggedInUserEnabled = func;
+  }
+
   private async graphqlLoginSignup(mutation: any, signature: any): Promise<any> {
     // TODO(dankins): graphql API requires messageHash, r,s,v but they aren't actually used
     const signatureWithHack = { ...signature, messageHash: "n/a", r: "n/a", s: "n/a", v: "n/a" };

--- a/packages/dapp/src/components/Dashboard/ClaimRewardsItem/ClaimRewardsItemWrapper.tsx
+++ b/packages/dapp/src/components/Dashboard/ClaimRewardsItem/ClaimRewardsItemWrapper.tsx
@@ -26,11 +26,7 @@ const ClaimRewardsItemWrapper: React.FunctionComponent<ClaimRewardsItemOwnProps>
 
   if (pollType === "CHALLENGE" || pollType === "APPEAL_CHALLENGE" || pollType === "PARAMETER_PROPOSAL_CHALLENGE") {
     if (challenge) {
-
-      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(
-        queryUserChallengeData,
-        challenge,
-      );
+      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(queryUserChallengeData, challenge);
 
       const unclaimedRewardAmount = userChallengeData!.voterReward;
 

--- a/packages/dapp/src/components/Dashboard/Dashboard.tsx
+++ b/packages/dapp/src/components/Dashboard/Dashboard.tsx
@@ -4,7 +4,15 @@ import styled from "styled-components/macro";
 import { Helmet } from "react-helmet";
 
 import { EthAddress } from "@joincivil/core";
-import { buttonSizes, Button, CivilContext, UserDashboardHeader, LoadUser, mediaQueries, colors } from "@joincivil/components";
+import {
+  buttonSizes,
+  Button,
+  CivilContext,
+  UserDashboardHeader,
+  LoadUser,
+  mediaQueries,
+  colors,
+} from "@joincivil/components";
 
 import { State } from "../../redux/reducers";
 import ScrollToTopOnMount from "../utility/ScrollToTop";
@@ -86,7 +94,7 @@ const DashboardComponent = (props: DashboardProps & DashboardReduxProps) => {
           } else if (civilUser && enableEthereum) {
             return (
               <StyledAuthButtonContainer>
-                <p>Enable Ethereum to view Your Civil Registry Dashboard</p>
+                <p>Enable Ethereum to view your Civil Registry dashboard</p>
                 <Button onClick={enableEthereum} size={buttonSizes.SMALL}>
                   Connect Wallet
                 </Button>
@@ -96,7 +104,7 @@ const DashboardComponent = (props: DashboardProps & DashboardReduxProps) => {
 
           return (
             <StyledAuthButtonContainer>
-              <p>Sign Up or Login to view Your Civil Registry Dashboard</p>
+              <p>Sign Up or Log In to view your Civil Registry dashboard</p>
             </StyledAuthButtonContainer>
           );
         }}

--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -232,7 +232,7 @@ export const getSalts = (challengeObj: ChallengesToProcess): BigNumber[] => {
 class DashboardActivity extends React.Component<
   DashboardActivityProps & DashboardActivityReduxProps,
   DashboardActivityState
-  > {
+> {
   public state = {
     isNoMobileTransactionVisible: false,
     activeTabIndex: 0,
@@ -291,19 +291,16 @@ class DashboardActivity extends React.Component<
 
                       const numUserNewsrooms =
                         newsrooms.count() ||
-                        (nrsignupData && nrsignupData.nrsignupNewsroom
-                          && nrsignupData.nrsignupNewsroom.newsroomAddress ? 1 : 0);
+                        (nrsignupData && nrsignupData.nrsignupNewsroom && nrsignupData.nrsignupNewsroom.newsroomAddress
+                          ? 1
+                          : 0);
 
                       return (
                         <>
                           <DashboardActivityComponent
                             userVotes={this.renderUserVotes(challengeError, myTasksViewProps)}
                             numUserVotes={myTasksViewProps.numUserTasks}
-                            userNewsrooms={this.renderWithNrsignupNewsrooms(
-                              newsrooms,
-                              nrsignupError,
-                              nrsignupData,
-                            )}
+                            userNewsrooms={this.renderWithNrsignupNewsrooms(newsrooms, nrsignupError, nrsignupData)}
                             numUserNewsrooms={numUserNewsrooms}
                             userChallenges={this.renderUserChallenges(challengeError, myChallengesViewProps)}
                             activeIndex={this.state.activeTabIndex}
@@ -335,7 +332,7 @@ class DashboardActivity extends React.Component<
     const newsrooms = channelNewsrooms;
 
     if (!newsrooms.size && data && data.nrsignupNewsroom) {
-      return (<NoNewsrooms hasInProgressApplication={true} applyToRegistryURL={registryUrl} />)
+      return <NoNewsrooms hasInProgressApplication={true} applyToRegistryURL={registryUrl} />;
     }
 
     if (!newsrooms.size) {
@@ -495,7 +492,11 @@ class DashboardActivity extends React.Component<
     return <MyTasks {...myTasksViewProps} />;
   };
 
-  private setActiveTabAndSubTabIndex = (activeTabIndex: number, activeSubTabIndex: number = 0, shouldPushHistory: boolean = true): void => {
+  private setActiveTabAndSubTabIndex = (
+    activeTabIndex: number,
+    activeSubTabIndex: number = 0,
+    shouldPushHistory: boolean = true,
+  ): void => {
     const tabName = TABS[activeTabIndex];
     this.setState({ activeTabIndex, activeSubTabIndex });
     const subTabName =

--- a/packages/dapp/src/components/Dashboard/MyTasksItem/MyTasksItemWrapper.tsx
+++ b/packages/dapp/src/components/Dashboard/MyTasksItem/MyTasksItemWrapper.tsx
@@ -13,9 +13,7 @@ import { getChallengeState, getAppealChallengeState } from "../../../selectors";
 import MyTasksItemComponent from "./MyTasksItemComponent";
 import { MyTasksItemOwnProps, MyTasksItemWrapperReduxProps } from "./MyTasksItemTypes";
 
-const MyTasksItemWrapper: React.FunctionComponent<
-  MyTasksItemOwnProps & MyTasksItemWrapperReduxProps
-> = props => {
+const MyTasksItemWrapper: React.FunctionComponent<MyTasksItemOwnProps & MyTasksItemWrapperReduxProps> = props => {
   const {
     challengeID,
     queryUserChallengeData,
@@ -39,16 +37,16 @@ const MyTasksItemWrapper: React.FunctionComponent<
   if (pollType === "CHALLENGE") {
     if (challenge) {
       const challengeData = transformGraphQLDataIntoChallenge(challenge);
-      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(
-        queryUserChallengeData,
-        challenge,
-      );
+      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(queryUserChallengeData, challenge);
       if (challengeData) {
         const listingAddress = challenge!.listingAddress;
         if (listingAddress && challenge.listing) {
           const listing = transformGraphQLDataIntoListing(challenge.listing, listingAddress);
           if (listing) {
-            const newsroom = { wrapper: transformGraphQLDataIntoNewsroom(challenge.listing, listingAddress), address: listingAddress };
+            const newsroom = {
+              wrapper: transformGraphQLDataIntoNewsroom(challenge.listing, listingAddress),
+              address: listingAddress,
+            };
             let appealUserChallengeData;
             if (queryUserAppealChallengeData) {
               appealUserChallengeData = transfromGraphQLDataIntoUserChallengeData(
@@ -114,7 +112,6 @@ const MyTasksItemWrapper: React.FunctionComponent<
         }
       }
     }
-
   }
   console.error("MyTasksItemWrapper: pollType !== CHALLENGE");
   return <></>;

--- a/packages/dapp/src/components/Dashboard/MyTasksProposalItem/MyTasksProposalItemWrapper.tsx
+++ b/packages/dapp/src/components/Dashboard/MyTasksProposalItem/MyTasksProposalItemWrapper.tsx
@@ -25,10 +25,7 @@ const MyTasksProposalItemWrapper: React.FunctionComponent<
 
   if (pollType === "PARAMETER_PROPOSAL_CHALLENGE") {
     if (challenge) {
-      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(
-        queryUserChallengeData,
-        challenge,
-      );
+      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(queryUserChallengeData, challenge);
       const challengeData = transformGraphQLDataIntoChallenge(challenge);
 
       const viewProps = {
@@ -44,7 +41,6 @@ const MyTasksProposalItemWrapper: React.FunctionComponent<
   }
   console.error("MyTasksProposalItemWrapper: pollType !== CHALLENGE");
   return <></>;
-
 };
 
 export default MyTasksProposalItemWrapper;

--- a/packages/dapp/src/components/Dashboard/NewsroomsListItem.tsx
+++ b/packages/dapp/src/components/Dashboard/NewsroomsListItem.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-import {
-  transformGraphQLDataIntoNewsroom,
-  transformGraphQLDataIntoListing,
-} from "../../helpers/queryTransformations";
+import { transformGraphQLDataIntoNewsroom, transformGraphQLDataIntoListing } from "../../helpers/queryTransformations";
 
 import NewsroomsListItemComponent from "./NewsroomsListItemComponent";
 
@@ -26,7 +23,6 @@ const NewsroomsListItemGraphQL: React.FunctionComponent<NewsroomListItemOwnProps
       />
     </>
   );
-
 };
 
 const NewsroomListItem: React.FunctionComponent<NewsroomListItemOwnProps> = props => {

--- a/packages/dapp/src/components/Dashboard/NewsroomsListItemComponent.tsx
+++ b/packages/dapp/src/components/Dashboard/NewsroomsListItemComponent.tsx
@@ -162,7 +162,7 @@ class NewsroomsListItemListingRedux extends React.Component<
       const etherscanBaseURL = getEtherscanBaseURL(network);
 
       const newsroomStatusOnRegistry = getNewsroomStatusOnRegistry();
-      const newsroomName = (newsroom && newsroom.data && newsroom.data.name) ? newsroom.data.name : "loading...";
+      const newsroomName = newsroom && newsroom.data && newsroom.data.name ? newsroom.data.name : "loading...";
 
       const displayProps = {
         newsroomName,

--- a/packages/dapp/src/components/Dashboard/RescueTokensItem/RescueTokensItemWrapper.tsx
+++ b/packages/dapp/src/components/Dashboard/RescueTokensItem/RescueTokensItemWrapper.tsx
@@ -26,11 +26,7 @@ const RescueTokensItemWrapper: React.FunctionComponent<RescueTokensItemOwnProps>
 
   if (pollType === "CHALLENGE" || pollType === "APPEAL_CHALLENGE" || pollType === "PARAMETER_PROPOSAL_CHALLENGE") {
     if (challenge) {
-
-      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(
-        queryUserChallengeData,
-        challenge,
-      );
+      const userChallengeData = transfromGraphQLDataIntoUserChallengeData(queryUserChallengeData, challenge);
 
       const unclaimedRewardAmount = userChallengeData!.voterReward;
 

--- a/packages/dapp/src/components/StoryFeed/StoryFeed.tsx
+++ b/packages/dapp/src/components/StoryFeed/StoryFeed.tsx
@@ -2,10 +2,7 @@ import * as React from "react";
 import gql from "graphql-tag";
 import { Query } from "react-apollo";
 import { Helmet } from "react-helmet";
-import { useSelector, useDispatch } from "react-redux";
-import { State } from "../../redux/reducers";
-import { showWeb3LoginModal } from "../../redux/actionCreators/ui";
-import { ICivilContext, CivilContext, StoryFeedItem, LoadingMessage } from "@joincivil/components";
+import { StoryFeedItem, LoadingMessage } from "@joincivil/components";
 import { Button, buttonSizes } from "@joincivil/elements";
 import { StoryFeedWrapper, StoryFeedHeader } from "./StoryFeedStyledComponents";
 import styled from "styled-components/macro";
@@ -74,40 +71,7 @@ const LoadMoreContainer = styled.div`
   width: 100%;
 `;
 
-function maybeAccount(state: State): any {
-  const { user } = state.networkDependent;
-  if (user.account && user.account.account && user.account.account !== "") {
-    return user.account;
-  }
-}
-
 const StoryFeedPage: React.FunctionComponent = props => {
-  // context
-  const civilCtx = React.useContext<ICivilContext>(CivilContext);
-  if (civilCtx === null) {
-    // context still loading
-    return <></>;
-  }
-
-  // redux
-  const dispatch = useDispatch();
-  const account: any | undefined = useSelector(maybeAccount);
-
-  const civilContext = React.useContext<ICivilContext>(CivilContext);
-  const civilUser = civilContext.currentUser;
-  const userAccount = account ? account.account : undefined;
-  const userEmail = civilUser ? civilUser.email : undefined;
-
-  async function onLoginPressed(): Promise<any> {
-    dispatch!(await showWeb3LoginModal());
-  }
-
-  React.useEffect(() => {
-    if (civilUser && !userAccount) {
-      civilCtx.civil!.currentProviderEnable().catch(err => console.log("error enabling ethereum", err));
-    }
-  }, [civilUser, userAccount]);
-
   return (
     <>
       <Helmet title="Civil Stories - The Civil Registry" />
@@ -133,9 +97,6 @@ const StoryFeedPage: React.FunctionComponent = props => {
                 return (
                   <StoryFeedItem
                     key={i}
-                    isLoggedIn={civilUser ? true : false}
-                    userAddress={userAccount}
-                    userEmail={userEmail}
                     storyId={storyData.id}
                     activeChallenge={false}
                     createdAt={storyData.createdAt}
@@ -147,7 +108,6 @@ const StoryFeedPage: React.FunctionComponent = props => {
                     totalContributors={
                       storyData.groupedSanitizedPayments ? storyData.groupedSanitizedPayments.length : 0
                     }
-                    handleLogin={onLoginPressed}
                   />
                 );
               }

--- a/packages/dapp/src/components/Web3AuthWrapper.tsx
+++ b/packages/dapp/src/components/Web3AuthWrapper.tsx
@@ -86,7 +86,6 @@ export const Web3AuthWrapper: React.FunctionComponent = () => {
   }
 
   React.useEffect(() => {
-    (window as any).context = civilContext; // @TODO/tobek tmp
     civilContext.auth.setShowWeb3Login(handleLoginClicked);
     civilContext.auth.setShowWeb3Signup(handleSignUpClicked);
   }, [dispatch]);

--- a/packages/dapp/src/components/Web3AuthWrapper.tsx
+++ b/packages/dapp/src/components/Web3AuthWrapper.tsx
@@ -18,6 +18,13 @@ export const Web3AuthWrapper: React.FunctionComponent = () => {
   const dispatch = useDispatch();
   const web3AuthType = useSelector((state: State) => state.web3AuthType);
   const showWeb3AuthModal = useSelector((state: State) => state.showWeb3AuthModal);
+  const userAddress: string | undefined = useSelector(
+    (state: State) =>
+      state.networkDependent &&
+      state.networkDependent.user &&
+      state.networkDependent.user.account &&
+      state.networkDependent.user.account.account,
+  );
 
   const showWeb3Signup = showWeb3AuthModal && web3AuthType === "signup";
   const showWeb3Login = showWeb3AuthModal && web3AuthType === "login";
@@ -77,6 +84,20 @@ export const Web3AuthWrapper: React.FunctionComponent = () => {
   async function handleUpdateUser(): Promise<void> {
     return civilContext.auth.handleInitialState();
   }
+
+  React.useEffect(() => {
+    (window as any).context = civilContext; // @TODO/tobek tmp
+    civilContext.auth.setShowWeb3Login(handleLoginClicked);
+    civilContext.auth.setShowWeb3Signup(handleSignUpClicked);
+  }, [dispatch]);
+
+  React.useEffect(() => {
+    civilContext.auth.setEnsureLoggedInUserEnabled(() => {
+      if (civilContext.currentUser && !userAddress) {
+        civilContext.civil!.currentProviderEnable().catch(err => console.error("error enabling ethereum", err));
+      }
+    });
+  }, [civilContext.currentUser, userAddress]);
 
   return (
     <>

--- a/packages/dapp/src/components/providers/AppProvider.tsx
+++ b/packages/dapp/src/components/providers/AppProvider.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundry } from "../errors/ErrorBoundry";
 
 import config from "../../helpers/config";
 import { store, history } from "../../redux/store";
+import { Web3AuthWrapper } from "../Web3AuthWrapper";
 import AnalyticsProvider from "./AnalyticsProvider";
 
 import { Provider } from "react-redux";
@@ -41,7 +42,12 @@ export const AppProvider: React.FunctionComponent = ({ children }) => {
         <ApolloProvider client={client}>
           <CivilProvider pluginConfig={pluginConfig} featureFlags={featureFlags} config={config}>
             <AnalyticsProvider>
-              <ConnectedRouter history={history}>{children}</ConnectedRouter>
+              <ConnectedRouter history={history}>
+                <>
+                  {children}
+                  <Web3AuthWrapper />
+                </>
+              </ConnectedRouter>
             </AnalyticsProvider>
           </CivilProvider>
         </ApolloProvider>

--- a/packages/dapp/src/embeds/StoryBoostLoader.tsx
+++ b/packages/dapp/src/embeds/StoryBoostLoader.tsx
@@ -16,7 +16,9 @@ import { routes, embedRoutes } from "../constants";
 import AppProvider from "../components/providers/AppProvider";
 
 const EmbedWrapper = styled.div`
-  background: white; // obscure embed loading message outside iframe
+  // obscure embed loading message outside iframe:
+  background: white;
+  min-height: 100vh;
 `;
 const CivilLogoLink = styled.a`
   position: absolute;
@@ -63,13 +65,7 @@ const StoryBoostLoaderComponent: React.FunctionComponent = () => {
         <CivilIcon />
       </CivilLogoLink>
       <ThemeProvider theme={theme}>
-        <StoryBoost
-          boostId={boostId}
-          isLoggedIn={false}
-          handleLogin={() => {
-            alert("@TODO/tobek");
-          }}
-        />
+        <StoryBoost boostId={boostId} />
       </ThemeProvider>
     </EmbedWrapper>
   );

--- a/packages/dapp/src/helpers/queryTransformations.ts
+++ b/packages/dapp/src/helpers/queryTransformations.ts
@@ -445,11 +445,7 @@ export function getUserChallengeDataSetByPollType(
 ): Set<string> {
   const challengeIDs = queryUserChallengeData
     .filter(challengeData => {
-      return userChallengeDataFilter(
-        challengeData,
-        pollType,
-        filterAvailableActions,
-      );
+      return userChallengeDataFilter(challengeData, pollType, filterAvailableActions);
     })
     .map(challengeData => {
       return challengeData.pollID;

--- a/packages/dapp/src/registry/RegistryApp.tsx
+++ b/packages/dapp/src/registry/RegistryApp.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Route, Switch } from "react-router-dom";
-import { Web3AuthWrapper } from "../components/Web3AuthWrapper";
 import Main from "../components/Main";
 import Footer from "../components/footer/Footer";
 import { NavBar } from "../components/header/NavBar";
@@ -16,7 +15,6 @@ export const RegistrySection: React.FunctionComponent = () => {
               <NavBar />
               <Main />
               <Footer />
-              <Web3AuthWrapper />
             </>
           </Route>
         </Switch>

--- a/packages/sdk/src/react/StoryBoost/StoryBoost.tsx
+++ b/packages/sdk/src/react/StoryBoost/StoryBoost.tsx
@@ -115,7 +115,7 @@ export class StoryBoost extends React.Component<StoryBoostProps, StoryBoostState
                   newsroomName={storyBoostData.channel.newsroom.name}
                   paymentAddress={storyBoostData.channel.newsroom.multisigAddress}
                   isStripeConnected={storyBoostData.channel.isStripeConnected}
-                  handleClose={this.handleEndPayment}
+                  handleClose={this.handleClose}
                 />
               </PaymentsModal>
             </>
@@ -127,9 +127,6 @@ export class StoryBoost extends React.Component<StoryBoostProps, StoryBoostState
 
   private handleStartPayment = () => {
     this.setState({ paymentsOpen: true });
-  };
-  private handleEndPayment = () => {
-    this.setState({ paymentsOpen: false });
   };
   private handleClose = () => {
     this.setState({ paymentsOpen: false });

--- a/packages/sdk/src/react/StoryBoost/StoryBoost.tsx
+++ b/packages/sdk/src/react/StoryBoost/StoryBoost.tsx
@@ -115,10 +115,6 @@ export class StoryBoost extends React.Component<StoryBoostProps, StoryBoostState
                   newsroomName={storyBoostData.channel.newsroom.name}
                   paymentAddress={storyBoostData.channel.newsroom.multisigAddress}
                   isStripeConnected={storyBoostData.channel.isStripeConnected}
-                  isLoggedIn={this.props.isLoggedIn}
-                  userAddress={this.props.userAddress}
-                  userEmail={this.props.userEmail}
-                  handleLogin={this.props.handleLogin}
                   handleClose={this.handleEndPayment}
                 />
               </PaymentsModal>

--- a/packages/sdk/src/react/StoryBoost/StoryBoost.tsx
+++ b/packages/sdk/src/react/StoryBoost/StoryBoost.tsx
@@ -109,7 +109,7 @@ export class StoryBoost extends React.Component<StoryBoostProps, StoryBoostState
                 <span>Support this newsroom</span>
                 <PaymentButton onClick={this.handleStartPayment} />
               </StoryBoostFooter>
-              <PaymentsModal open={this.state.paymentsOpen}>
+              <PaymentsModal open={this.state.paymentsOpen} handleClose={this.handleClose}>
                 <Payments
                   postId={this.props.boostId}
                   newsroomName={storyBoostData.channel.newsroom.name}
@@ -128,8 +128,10 @@ export class StoryBoost extends React.Component<StoryBoostProps, StoryBoostState
   private handleStartPayment = () => {
     this.setState({ paymentsOpen: true });
   };
-
   private handleEndPayment = () => {
+    this.setState({ paymentsOpen: false });
+  };
+  private handleClose = () => {
     this.setState({ paymentsOpen: false });
   };
 }

--- a/packages/sdk/src/react/StoryBoost/embed.tsx
+++ b/packages/sdk/src/react/StoryBoost/embed.tsx
@@ -76,14 +76,17 @@ function init(): void {
             return <BoostEmbedIframe noIframe={true} fallbackUrl={fallbackFallbackUrl} />;
           }
           if (getError) {
-            console.error("Error getting boost ID via postsGetByReference for url", url, "error:", getError);
-            return (
-              <BoostEmbedIframe
-                noIframe={true}
-                fallbackUrl={fallbackFallbackUrl}
-                error={"Error getting boost ID: " + getError.message || getError.toString()}
-              />
-            );
+            // If "could not find post" that's fine, we'll create it with mutation, but if it's a different error then bomb:
+            if (getError.message.indexOf("could not find post") === -1) {
+              console.error("Error getting boost ID via postsGetByReference for url", url, "error:", getError);
+              return (
+                <BoostEmbedIframe
+                  noIframe={true}
+                  fallbackUrl={fallbackFallbackUrl}
+                  error={"Error getting boost ID: " + getError.message || getError.toString()}
+                />
+              );
+            }
           }
           if (!getData || !getData.postsGetByReference || !getData.postsGetByReference.id) {
             return (
@@ -93,8 +96,8 @@ function init(): void {
               >
                 {(mutation, { loading: createLoading, data: createData, error: createError, called: createCalled }) => {
                   if (!createCalled && !createError) {
-                    console.warn("Posting external link to Civil", url);
-                    window.setImmediate(() => mutation().catch(() => {}));
+                    console.warn("Attempting to post external link to Civil:", url);
+                    window.setTimeout(mutation, 0);
                     return <BoostEmbedIframe noIframe={true} fallbackUrl={fallbackFallbackUrl} />;
                   }
                   if (createLoading) {

--- a/packages/sdk/src/react/StoryBoost/embed.tsx
+++ b/packages/sdk/src/react/StoryBoost/embed.tsx
@@ -46,11 +46,10 @@ function getPostUrl(): string {
   }
 
   // @TODO/tobek dev/temp testing - we don't want to post a localhost dev page to civil, so pick another URL
+  const FALLBACK_STORY =
+    "https://blockclubchicago.org/2019/11/04/south-sides-own-sweet-potato-patch-will-deliver-healthy-food-to-homes-in-food-deserts/";
   if (document.location.origin.indexOf("localhost") !== -1) {
-    url = window.prompt(
-      "enter a URL to get/create",
-      "https://blockclubchicago.org/2019/11/04/south-sides-own-sweet-potato-patch-will-deliver-healthy-food-to-homes-in-food-deserts/",
-    )!;
+    url = window.prompt("enter a URL to get/create", FALLBACK_STORY) || FALLBACK_STORY;
   }
 
   return url;


### PR DESCRIPTION
Basically we need a way to launch login/signup flow (e.g. `dispatch(await showWeb3LoginModal())`) from outside of dapp package. This commit has dapp `Web3AuthWrapper` hook these functions into `CivilContext` via `AuthService` so that `Payments` component can call it itself.

Other stuff refactored to use context instead of passing down from story feed.

End result is that story boost embed gets all this stuff for free.