### PR TITLE
style(sdk): tweak embed styles + support email in error

### DIFF
--- a/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
+++ b/packages/components/src/TCRUserDashboard/DashboardNewsroom.tsx
@@ -180,12 +180,10 @@ const DashboardNewsroomBase: React.FunctionComponent<DashboardNewsroomProps> = p
           Copy
         </InvertedButton>{" "}
         {copied && "Copied!"}
-        {/* TODO waiting on WordPress plugin url
-          <p>
-            Use WordPress? You can download and install the Story Boost plugin to automatically embed Story Boosts on
-            your site.
-          </p>
-          */}
+        <p>
+          Use WordPress? You can download and install the Story Boost plugin to automatically embed Story Boosts on your
+          site.
+        </p>
         <p>
           Download this zip file, navigate to the Plugins page in your admin dashboard, select Add New, then Upload
           Plugin.
@@ -194,7 +192,7 @@ const DashboardNewsroomBase: React.FunctionComponent<DashboardNewsroomProps> = p
           size={buttonSizes.MEDIUM_WIDE}
           to={"https://drive.google.com/uc?export=download&id=1Rq4ZW-gwDMy5TLIr_aKJzFUYnSIVXpC6"}
         >
-          Get the Story Boost Plugin
+          Download Story Boost Plugin
         </InvertedButton>
         <FeatureFlag feature={"pew"}>
           <Query<any>

--- a/packages/sdk/src/react/boosts/BoostEmbedIframe.tsx
+++ b/packages/sdk/src/react/boosts/BoostEmbedIframe.tsx
@@ -13,6 +13,7 @@ let EMBED_WRAPPER_STYLES: React.CSSProperties = {
   border: "1px solid #E9E9EA", // colors.accent.CIVIL_GRAY_4 but not worth importing entire package just for that
   borderRadius: "4px",
   textAlign: "center",
+  lineHeight: 1.1,
 };
 let EMBED_IFRAME_STYLES: React.CSSProperties = {
   position: "absolute",
@@ -33,7 +34,7 @@ const EMBED_LOADING_IMG_STYLES: React.CSSProperties = {
 const EMBED_NOT_LOADED_STYLES: React.CSSProperties = {
   position: "absolute",
   color: "#9B9B9B",
-  fontSize: "smaller",
+  fontSize: 12,
   bottom: 0,
   padding: 16,
   margin: 0,
@@ -41,6 +42,8 @@ const EMBED_NOT_LOADED_STYLES: React.CSSProperties = {
 const EMBED_ERROR_STYLES: React.CSSProperties = {
   whiteSpace: "pre-wrap",
   padding: "0 10px",
+  fontSize: 12,
+  lineHeight: 1.2,
 };
 
 export interface BoostEmbedIframeProps {
@@ -130,7 +133,7 @@ export const BoostEmbedIframe = (props: BoostEmbedIframeProps & BoostEmbedIframe
                 <a href={props.fallbackUrl} target="_blank">
                   on Civil
                 </a>
-                .
+                . If the problem persists, please contact <a href="mailto:support@civil.co">support@civil.co</a>.
               </p>
               <pre style={EMBED_ERROR_STYLES}>{props.error}</pre>
             </>


### PR DESCRIPTION
Minor stuff but useful to get out soon in case we send that email to newsrooms Friday.

Was testing on default WP theme which has an insane line height and embed looked terrible.

Also adds support email to error message (but more specific error messages based on the updates you made Nick are forthcoming).