### PR TITLE
Share network/gql logic between dapp and embeds [CIVIL-1283]

### DIFF
--- a/packages/dapp/src/components/providers/AppProvider.tsx
+++ b/packages/dapp/src/components/providers/AppProvider.tsx
@@ -3,7 +3,7 @@ import { ApolloProvider } from "react-apollo";
 import { ConnectedRouter } from "connected-react-router";
 
 import { INFURA_WEBSOCKET_HOSTS } from "@joincivil/ethapi";
-import { getApolloClient } from "@joincivil/utils";
+import { setNetworkValue, getApolloClient } from "@joincivil/utils";
 import { CivilProvider } from "@joincivil/components";
 
 import { ErrorBoundry } from "../errors/ErrorBoundry";
@@ -17,6 +17,9 @@ import { Provider } from "react-redux";
 
 console.log("using config:", config);
 
+if (config.DEFAULT_ETHEREUM_NETWORK) {
+  setNetworkValue(parseInt(config.DEFAULT_ETHEREUM_NETWORK, 10));
+}
 const client = getApolloClient();
 
 const pluginConfig = {

--- a/packages/utils/src/apolloClient.ts
+++ b/packages/utils/src/apolloClient.ts
@@ -54,6 +54,14 @@ export function setNetworkValue(network: number): void {
   setItem(NETWORK_KEY, network);
 }
 
+/** Don't override explicitly set network value, but if none set, this will do. Handles possible race condition between web3 network change subscription firing vs. our default value for this based on environment. */
+export function setDefaultNetworkValue(network: number): void {
+  if (fetchItem(NETWORK_KEY)) {
+    return;
+  }
+  setItem(NETWORK_KEY, network);
+}
+
 export function getApolloClient(httpLinkOptions: HttpLink.Options = {}): ApolloClient<NormalizedCacheObject> {
   if (client) {
     return client;


### PR DESCRIPTION
Moving some stuff from `Main` (dapp-only) to `Web3AuthWrapper` and `AppProvider` (both dapp and embeds). This fixes staging-only bug where if the embed is the first time you visit the dapp then the network value is set wrong, also fixes issues where iframes have isolated localStorage as Safari does.

Also updating logic so that gql endpoint depends on `config.DEFAULT_ETHEREUM_NETWORK` to begin with, but it won't overwrite network value set by web3 network being updated. (Though we still don't, I think, change the uri in already-created apollo client, but on page refresh the network value will take effect).