### PR TITLE
Support adding users to smart contract from post-apply manager [CIVIL-1297]

### DIFF
--- a/packages/dapp/src/components/Dashboard/ManageNewsroom/ManageNewsroom.tsx
+++ b/packages/dapp/src/components/Dashboard/ManageNewsroom/ManageNewsroom.tsx
@@ -14,7 +14,7 @@ import {
   withNewsroomChannel,
   NewsroomChannelInjectedProps,
 } from "@joincivil/components";
-import { NewsroomManager } from "@joincivil/newsroom-signup";
+import { NewsroomManager, ManageContractMembers } from "@joincivil/newsroom-signup";
 import { routes } from "../../../constants";
 import { getListingPhaseState } from "../../../selectors";
 import { LISTING_QUERY, transformGraphQLDataIntoListing } from "@joincivil/utils";
@@ -74,9 +74,9 @@ interface ManageQueryVariables {
 }
 
 export interface ManageParams {
-  activeTab?: "edit-charter" | "launch-boost";
+  activeTab?: "edit-charter" | "smart-contract" | "launch-boost";
 }
-const TABS = ["edit-charter", "launch-boost"];
+const TABS = ["edit-charter", "smart-contract", "launch-boost"];
 
 export interface ManageNewsroomOwnProps extends RouteComponentProps<ManageParams> {
   newsroomAddress: string;
@@ -156,6 +156,9 @@ const ManageNewsroomComponent: React.FunctionComponent<
                         publishedCharter={charter}
                         listingPhaseState={listingPhaseState}
                       />
+                    </Tab>
+                    <Tab title={"Smart Contract"}>
+                      <ManageContractMembers charter={charter} newsroomAddress={props.newsroomAddress} />
                     </Tab>
                     <Tab title={"Launch Boost"}>
                       <BoostForm

--- a/packages/newsroom-signup/src/NewsroomManager/ManageContractMembers.tsx
+++ b/packages/newsroom-signup/src/NewsroomManager/ManageContractMembers.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { CivilContext, ICivilContext, LoadingMessage } from "@joincivil/components";
+import { NewsroomInstance } from "@joincivil/core";
+import { EthAddress, CharterData } from "@joincivil/typescript-types";
+import styled from "styled-components";
+import { AddMembersToContract } from "../SmartContract/AddMembersToContract";
+import { updateNewsroom, fetchNewsroom, getEditors } from "../actionCreators";
+import { StateWithNewsroom } from "../reducers";
+
+const Wrapper = styled.div`
+  margin: auto;
+  max-width: 880px;
+`;
+
+export interface ManageContractMembersProps {
+  charter: Partial<CharterData>;
+  /** @NOTE: Make sure to use the newsroom instance `newsroom.address`, which is mixed case, because everything in newsroom-signup depends on that. This is used just to instantiate the contract. */
+  newsroomAddress: EthAddress;
+}
+
+export const ManageContractMembers: React.FunctionComponent<ManageContractMembersProps> = props => {
+  const dispatch = useDispatch();
+  const context = React.useContext<ICivilContext>(CivilContext);
+  const [newsroom, setNewsroom] = React.useState<NewsroomInstance | undefined>();
+
+  React.useEffect(() => {
+    if (!context.civil) {
+      return;
+    }
+    context.civil.newsroomAtUntrusted(props.newsroomAddress).then(setNewsroom);
+  }, [context.civil]);
+
+  const reduxCharter = useSelector((state: StateWithNewsroom) => {
+    if (!newsroom) {
+      return undefined;
+    }
+    const newsroomState = state.newsrooms.get(newsroom.address);
+    return newsroomState && newsroomState.charter;
+  });
+  const owners = useSelector((state: StateWithNewsroom) => {
+    if (!newsroom) {
+      return undefined;
+    }
+    const newsroomState = state.newsrooms.get(newsroom.address);
+    return newsroomState && newsroomState.wrapper && newsroomState.wrapper.data && newsroomState.wrapper.data.owners;
+  });
+
+  // Hydrate redux store if it hasn't been already:
+  React.useEffect(() => {
+    if (!newsroom) {
+      return;
+    }
+    if (!reduxCharter) {
+      dispatch(updateNewsroom(newsroom.address, { newsroom, charter: props.charter }));
+    }
+    dispatch(fetchNewsroom(newsroom.address));
+  }, [reduxCharter, newsroom, dispatch]);
+  React.useEffect(() => {
+    if (!newsroom || !context.civil) {
+      return;
+    }
+    dispatch(getEditors(newsroom.address, context.civil));
+  }, [newsroom, dispatch, context.civil]);
+
+  if (!newsroom) {
+    return <LoadingMessage>Loading Newsroom</LoadingMessage>;
+  }
+
+  if (!owners) {
+    return <LoadingMessage>Loading Users</LoadingMessage>;
+  }
+
+  return (
+    <Wrapper>
+      <AddMembersToContract
+        charter={reduxCharter || props.charter}
+        newsroom={newsroom}
+        profileWalletAddress={context.currentUser.ethAddress}
+        updateCharter={() => {}}
+        managerMode={true}
+      />
+    </Wrapper>
+  );
+};

--- a/packages/newsroom-signup/src/SmartContract/AddMembersToContract.tsx
+++ b/packages/newsroom-signup/src/SmartContract/AddMembersToContract.tsx
@@ -11,6 +11,7 @@ import {
   ICivilContext,
 } from "@joincivil/components";
 import { CharterData, EthAddress } from "@joincivil/typescript-types";
+import { NewsroomInstance } from "@joincivil/core";
 import styled from "styled-components";
 import { AddMember } from "./AddMember";
 
@@ -38,8 +39,9 @@ const MemberUlLabel = styled.div`
 
 export interface AddMembersToContractProps {
   charter: Partial<CharterData>;
-  newsroom: any;
+  newsroom: NewsroomInstance;
   profileWalletAddress?: EthAddress;
+  managerMode?: boolean;
   updateCharter(charter: Partial<CharterData>): void;
 }
 
@@ -52,9 +54,9 @@ export class AddMembersToContract extends React.Component<AddMembersToContractPr
       <>
         <OBSectionHeader>Assign access to your Newsroom Smart Contract</OBSectionHeader>
         <OBSectionDescription>
-          Now you'll assign roles to key staff which will determine their level of access to the Newsroom Smart
-          Contract. We recommend adding at least two people as Officers to your Newsroom Smart Contract. This is for
-          your protection in the event you lose access to your wallet.
+          {this.props.managerMode ? "Here you can" : "Now you'll"} assign roles to key staff which will determine their
+          level of access to the Newsroom Smart Contract. We recommend adding at least two people as Officers to your
+          Newsroom Smart Contract. This is for your protection in the event you lose access to your wallet.
         </OBSectionDescription>
         <OBSectionDescription>
           If you are the only Officer on your contract and you lose access to your wallet, you will no longer you will
@@ -103,10 +105,20 @@ export class AddMembersToContract extends React.Component<AddMembersToContractPr
                   updateCharter={this.props.updateCharter}
                   charter={this.props.charter}
                   profileWalletAddress={this.props.profileWalletAddress}
+                  forceCharterUpdateForMissingAddress={this.props.managerMode}
                 />
               );
             })}
         </MemberUL>
+        <OBSectionDescription>
+          To add additional users, please{" "}
+          {this.props.managerMode
+            ? 'select the "Edit Charter" tab above'
+            : 'use the links above to navigate back to the "Newsroom Roster" step'}{" "}
+          and first add the user there. Make sure you have the user's ethereum wallet address on hand so that you can
+          include it. Once you have {this.props.managerMode ? "published your updated charter" : "updated your charter"}
+          , you can return here and assign them a role on your Newsroom Smart Contract.
+        </OBSectionDescription>
       </>
     );
   }

--- a/packages/newsroom-signup/src/SmartContract/index.tsx
+++ b/packages/newsroom-signup/src/SmartContract/index.tsx
@@ -90,7 +90,7 @@ export class SmartContract extends React.Component<SmartContractProps> {
       </Mutation>,
       <AddMembersToContract
         charter={this.props.charter!}
-        newsroom={this.props.newsroom}
+        newsroom={this.props.newsroom!}
         updateCharter={this.props.updateCharter}
         profileWalletAddress={this.props.profileWalletAddress}
       />,


### PR DESCRIPTION
Adds a new "Smart Contract" tab in the `/manage-newsroom/<address>` manager, using a new `newsroom-signup` component `ManageContractMembers` that wraps the pre-existing smart contract member logic in a tidy way, hydrating various redux bits as necessary in this different context, and making sure changes are shared between this component and the post-apply charter editor one tab over since users may have to go back and forth between them (unfortunately, for now at least).