### PR TITLE
Slightly better post-apply flow

### DIFF
--- a/packages/newsroom-signup/src/ApplyToTCR/ApplyToTCRForm.tsx
+++ b/packages/newsroom-signup/src/ApplyToTCR/ApplyToTCRForm.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Link } from "react-router-dom";
 import { compose } from "redux";
 import { BigNumber } from "@joincivil/typescript-types";
 import { EthAddress, TxHash } from "@joincivil/core";
@@ -67,7 +68,10 @@ const transactionSuccessContent = {
   ],
   [TransactionTypes.APPLY_TO_REGISTRY]: [
     "Transaction Successful",
-    <ModalContent>Your application to the registry has been recorded!</ModalContent>,
+    <ModalContent>
+      Your application to the registry has been recorded! You can follow the progress of your application on your{" "}
+      <Link to="/dashboard/newsrooms">Newsroom Dashboard</Link>.
+    </ModalContent>,
   ],
 };
 


### PR DESCRIPTION
Had this lying around on my computer, not sure if it really matters since I think no one will go all the way through this flow anymore, but it's a trivial update that is a bit better.

> With redux stuff removed, there's no feedback at all after applying to registry, it looks like you never did it. This way we can at least direct the user to the dashboard where they can see they've applied.