### PR TITLE
chore: cleanup fragment name

### DIFF
--- a/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
+++ b/packages/dapp/src/components/Dashboard/DashboardActivity.tsx
@@ -95,8 +95,8 @@ const USER_NRSIGNUP_QUERY = gql`
   }
 `;
 
-const CHALLENGE_FRAGMENT = gql`
-  fragment ChallengeFragment on Challenge {
+const DASHBOARD_CHALLENGE_FRAGMENT = gql`
+  fragment DashboardChallengeFragment on Challenge {
     challengeID
     challengeType
     listingAddress
@@ -183,7 +183,7 @@ const USER_CHALLENGE_DASHBOARD_QUERY = gql`
       voterReward
       parentChallengeID
       challenge {
-        ...ChallengeFragment
+        ...DashboardChallengeFragment
       }
     }
     challengesToReveal: userChallengeData(userAddr: $userAddress, canUserReveal: true) {
@@ -200,10 +200,10 @@ const USER_CHALLENGE_DASHBOARD_QUERY = gql`
       pollType
     }
     challengesStarted: challengesStartedByUser(addr: $userAddress) {
-      ...ChallengeFragment
+      ...DashboardChallengeFragment
     }
   }
-  ${CHALLENGE_FRAGMENT}
+  ${DASHBOARD_CHALLENGE_FRAGMENT}
 `;
 
 // We're storing which challenges to multi-claim in the state of this component, because


### PR DESCRIPTION
graphql complains if 2 fragments across app have same name