### PR TITLE
Fix story boost embed onboarding [CIVIL-1457]

### DIFF
--- a/packages/sdk/src/react/boosts/BoostEmbedIframe.tsx
+++ b/packages/sdk/src/react/boosts/BoostEmbedIframe.tsx
@@ -142,7 +142,7 @@ export const BoostEmbedIframe = (props: BoostEmbedIframeProps & BoostEmbedIframe
             key={props.iframeId}
             id={props.iframeId}
             src={props.iframeSrc}
-            sandbox="allow-popups allow-scripts allow-same-origin"
+            sandbox="allow-forms allow-popups allow-scripts allow-same-origin"
           ></iframe>
         )}
 


### PR DESCRIPTION
Non `allow-forms` sandbox was preventing submission of username during embedded new user onboarding.