### PR TITLE
fix: better permissions checks and UI for Manage Newsroom [CIVIL-918]

### DIFF
--- a/packages/newsroom-signup/src/NewsroomProfile/RosterMember.tsx
+++ b/packages/newsroom-signup/src/NewsroomProfile/RosterMember.tsx
@@ -118,7 +118,7 @@ export class RosterMemberComponent extends React.Component<RosterMemberProps & D
             invalidMessage={"Too long"}
           />
           <HelperText>Maximum of 1000 characters</HelperText>
-          <FormSubhead optional>Public Wallet Address</FormSubhead>
+          <FormSubhead optionalForNonAdmin>Public Wallet Address</FormSubhead>
           <Input name="ethAddress" value={user.rosterData.ethAddress || ""} onChange={this.rosterInputChange} />
           <FormSubhead optional>Email Address</FormSubhead>
           <EmailHelpText>Email addresses will not be displayed on the Registry Profile page. </EmailHelpText>

--- a/packages/newsroom-signup/src/styledComponents.tsx
+++ b/packages/newsroom-signup/src/styledComponents.tsx
@@ -46,6 +46,7 @@ export const FormTitle = styled.h4`
 
 export interface FormSubheadProps {
   optional?: any;
+  optionalForNonAdmin?: any;
 }
 export const FormSubhead = styled.h4<FormSubheadProps>`
   font-size: 14px;
@@ -59,6 +60,14 @@ export const FormSubhead = styled.h4<FormSubheadProps>`
     `
     &:after {
       content: " (optional)";
+      font-style: italic;
+    }
+  `};
+  ${props =>
+    props.optionalForNonAdmin &&
+    `
+    &:after {
+      content: " (optional, but required for officers)";
       font-style: italic;
     }
   `};

--- a/packages/sdk/src/react/boosts/BoostPermissionsHOC.tsx
+++ b/packages/sdk/src/react/boosts/BoostPermissionsHOC.tsx
@@ -156,6 +156,7 @@ export const withBoostPermissions = <TProps extends BoostPermissionsInjectedProp
         return;
       }
 
+      this.context.civil.currentProviderEnable();
       this.setState({
         userEthAddress: await this.context.civil.accountStream.first().toPromise(),
       });


### PR DESCRIPTION
Whole Manage Newsroom page should be blocked if not `currentUserIsAdmin`, etc.